### PR TITLE
Add PirateWeather source

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,6 +62,7 @@ android {
         it.buildConfigField "String", "MF_WSFT_JWT_KEY", "\"${properties.getProperty("breezy.mf.jwtKey") ?: ""}\""
         it.buildConfigField "String", "MF_WSFT_KEY", "\"${properties.getProperty("breezy.mf.key") ?: ""}\""
         it.buildConfigField "String", "OPEN_WEATHER_KEY", "\"${properties.getProperty("breezy.openweather.key") ?: ""}\""
+        it.buildConfigField "String", "PIRATE_WEATHER_KEY", "\"${properties.getProperty("breezy.pirateweather.key") ?: ""}\""
     }
 
     sourceSets {

--- a/app/src/main/java/org/breezyweather/sources/SourceManager.kt
+++ b/app/src/main/java/org/breezyweather/sources/SourceManager.kt
@@ -14,6 +14,7 @@ import org.breezyweather.sources.mf.MfService
 import org.breezyweather.sources.noreversegeocoding.NoReverseGeocodingService
 import org.breezyweather.sources.openmeteo.OpenMeteoService
 import org.breezyweather.sources.openweather.OpenWeatherService
+import org.breezyweather.sources.pirateweather.PirateWeatherService
 import javax.inject.Inject
 
 class SourceManager @Inject constructor(
@@ -23,6 +24,7 @@ class SourceManager @Inject constructor(
     accuService: AccuService,
     metNoService: MetNoService,
     openWeatherService: OpenWeatherService,
+    pirateWeatherService: PirateWeatherService,
     mfService: MfService,
     chinaService: ChinaService,
     noReverseGeocodingService: NoReverseGeocodingService
@@ -38,6 +40,7 @@ class SourceManager @Inject constructor(
         accuService,
         metNoService,
         openWeatherService,
+        pirateWeatherService,
         mfService,
         chinaService,
 

--- a/app/src/main/java/org/breezyweather/sources/pirateweather/PirateWeatherApi.kt
+++ b/app/src/main/java/org/breezyweather/sources/pirateweather/PirateWeatherApi.kt
@@ -1,0 +1,21 @@
+package org.breezyweather.sources.pirateweather
+
+import retrofit2.http.GET
+import retrofit2.http.Query
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.sources.pirateweather.json.PirateWeatherForecastResult
+import retrofit2.http.Path
+
+/**
+ * See https://docs.pirateweather.net/en/latest/Specification/
+ */
+interface PirateWeatherApi {
+    @GET("forecast/{apikey}/{lat},{lon}")
+    fun getForecast(
+        @Path("apikey") apikey: String,
+        @Path("lat") lat: Float,
+        @Path("lon") lon: Float,
+        @Query("units") units: String,
+        @Query("lang") lang: String
+    ): Observable<PirateWeatherForecastResult>
+}

--- a/app/src/main/java/org/breezyweather/sources/pirateweather/PirateWeatherResultConverter.kt
+++ b/app/src/main/java/org/breezyweather/sources/pirateweather/PirateWeatherResultConverter.kt
@@ -1,0 +1,225 @@
+package org.breezyweather.sources.pirateweather
+
+import org.breezyweather.common.basic.models.weather.Alert
+import org.breezyweather.common.basic.models.weather.Astro
+import org.breezyweather.common.basic.models.weather.Base
+import org.breezyweather.common.basic.models.weather.Current
+import org.breezyweather.common.basic.models.weather.Daily
+import org.breezyweather.common.basic.models.weather.HalfDay
+import org.breezyweather.common.basic.models.weather.Minutely
+import org.breezyweather.common.basic.models.weather.MoonPhase
+import org.breezyweather.common.basic.models.weather.Precipitation
+import org.breezyweather.common.basic.models.weather.PrecipitationProbability
+import org.breezyweather.common.basic.models.weather.Temperature
+import org.breezyweather.common.basic.models.weather.UV
+import org.breezyweather.common.basic.models.weather.WeatherCode
+import org.breezyweather.common.basic.models.weather.Wind
+import org.breezyweather.common.basic.wrappers.HourlyWrapper
+import org.breezyweather.common.basic.wrappers.WeatherResultWrapper
+import org.breezyweather.common.exceptions.WeatherException
+import org.breezyweather.common.extensions.toDate
+import org.breezyweather.sources.pirateweather.json.PirateWeatherAlert
+import org.breezyweather.sources.pirateweather.json.PirateWeatherCurrently
+import org.breezyweather.sources.pirateweather.json.PirateWeatherDaily
+import org.breezyweather.sources.pirateweather.json.PirateWeatherHourly
+import org.breezyweather.sources.pirateweather.json.PirateWeatherMinutely
+import org.breezyweather.sources.pirateweather.json.PirateWeatherForecastResult
+import java.util.Date
+import kotlin.math.roundToInt
+
+
+/**
+ * Converts PirateWeather result into a forecast
+ */
+fun convert(
+    forecastResult: PirateWeatherForecastResult
+): WeatherResultWrapper {
+    return WeatherResultWrapper(
+        base = Base(
+            publishDate = forecastResult.currently?.time?.times(1000)?.toDate() ?: Date()
+        ),
+        current = forecastResult.currently?.let { getCurrentForecast(it) },
+        dailyForecast = forecastResult.daily.data.let { getDailyForecast(it) },
+        hourlyForecast = forecastResult.hourly.data.let { getHourlyForecast(it) },
+        minutelyForecast = forecastResult.minutely.data.let {getMinutelyForecast(it) },
+        alertList = getAlertList(forecastResult.alerts)
+    )
+}
+
+/**
+ * Returns current weather forecast
+ */
+private fun getCurrentForecast(result: PirateWeatherCurrently): Current {
+    return Current(
+        weatherText = result.summary,
+        weatherCode = getWeatherCode(result.icon),
+        temperature = Temperature(
+            temperature = result.temperature,
+            apparentTemperature = result.apparentTemperature,
+        ),
+        wind = Wind(
+            degree = result.windBearing,
+            speed = result.windSpeed?.times(3.6f),
+        ),
+        uV = UV(index = result.uvIndex),
+        relativeHumidity = result.humidity?.times(100),
+        dewPoint = result.dewPoint,
+        pressure = result.pressure,
+        cloudCover = result.cloudCover?.times(100)?.roundToInt(),
+        visibility = result.visibility,
+    )
+}
+
+private fun getDailyForecast(
+    dailyResult: List<PirateWeatherDaily>
+): List<Daily> {
+    return dailyResult.map { result ->
+        Daily(
+            date = Date(result.time.times(1000)),
+            day = HalfDay(
+                weatherText = result.summary,
+                weatherCode = getWeatherCode(result.icon),
+                temperature = Temperature(
+                    temperature = result.temperatureHigh,
+                    apparentTemperature = result.apparentTemperatureHigh,
+                ),
+                // see https://docs.pirateweather.net/en/latest/API/#preciptype
+                precipitation = Precipitation(
+                    total = result.precipAccumulation,
+                    rain = if (result.precipType.equals("rain")) result.precipIntensity else null,
+                    snow = if (result.precipType.equals("snow")) result.precipIntensity else null,
+                ),
+                precipitationProbability = PrecipitationProbability(
+                    total = result.precipProbability,
+                ),
+                wind = Wind(
+                    degree = result.windBearing,
+                    speed = result.windSpeed?.times(3.6f),
+                ),
+                cloudCover = result.cloudCover?.times(100)?.roundToInt(), // 0-1 -> 0-100
+            ),
+            night = HalfDay(
+                weatherText = result.summary,
+                weatherCode = getWeatherCode(result.icon),
+                // temperatureLow/High are always forward-looking
+                // See https://docs.pirateweather.net/en/latest/API/#temperaturelow
+                temperature = Temperature(
+                    temperature = result.temperatureLow,
+                    apparentTemperature = result.apparentTemperatureLow,
+                ),
+            ),
+            sun = Astro(
+                riseDate = result.sunrise?.times(1000)?.toDate(),
+                setDate = result.sunset?.times(1000)?.toDate(),
+            ),
+            moon = Astro(),
+            moonPhase = MoonPhase(
+                angle = result.moonPhase?.times(360)?.roundToInt(), // Seems correct
+            ),
+            uV = UV(index = result.uvIndex),
+        )
+    }
+}
+
+/**
+ * Returns hourly forecast
+ */
+private fun getHourlyForecast(
+    hourlyResult: List<PirateWeatherHourly>
+): List<HourlyWrapper> {
+    return hourlyResult.map { result ->
+        HourlyWrapper(
+            date = Date(result.time.times(1000)),
+            weatherText = result.summary,
+            weatherCode = getWeatherCode(result.icon),
+            temperature = Temperature(
+                temperature = result.temperature,
+                apparentTemperature = result.apparentTemperature,
+            ),
+            // see https://docs.pirateweather.net/en/latest/API/#preciptype
+            precipitation = Precipitation(
+                total = result.precipAccumulation,
+                rain = if (result.precipType.equals("rain")) result.precipIntensity else null,
+                snow = if (result.precipType.equals("snow")) result.precipIntensity else null,
+            ),
+            precipitationProbability = PrecipitationProbability(
+                total = result.precipProbability,
+            ),
+            wind = Wind(
+                degree = result.windBearing,
+                speed = result.windSpeed?.times(3.6f),
+            ),
+            uV = UV(
+                index = result.uvIndex,
+            ),
+            relativeHumidity = result.humidity?.times(100),
+            dewPoint = result.dewPoint,
+            pressure = result.pressure,
+            cloudCover = result.cloudCover?.times(100)?.roundToInt(),
+            visibility = result.visibility,
+        )
+    }
+}
+
+
+/**
+ * Returns minutely forecast
+ * Copied from openweather implementation
+ */
+private fun getMinutelyForecast(minutelyResult: List<PirateWeatherMinutely>?): List<Minutely> {
+    val minutelyList: MutableList<Minutely> = arrayListOf()
+    minutelyResult?.forEachIndexed { i, minutelyForecast ->
+        minutelyList.add(
+            Minutely(
+                Date(minutelyForecast.time * 1000),
+                if (i < minutelyResult.size - 1) {
+                    ((minutelyResult[i + 1].time - minutelyForecast.time) / 60).toDouble().roundToInt()
+                } else ((minutelyForecast.time - minutelyResult[i - 1].time) / 60).toDouble()
+                    .roundToInt(),
+                minutelyForecast.precipIntensity?.toDouble()
+            )
+        )
+    }
+    return minutelyList
+}
+
+/**
+ * Returns alerts
+ */
+private fun getAlertList(alertList: List<PirateWeatherAlert>): List<Alert> {
+    return alertList.map { alert ->
+        Alert(
+            // TODO: Avoid having the same ID for two different alerts starting at the same time
+            alertId = alert.start + alert.end,
+            startDate = Date(alert.start.times(1000)),
+            endDate = Date(alert.end.times(1000)),
+            description = alert.title ?: "Unnamed alert",
+            content = alert.description,
+            // TODO: Add more refined priority states (not evident from PirateWeather docs)
+            priority = when (alert.severity) {
+                "Moderate" -> 1
+                else -> 1
+            }
+        )
+    }
+}
+
+/**
+ * Gets weather code
+ *
+ * Unfortunately, PirateWeather does not report weather codes
+ * See https://docs.pirateweather.net/en/latest/API/#icon
+ */
+private fun getWeatherCode(icon: String?): WeatherCode? {
+    return when (icon) {
+        "rain" -> WeatherCode.RAIN
+        "sleet" -> WeatherCode.SLEET
+        "snow" -> WeatherCode.SNOW
+        "fog" -> WeatherCode.FOG
+        "wind" -> WeatherCode.WIND
+        "clear-day", "clear-night" -> WeatherCode.CLEAR
+        "partly-cloudy-day", "partly-cloudy-night" -> WeatherCode.PARTLY_CLOUDY
+        "cloudy" -> WeatherCode.CLOUDY
+        else -> null
+    }
+}

--- a/app/src/main/java/org/breezyweather/sources/pirateweather/PirateWeatherService.kt
+++ b/app/src/main/java/org/breezyweather/sources/pirateweather/PirateWeatherService.kt
@@ -1,0 +1,90 @@
+package org.breezyweather.sources.pirateweather
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.BuildConfig
+import org.breezyweather.R
+import org.breezyweather.common.basic.models.Location
+import org.breezyweather.common.basic.wrappers.WeatherResultWrapper
+import org.breezyweather.common.exceptions.ApiKeyMissingException
+import org.breezyweather.common.preference.EditTextPreference
+import org.breezyweather.common.preference.Preference
+import org.breezyweather.common.source.ConfigurableSource
+import org.breezyweather.common.source.HttpSource
+import org.breezyweather.common.source.WeatherSource
+import org.breezyweather.settings.SettingsManager
+import org.breezyweather.settings.SourceConfigStore
+import retrofit2.Retrofit
+import javax.inject.Inject
+
+class PirateWeatherService @Inject constructor(
+    @ApplicationContext context: Context,
+    client: Retrofit.Builder
+) : HttpSource(), WeatherSource, ConfigurableSource {
+
+    override val id = "pirateweather"
+    override val name = "PirateWeather"
+    override val privacyPolicyUrl = "https://pirate-weather.apiable.io/privacy"
+
+    override val color = -0xff6e42
+    override val weatherAttribution = "PirateWeather"
+
+    private val mApi by lazy {
+        client
+            .baseUrl(PIRATE_WEATHER_BASE_URL)
+            .build()
+            .create(PirateWeatherApi::class.java)
+    }
+
+    override fun requestWeather(
+        context: Context, location: Location
+    ): Observable<WeatherResultWrapper> {
+        if (!isConfigured()) {
+            return Observable.error(ApiKeyMissingException())
+        }
+        val apiKey = getApiKeyOrDefault()
+        val languageCode = SettingsManager.getInstance(context).language.code
+        val pirateWeatherResult = mApi.getForecast(
+            apiKey,
+            location.latitude,
+            location.longitude,
+            "si", // represents metric,
+            languageCode
+        )
+
+        return pirateWeatherResult.map { convert(it) }
+    }
+
+    // CONFIG
+    private val config = SourceConfigStore(context, id)
+    private var apikey: String
+        set(value) {
+            config.edit().putString("apikey", value).apply()
+        }
+        get() = config.getString("apikey", null) ?: ""
+
+    private fun getApiKeyOrDefault() = apikey.ifEmpty { BuildConfig.PIRATE_WEATHER_KEY }
+    private fun isConfigured() = getApiKeyOrDefault().isNotEmpty()
+
+    override fun getPreferences(context: Context): List<Preference> {
+        return listOf(
+            EditTextPreference(
+                titleId = R.string.settings_weather_provider_pirate_weather_api_key,
+                summary = { c, content ->
+                    content.ifEmpty {
+                        c.getString(R.string.settings_source_default_value)
+                    }
+                },
+                content = apikey,
+                onValueChanged = {
+                    apikey = it
+                }
+            )
+        )
+    }
+
+    companion object {
+        private const val PIRATE_WEATHER_BASE_URL = "https://api.pirateweather.net/"
+    }
+}

--- a/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherAlert.kt
+++ b/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherAlert.kt
@@ -1,0 +1,15 @@
+package org.breezyweather.sources.pirateweather.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PirateWeatherAlert (
+    val title: String?,
+    @SerialName("time") val start: Long,
+    @SerialName("expires") val end: Long,
+    val description: String?,
+    val regions: List<String>?,
+    val severity: String?,
+    val uri: String?,
+)

--- a/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherCurrently.kt
+++ b/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherCurrently.kt
@@ -1,0 +1,33 @@
+package org.breezyweather.sources.pirateweather.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PirateWeatherCurrently(
+    val time: Long,
+    val icon: String?,
+    val summary: String?,
+
+    val nearestStormDistance: Int?,
+    val nearestStormBearing: Int?,
+
+    val precipType: String?,
+    val precipIntensity: Float?,
+    val precipProbability: Float?,
+    val precipIntensityError: Float?,
+
+    val temperature: Float?,
+    val apparentTemperature: Float?,
+
+    val dewPoint: Float?,
+    val humidity: Float?,
+    val pressure: Float?,
+    val windSpeed: Float?,
+    val windGust: Float?,
+    val windBearing: Float?,
+    val cloudCover: Float?,
+    val uvIndex: Float?,
+    val visibility: Float?,
+    val ozone: Float?
+)

--- a/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherDaily.kt
+++ b/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherDaily.kt
@@ -1,0 +1,52 @@
+package org.breezyweather.sources.pirateweather.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PirateWeatherDaily(
+    val time: Long,
+    val icon: String?,
+    val summary: String?,
+
+    @SerialName("sunriseTime") val sunrise: Long?,
+    @SerialName("sunsetTime") val sunset: Long?,
+    val moonPhase: Float?,
+
+    val precipType: String?,
+    val precipIntensity: Float?,
+    val precipIntensityMax: Float?,
+    val precipIntensityMaxTime: Long?,
+    val precipProbability: Float?,
+    val precipAccumulation: Float?,
+
+    val temperatureHigh: Float?,
+    val temperatureHighTime: Long?,
+    val temperatureLow: Float?,
+    val temperatureLowTime: Long?,
+    val apparentTemperatureHigh: Float?,
+    val apparentTemperatureHighTime: Long?,
+    val apparentTemperatureLow: Float?,
+    val apparentTemperatureLowTime: Long?,
+
+    val temperatureMin: Float?,
+    val temperatureMinTime: Long?,
+    val temperatureMax: Float?,
+    val temperatureMaxTime: Long?,
+    val apparentTemperatureMin: Float?,
+    val apparentTemperatureMinTime: Long?,
+    val apparentTemperatureMax: Float?,
+    val apparentTemperatureMaxTime: Long?,
+
+    val dewPoint: Float?,
+    val humidity: Float?,
+    val pressure: Float?,
+    val windSpeed: Float?,
+    val windGust: Float?,
+    val windGustTime: Long?,
+    val windBearing: Float?,
+    val cloudCover: Float?,
+    val uvIndex: Float?,
+    val uvIndexTime: Long?,
+    val visibility: Float?,
+)

--- a/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherFlags.kt
+++ b/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherFlags.kt
@@ -1,0 +1,12 @@
+package org.breezyweather.sources.pirateweather.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PirateWeatherFlags(
+    val sources: List<String>,
+    val sourceTimes: PirateWeatherFlagsSourceTimes?,
+    val nearestStation: Int?,
+    val units: String?,
+    val version: String?
+)

--- a/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherFlagsSourceTimes.kt
+++ b/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherFlagsSourceTimes.kt
@@ -1,0 +1,13 @@
+package org.breezyweather.sources.pirateweather.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PirateWeatherFlagsSourceTimes(
+    @SerialName("hrrr_0-18") val hrrr_0_18: String?,
+    val hrrr_subh: String?,
+    @SerialName("hrrr_18-48") val hrrr_18_48: String?,
+    val gfs: String?,
+    val gefs: String?
+)

--- a/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherForecast.kt
+++ b/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherForecast.kt
@@ -1,0 +1,11 @@
+package org.breezyweather.sources.pirateweather.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PirateWeatherForecast<T>(
+    val summary: String?,
+    val icon: String?,
+    val data: List<T>,
+)

--- a/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherForecastResult.kt
+++ b/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherForecastResult.kt
@@ -1,0 +1,18 @@
+package org.breezyweather.sources.pirateweather.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PirateWeatherForecastResult(
+    val latitude: Float?,
+    val longitude: Float?,
+    val timezone: String?,
+    val offset: Float?,
+    val elevation: Int?,
+    val currently: PirateWeatherCurrently?,
+    val minutely: PirateWeatherForecast<PirateWeatherMinutely>,
+    val hourly: PirateWeatherForecast<PirateWeatherHourly>,
+    val daily: PirateWeatherForecast<PirateWeatherDaily>,
+    val alerts: List<PirateWeatherAlert>,
+    val flags: PirateWeatherFlags,
+)

--- a/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherHourly.kt
+++ b/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherHourly.kt
@@ -1,0 +1,31 @@
+package org.breezyweather.sources.pirateweather.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PirateWeatherHourly(
+    val time: Long,
+    val icon: String?,
+    val summary: String?,
+
+    val precipType: String?,
+    val precipIntensity: Float?,
+    val precipProbability: Float?,
+    val precipIntensityError: Float?,
+    val precipAccumulation: Float?,
+
+    val temperature: Float?,
+    val apparentTemperature: Float?,
+    val dewPoint: Float?,
+    val humidity: Float?,
+    val pressure: Float?,
+    val windSpeed: Float?,
+    val windGust: Float?,
+    val windBearing: Float?,
+    val uvIndex: Float?,
+    val cloudCover: Float?,
+    val visibility: Float?,
+
+    val ozone: Float?
+)

--- a/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherMinutely.kt
+++ b/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherMinutely.kt
@@ -1,0 +1,12 @@
+package org.breezyweather.sources.pirateweather.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PirateWeatherMinutely(
+    val time: Long,
+    val precipType: String?,
+    val precipIntensity: Float?,
+    val precipProbability: Float?,
+    val precipIntensityError: Float?,
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -460,6 +460,7 @@
     <string name="settings_location_provider_baidu_ip_api_key" translatable="false">@string/settings_source_api_key</string>
     <string name="settings_weather_provider_accu_api_key" translatable="false">@string/settings_source_api_key</string>
     <string name="settings_weather_provider_open_weather_api_key" translatable="false">@string/settings_source_api_key</string>
+    <string name="settings_weather_provider_pirate_weather_api_key" translatable="false">@string/settings_source_api_key</string>
     <string name="settings_weather_provider_mf_api_key" translatable="false">@string/settings_source_api_key</string>
     <string name="settings_weather_source_open_weather_one_call_version">OneCall version</string>
     <string name="settings_weather_source_iqa_atmo_aura_key">ATMO AURA key</string>


### PR DESCRIPTION
| Name  | About  | Requires API key  | id  |
|---|---|---|---|
| Pirate Weather | Open weather source which follows DarkSky API style  | Yes | pirateweather  |

### Link to publicly available documentation of the API
https://docs.pirateweather.net/en/latest/Specification/

### Available and not available data
Available: current/minutely/hourly/daily forecasts, wind speed/direction, precipitation, alerts.
Not available: air quality, **moonrise/moonset times**.

### About PR:
This is the previous PR, with fixed windspeed, more nullable fields and proper SourceManager service location. I apologize for the confusion, git is not my strength.