### PR TITLE
change the app_name translation for Chinese

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- app. -->
-    <string name="app_name">天气</string>
+    <string name="app_name">微风天气</string>
     <!-- keyword. -->
     <string name="location_current">当前位置</string>
     <string name="location_resident">常驻位置</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- app. -->
-    <string name="app_name">天氣</string>
+    <string name="app_name">微風天氣</string>
     <!-- keyword. -->
     <string name="location_current">當前位置</string>
     <string name="location_resident">常駐位置</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- app. -->
-    <string name="app_name">天氣</string>
+    <string name="app_name">微風天氣</string>
     <!-- keyword. -->
     <string name="location_current">當前位置</string>
     <string name="location_resident">常駐位置</string>


### PR DESCRIPTION
When the user's system language is Chinese, the name of the App displayed  as "天气", not like "几何天气", this change provides a possible Chinese name for Breezy Weather.