### PR TITLE
Add here.com source

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,6 +63,7 @@ android {
         it.buildConfigField "String", "MF_WSFT_KEY", "\"${properties.getProperty("breezy.mf.key") ?: ""}\""
         it.buildConfigField "String", "OPEN_WEATHER_KEY", "\"${properties.getProperty("breezy.openweather.key") ?: ""}\""
         it.buildConfigField "String", "PIRATE_WEATHER_KEY", "\"${properties.getProperty("breezy.pirateweather.key") ?: ""}\""
+        it.buildConfigField "String", "HERE_KEY", "\"${properties.getProperty("breezy.here.key") ?: ""}\""
     }
 
     sourceSets {

--- a/app/src/main/java/org/breezyweather/sources/SourceManager.kt
+++ b/app/src/main/java/org/breezyweather/sources/SourceManager.kt
@@ -9,6 +9,7 @@ import org.breezyweather.sources.accu.AccuService
 import org.breezyweather.sources.android.AndroidLocationSource
 import org.breezyweather.sources.baiduip.BaiduIPLocationService
 import org.breezyweather.sources.china.ChinaService
+import org.breezyweather.sources.here.HereService
 import org.breezyweather.sources.metno.MetNoService
 import org.breezyweather.sources.mf.MfService
 import org.breezyweather.sources.noreversegeocoding.NoReverseGeocodingService
@@ -25,6 +26,7 @@ class SourceManager @Inject constructor(
     metNoService: MetNoService,
     openWeatherService: OpenWeatherService,
     pirateWeatherService: PirateWeatherService,
+    hereService: HereService,
     mfService: MfService,
     chinaService: ChinaService,
     noReverseGeocodingService: NoReverseGeocodingService
@@ -41,6 +43,7 @@ class SourceManager @Inject constructor(
         metNoService,
         openWeatherService,
         pirateWeatherService,
+        hereService,
         mfService,
         chinaService,
 

--- a/app/src/main/java/org/breezyweather/sources/here/HereGeocodingApi.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/HereGeocodingApi.kt
@@ -1,0 +1,18 @@
+package org.breezyweather.sources.here
+
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.sources.here.json.HereGeocodingResult
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface HereGeocodingApi {
+    @GET("v1/geocode")
+    fun geoCode(
+        @Query("apiKey") apikey: String,
+        @Query("q") query: String,
+        @Query("types") types: String,
+        @Query("limit") limit: Int,
+        @Query("lang") language: String,
+        @Query("show") show: String
+    ): Observable<HereGeocodingResult>
+}

--- a/app/src/main/java/org/breezyweather/sources/here/HereResultConverter.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/HereResultConverter.kt
@@ -1,0 +1,424 @@
+package org.breezyweather.sources.here
+
+import org.breezyweather.common.basic.models.Location
+import org.breezyweather.common.basic.models.weather.Alert
+import org.breezyweather.common.basic.models.weather.Astro
+import org.breezyweather.common.basic.models.weather.Base
+import org.breezyweather.common.basic.models.weather.Current
+import org.breezyweather.common.basic.models.weather.Daily
+import org.breezyweather.common.basic.models.weather.HalfDay
+import org.breezyweather.common.basic.models.weather.MoonPhase
+import org.breezyweather.common.basic.models.weather.Precipitation
+import org.breezyweather.common.basic.models.weather.PrecipitationProbability
+import org.breezyweather.common.basic.models.weather.Temperature
+import org.breezyweather.common.basic.models.weather.UV
+import org.breezyweather.common.basic.models.weather.WeatherCode
+import org.breezyweather.common.basic.models.weather.Wind
+import org.breezyweather.common.basic.wrappers.HourlyWrapper
+import org.breezyweather.common.basic.wrappers.WeatherResultWrapper
+import org.breezyweather.common.exceptions.LocationSearchException
+import org.breezyweather.common.exceptions.WeatherException
+import org.breezyweather.common.extensions.toDate
+import org.breezyweather.common.extensions.toDateNoHour
+import org.breezyweather.common.extensions.toTimezoneNoHour
+import org.breezyweather.sources.here.json.HereGeocodingResult
+import org.breezyweather.sources.here.json.HereWeatherAlert
+import org.breezyweather.sources.here.json.HereWeatherAlertTimeSegment
+import org.breezyweather.sources.here.json.HereWeatherAstronomy
+import org.breezyweather.sources.here.json.HereWeatherData
+import org.breezyweather.sources.here.json.HereWeatherForecastResult
+import org.breezyweather.sources.here.json.HereWeatherNWSAlerts
+import org.breezyweather.sources.here.json.HereWeatherStatusResult
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import java.util.UUID
+import kotlin.math.roundToInt
+import kotlin.time.Duration.Companion.hours
+
+private val DATEFORMAT = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
+private val ASTRODATEFORMAT = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US)
+
+/**
+ * Converts here.com geocoding result into a list of locations
+ */
+fun convert(
+    result: HereGeocodingResult
+): List<Location> {
+    if (result.items == null) {
+        throw LocationSearchException()
+    }
+
+    return result.items.map { item ->
+        Location(
+            cityId = item.id,
+            latitude = item.position.lat,
+            longitude = item.position.lng,
+            timeZone = TimeZone.getTimeZone(item.timeZone?.name),
+            country = item.address.countryName,
+            countryCode = item.address.countryCode,
+            province = item.address.state,
+            provinceCode = item.address.stateCode,
+            district = item.address.county,
+            city = item.address.city,
+            weatherSource = "here"
+        )
+    }
+}
+
+/**
+ * Converts here.com weather result into a forecast
+ */
+fun convert(
+    hereWeatherForecastResult: HereWeatherForecastResult,
+    hereWeatherStatusResult: HereWeatherStatusResult,
+): WeatherResultWrapper {
+    if (!hereWeatherStatusResult.status.equals("ok")) {
+        throw WeatherException()
+    }
+
+    // Indexes changed several times while testing, so had to resort to this
+    // There is 100% a way to make it nicer
+    val currentForecasts =
+        hereWeatherForecastResult.dataList.find { it?.currentForecasts != null }?.currentForecasts
+    val hourlyForecasts =
+        hereWeatherForecastResult.dataList.find { it?.hourlyForecasts != null }?.hourlyForecasts
+
+    val dailyExtendedForecasts =
+        hereWeatherForecastResult.dataList.find { it?.extendedDailyForecasts != null }?.extendedDailyForecasts
+    val dailySimpleForecasts =
+        hereWeatherForecastResult.dataList.find { it?.dailyForecasts != null }?.dailyForecasts
+    val astronomyForecasts =
+        hereWeatherForecastResult.dataList.find { it?.astronomyForecasts != null }?.astronomyForecasts
+
+    val alerts = hereWeatherForecastResult.dataList.find { it?.alerts != null }?.alerts
+    val nwsAlerts = hereWeatherForecastResult.dataList.find { it?.nwsAlerts != null }?.nwsAlerts
+
+    return WeatherResultWrapper(
+        base = Base(
+            publishDate = currentForecasts?.get(0)?.time?.toDateNoHour() ?: Date()
+        ),
+        current = currentForecasts?.get(0)?.let { getCurrentForecast(it) },
+        dailyForecast = getDailyForecast(
+            dailySimpleForecasts?.get(0)?.forecasts,
+            dailyExtendedForecasts?.get(0)?.forecasts,
+            astronomyForecasts?.get(0)?.forecasts
+        ),
+        hourlyForecast = hourlyForecasts?.get(0)?.forecasts?.let { getHourlyForecast(it) },
+        alertList = getAlertList(
+            alerts, nwsAlerts, getTimeZone(currentForecasts?.get(0)?.time)
+        )
+    )
+}
+
+/**
+ * Parses time from String
+ */
+private fun getDate(time: String?): Date? {
+    return time?.let { DATEFORMAT.parse(it) }
+}
+
+/**
+ * Parses time for astro events
+ */
+private fun getAstroDate(date: String?, time: String?): Date? {
+    if (date == null || time == null) return null
+    val withTime = date.replace("00:00:00", time) // bad, API21 forced my hand
+    return withTime.let { ASTRODATEFORMAT.parse(it) }
+}
+
+/**
+ * Retrieves timezone from Date string
+ */
+private fun getTimeZone(time: String?): TimeZone? {
+    if (time == null || getDate(time) == null) return null
+    val regex = Regex("([-+][01][0-9]:[0-9][0-9])$")
+    val capture = regex.find(time)?.value
+    if (capture.isNullOrEmpty()) return TimeZone.getDefault()
+
+    return TimeZone.getTimeZone("GMT${capture}")
+}
+
+/**
+ * Returns current forecast
+ */
+private fun getCurrentForecast(result: HereWeatherData): Current {
+    return Current(
+        weatherText = result.skyDesc,
+        weatherCode = getWeatherCode(result.iconId),
+        temperature = Temperature(
+            temperature = result.temperature,
+            apparentTemperature = result.apparentTemperature?.toFloat()
+        ),
+        wind = Wind(
+            degree = result.windDirection, speed = result.windSpeed
+        ),
+        uV = UV(
+            index = result.uvIndex?.toFloat()
+        ),
+        relativeHumidity = result.humidity?.toFloat(),
+        dewPoint = result.dewPoint,
+        pressure = result.pressure,
+        visibility = result.visibility,
+    )
+}
+
+/**
+ * Returns daily forecast
+ */
+private fun getDailyForecast(
+    dailySimpleForecasts: List<HereWeatherData>?,
+    dailyExtendedForecasts: List<HereWeatherData>?,
+    astroForecasts: List<HereWeatherAstronomy>?
+): List<Daily>? {
+    if (dailyExtendedForecasts == null) {
+        return null
+    }
+
+    val dailyList = arrayListOf<Daily>()
+
+    var currentDay = 0
+    for ((index, nightSegment) in dailyExtendedForecasts.withIndex()) {
+        if (nightSegment.timeOfDay != "night") {
+            continue
+        }
+        currentDay++
+
+        val daySegment = if (index >= 2) dailyExtendedForecasts[index - 2] else null
+        val fullDay = dailySimpleForecasts?.get(currentDay - 1)
+        val astro = astroForecasts?.get(currentDay - 1)
+
+        dailyList.add(
+            Daily(
+                date = getDate(daySegment?.time) ?: Date(),
+                // Use day segment if available
+                day = daySegment?.let {
+                    HalfDay(
+                        weatherText = it.skyDesc,
+                        weatherCode = getWeatherCode(it.iconId),
+                        temperature = Temperature(
+                            temperature = it.temperature,
+                            apparentTemperature = it.apparentTemperature?.toFloat()
+                        ),
+                        precipitation = Precipitation(
+                            total = it.precipitation12H ?: getTotalPrecipFallback(it),
+                            rain = it.rainFall,
+                            snow = it.snowFall,
+                        ),
+                        precipitationProbability = PrecipitationProbability(
+                            total = it.precipitationProbability?.toFloat()
+                        )
+                    )
+                }, night = HalfDay(
+                    weatherText = nightSegment.skyDesc,
+                    weatherCode = getWeatherCode(nightSegment.iconId),
+                    temperature = Temperature(
+                        temperature = nightSegment.temperature,
+                        apparentTemperature = nightSegment.apparentTemperature?.toFloat()
+                    )
+                ), sun = Astro(
+                    riseDate = getAstroDate(astro?.time, astro?.sunRise),
+                    setDate = getAstroDate(astro?.time, astro?.sunSet)
+                ), moon = Astro(
+                    riseDate = getAstroDate(astro?.time, astro?.moonRise),
+                    setDate = getAstroDate(astro?.time, astro?.moonSet)
+                ), moonPhase = MoonPhase(
+                    angle = astro?.moonPhase?.times(360f)?.roundToInt()
+                ), uV = UV(
+                    index = fullDay?.uvIndex?.toFloat()
+                )
+            )
+        )
+    }
+    return dailyList
+}
+
+/**
+ * Returns hourly forecast
+ */
+private fun getHourlyForecast(
+    hourlyResult: List<HereWeatherData>
+): List<HourlyWrapper> {
+    return hourlyResult.map { result ->
+        HourlyWrapper(
+            date = getDate(result.time) ?: Date(),
+            weatherText = result.skyDesc,
+            weatherCode = getWeatherCode(result.iconId),
+            temperature = Temperature(
+                temperature = result.temperature,
+                apparentTemperature = result.apparentTemperature?.toFloat()
+            ),
+            precipitation = Precipitation(
+                total = result.precipitation1H ?: getTotalPrecipFallback(result),
+                rain = result.rainFall,
+                snow = result.snowFall,
+            ),
+            precipitationProbability = PrecipitationProbability(
+                total = result.precipitationProbability?.toFloat()
+            ),
+            wind = Wind(
+                degree = result.windDirection, speed = result.windSpeed
+            ),
+            uV = UV(
+                index = result.uvIndex?.toFloat()
+            ),
+            relativeHumidity = result.humidity?.toFloat(),
+            dewPoint = result.dewPoint,
+            pressure = result.pressure,
+            visibility = result.visibility
+        )
+    }
+}
+
+/**
+ * Fallback total precipitation calculation
+ * Sums up snow and rain values
+ */
+private fun getTotalPrecipFallback(weatherData: HereWeatherData): Float {
+    return (weatherData.rainFall ?: 0f).plus(weatherData.snowFall ?: 0f)
+}
+
+/**
+ * Returns a list of alerts, combined from
+ * general alerts forecasted for next 24 hours and
+ * NWS warnings and watches
+ *
+ * TODO: Smarter deduplication
+ */
+private fun getAlertList(
+    alerts: List<HereWeatherAlert>?, nwsAlerts: HereWeatherNWSAlerts?, tz: TimeZone?
+): List<Alert> {
+    val converted = arrayListOf<Alert>()
+
+    alerts?.let {
+        for (alert in it) {
+            if (alert.timeSegments.isNullOrEmpty()) {
+                continue
+            }
+
+            for (timeSegment in alert.timeSegments) {
+                converted.add(
+                    Alert(
+                        // see https://stackoverflow.com/questions/15184820/how-to-generate-unique-positive-long-using-uuid
+                        alertId = UUID.randomUUID().mostSignificantBits and Long.MAX_VALUE,
+                        startDate = getForecastedAlertStart(timeSegment, tz),
+                        endDate = getForecastedAlertEnd(timeSegment, tz),
+                        description = alert.description?.substringBefore(" - ")
+                            ?: alert.description
+                            ?: "",
+                        content = alert.description?.substringAfter(" - "),
+                        priority = getForecastedAlertPriority(alert)
+                    )
+                )
+            }
+        }
+    }
+
+    val nwsAlertsCombined = (nwsAlerts?.warnings ?: listOf()) + (nwsAlerts?.watches ?: listOf())
+    for (alert in nwsAlertsCombined) {
+        val description = alert.description ?: ""
+        val startDate = getDate(alert.start) ?: Date()
+        val endDate = getDate(alert.end) ?: Date()
+
+        // try to deduplicate
+        if (converted.find {
+                it.description == description &&
+                        it.startDate == startDate &&
+                        it.endDate == endDate
+            } != null) {
+            continue
+        }
+
+        converted.add(
+            Alert(
+                alertId = UUID.randomUUID().mostSignificantBits and Long.MAX_VALUE,
+                startDate = startDate,
+                endDate = endDate,
+                description = description,
+                content = alert.message,
+                priority = alert.severity ?: 1
+            )
+        )
+    }
+
+    return converted
+}
+
+/**
+ * Returns forecasted alert start time
+ * manually inferred from time of day in HereAlertTimeSegment
+ *
+ * TODO: Alerts are forecasted for next 24 hours
+ *  Right now each alert is set to today regardless of dayOfWeek,
+ *  but it is possible that the alert is for tomorrow
+ */
+private fun getForecastedAlertStart(
+    timeSegment: HereWeatherAlertTimeSegment, tz: TimeZone?
+): Date {
+    val dayStart = tz?.let { Date().toTimezoneNoHour(it) } ?: Date()
+
+    val alertStart = when (timeSegment.timeOfDay) {
+        "morning" -> 2
+        "afternoon" -> 10
+        "evening" -> 16
+        "night" -> 20
+        else -> 0
+    }
+    return dayStart.time.plus(alertStart.hours.inWholeMilliseconds).toDate()
+}
+
+/**
+ * Returns forecasted alert end time
+ * manually inferred from time of day in HereAlertTimeSegment
+ */
+private fun getForecastedAlertEnd(
+    timeSegment: HereWeatherAlertTimeSegment, tz: TimeZone?
+): Date {
+    val dayStart = tz?.let { Date().toTimezoneNoHour(it) } ?: Date()
+    val alertEnd = when (timeSegment.timeOfDay) {
+        "morning" -> 10
+        "afternoon" -> 16
+        "evening" -> 20
+        "night" -> 24
+        else -> 0
+    }
+    return dayStart.time.plus(alertEnd.hours.inWholeMilliseconds).toDate()
+}
+
+/**
+ * Returns forecasted alert priority
+ * manually inferred from alert's description.
+ *
+ * See https://developer.here.com/documentation/destination-weather/api-reference-v3.html
+ * ApiInformation for details
+ */
+private fun getForecastedAlertPriority(alert: HereWeatherAlert): Int {
+    return when (alert.type) {
+        1, 4, 7, 8, 10, 11, 13, 14, 15, 17, 18, 20, 22, 30, 32, 35 -> 3
+        2, 5, 9, 16, 19, 21, 33, 34 -> 2
+        3, 6, 12, 31 -> 1
+        else -> 1
+    }
+}
+
+/**
+ * Returns weather code based on icon id
+ */
+private fun getWeatherCode(icon: Int?): WeatherCode? {
+    return when (icon) {
+        1, 2, 13, 14 -> WeatherCode.CLEAR
+        3 -> WeatherCode.HAZE
+        4, 5, 15, 16 -> WeatherCode.PARTLY_CLOUDY
+        6 -> WeatherCode.PARTLY_CLOUDY
+        7, 17 -> WeatherCode.CLOUDY
+        8, 9, 10, 12 -> WeatherCode.FOG
+        11 -> WeatherCode.WIND
+        18, 19, 20, 32, 33, 34 -> WeatherCode.RAIN
+        21, 22, 23, 25, 26, 35 -> WeatherCode.THUNDERSTORM
+        24 -> WeatherCode.HAIL
+        27, 28 -> WeatherCode.SLEET
+        29, 30, 31 -> WeatherCode.SNOW
+        else -> null
+    }
+}

--- a/app/src/main/java/org/breezyweather/sources/here/HereRevGeocodingApi.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/HereRevGeocodingApi.kt
@@ -1,0 +1,18 @@
+package org.breezyweather.sources.here
+
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.sources.here.json.HereGeocodingResult
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface HereRevGeocodingApi {
+    @GET("v1/revgeocode")
+    fun revGeoCode(
+        @Query("apiKey") apikey: String,
+        @Query("at") query: String,
+        @Query("types") types: String,
+        @Query("limit") limit: Int,
+        @Query("lang") language: String,
+        @Query("show") show: String
+    ): Observable<HereGeocodingResult>
+}

--- a/app/src/main/java/org/breezyweather/sources/here/HereService.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/HereService.kt
@@ -1,0 +1,199 @@
+package org.breezyweather.sources.here
+
+import android.content.Context
+import android.graphics.Color
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.BreezyWeather
+import org.breezyweather.BuildConfig
+import org.breezyweather.R
+import org.breezyweather.common.basic.models.Location
+import org.breezyweather.common.basic.wrappers.WeatherResultWrapper
+import org.breezyweather.common.exceptions.ApiKeyMissingException
+import org.breezyweather.common.preference.EditTextPreference
+import org.breezyweather.common.preference.Preference
+import org.breezyweather.common.source.ConfigurableSource
+import org.breezyweather.common.source.HttpSource
+import org.breezyweather.common.source.LocationSearchSource
+import org.breezyweather.common.source.ReverseGeocodingSource
+import org.breezyweather.common.source.WeatherSource
+import org.breezyweather.settings.SettingsManager
+import org.breezyweather.settings.SourceConfigStore
+import org.breezyweather.sources.here.json.HereWeatherForecastResult
+import org.breezyweather.sources.here.json.HereWeatherStatusResult
+import retrofit2.Retrofit
+import javax.inject.Inject
+
+class HereService @Inject constructor(
+    @ApplicationContext context: Context,
+    client: Retrofit.Builder
+) : HttpSource(), WeatherSource, LocationSearchSource, ReverseGeocodingSource, ConfigurableSource {
+    override val id = "here"
+    override val name = "Here.com"
+    override val privacyPolicyUrl = "https://legal.here.com/privacy/policy"
+
+    override val color = Color.rgb(0, 175, 170)
+    override val weatherAttribution = "Here.com"        // can't find
+    override val locationSearchAttribution = "Here.com" // can't find
+
+    private val mWeatherApi by lazy {
+        client
+            .baseUrl(if (BreezyWeather.instance.debugMode) HERE_WEATHER_DEV_BASE_URL else HERE_WEATHER_BASE_URL)
+            .build()
+            .create(HereWeatherApi::class.java)
+    }
+
+    private val mGeocodingApi by lazy {
+        client
+            .baseUrl(HERE_GEOCODING_BASE_URL)
+            .build()
+            .create(HereGeocodingApi::class.java)
+    }
+
+    private val mRevGeocodingApi by lazy {
+        client
+            .baseUrl(HERE_REV_GEOCODING_BASE_URL)
+            .build()
+            .create(HereRevGeocodingApi::class.java)
+    }
+
+    /**
+     * Returns weather
+     */
+    override fun requestWeather(
+        context: Context, location: Location
+    ): Observable<WeatherResultWrapper> {
+        if (!isConfigured()) {
+            return Observable.error(ApiKeyMissingException())
+        }
+
+        val apiKey = getApiKeyOrDefault()
+        val languageCode = SettingsManager.getInstance(context).language.code
+        val products = listOf(
+            "observation",
+            "forecast7days",
+            "forecast7daysSimple",
+            "forecastHourly",
+            "forecastAstronomy",
+            "alerts",
+            "nwsAlerts",
+        )
+        val forecast = mWeatherApi.getForecast(
+            apiKey,
+            products.joinToString(separator = ","),
+            listOf(
+                location.latitude.toDouble(),
+                location.longitude.toDouble(),
+            ).joinToString(separator = ","),
+            "metric",
+            if (languageCode == "en") "en-US" else languageCode, //errors when lang=en
+            oneObservation = true
+        )
+
+        val status = mWeatherApi.getStatus(
+            apiKey
+        )
+
+        return Observable.zip(
+            forecast,
+            status
+        ) { hereWeatherForecastResult: HereWeatherForecastResult,
+            hereWeatherStatusResult: HereWeatherStatusResult
+            ->
+            convert(
+                hereWeatherForecastResult,
+                hereWeatherStatusResult
+            )
+        }
+    }
+
+    /**
+     * Returns cities matching a query
+     */
+    override fun requestLocationSearch(
+        context: Context,
+        query: String
+    ): Observable<List<Location>> {
+        if (!isConfigured()) {
+            return Observable.error(ApiKeyMissingException())
+        }
+
+        val apiKey = getApiKeyOrDefault()
+        val languageCode = SettingsManager.getInstance(context).language.code
+
+        val locationResult = mGeocodingApi.geoCode(
+            apiKey,
+            query,
+            types = "city",
+            limit = 20,     // default api value
+            languageCode,
+            show = "tz"     // adds timezone info
+        )
+
+        return locationResult.map { convert(it) }
+    }
+
+    /**
+     * Returns cities near provided coordinates
+     */
+    override fun requestReverseGeocodingLocation(
+        context: Context,
+        location: Location
+    ): Observable<List<Location>> {
+        if (!isConfigured()) {
+            return Observable.error(ApiKeyMissingException())
+        }
+
+        val apiKey = getApiKeyOrDefault()
+        val languageCode = SettingsManager.getInstance(context).language.code
+
+        val locationResult = mRevGeocodingApi.revGeoCode(
+            apiKey,
+            listOf(
+                location.latitude.toDouble(),
+                location.longitude.toDouble(),
+            ).joinToString(separator = ","),
+            types = "city",
+            limit = 20,
+            languageCode,
+            show = "tz"
+        )
+
+        return locationResult.map { convert(it) }
+    }
+
+    // CONFIG
+    private val config = SourceConfigStore(context, id)
+    private var apikey: String
+        set(value) {
+            config.edit().putString("apikey", value).apply()
+        }
+        get() = config.getString("apikey", null) ?: ""
+
+    private fun getApiKeyOrDefault() = apikey.ifEmpty { BuildConfig.HERE_KEY }
+    private fun isConfigured() = getApiKeyOrDefault().isNotEmpty()
+
+    override fun getPreferences(context: Context): List<Preference> {
+        return listOf(
+            EditTextPreference(
+                titleId = R.string.settings_weather_provider_here_api_key,
+                summary = { c, content ->
+                    content.ifEmpty {
+                        c.getString(R.string.settings_source_default_value)
+                    }
+                },
+                content = apikey,
+                onValueChanged = {
+                    apikey = it
+                }
+            ),
+        )
+    }
+
+    companion object {
+        private const val HERE_WEATHER_BASE_URL = "https://weather.cc.api.here.com/"
+        private const val HERE_WEATHER_DEV_BASE_URL = "https://weather.cit.cc.api.here.com/"
+        private const val HERE_GEOCODING_BASE_URL = "https://geocode.search.hereapi.com/"
+        private const val HERE_REV_GEOCODING_BASE_URL = "https://revgeocode.search.hereapi.com/"
+    }
+}

--- a/app/src/main/java/org/breezyweather/sources/here/HereWeatherApi.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/HereWeatherApi.kt
@@ -1,0 +1,27 @@
+package org.breezyweather.sources.here
+
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.sources.here.json.HereWeatherForecastResult
+import org.breezyweather.sources.here.json.HereWeatherStatusResult
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+/**
+ * OpenWeather API.
+ */
+interface HereWeatherApi {
+    @GET("v3/report")
+    fun getForecast(
+        @Query("apiKey") apikey: String,
+        @Query("products", encoded = true) products: String,
+        @Query("location", encoded = true) location: String,
+        @Query("units") units: String,
+        @Query("lang") lang: String,
+        @Query("oneObservation") oneObservation: Boolean,
+    ): Observable<HereWeatherForecastResult>
+
+    @GET("v3/health")
+    fun getStatus(
+        @Query("apiKey") apikey: String,
+    ): Observable<HereWeatherStatusResult>
+}

--- a/app/src/main/java/org/breezyweather/sources/here/json/HereGeocodingAddress.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/json/HereGeocodingAddress.kt
@@ -1,0 +1,15 @@
+package org.breezyweather.sources.here.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HereGeocodingAddress(
+    val label: String,
+    val countryCode: String,
+    val countryName: String,
+    val stateCode: String?,
+    val state: String?,
+    val county: String?,
+    val city: String,
+    val postalCode: String
+)

--- a/app/src/main/java/org/breezyweather/sources/here/json/HereGeocodingData.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/json/HereGeocodingData.kt
@@ -1,0 +1,11 @@
+package org.breezyweather.sources.here.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HereGeocodingData(
+    val id: String,
+    val position: HereGeocodingPosition,
+    val address: HereGeocodingAddress,
+    val timeZone: HereGeocodingTimezone?
+)

--- a/app/src/main/java/org/breezyweather/sources/here/json/HereGeocodingPosition.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/json/HereGeocodingPosition.kt
@@ -1,0 +1,9 @@
+package org.breezyweather.sources.here.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HereGeocodingPosition(
+    val lat: Float,
+    val lng: Float
+)

--- a/app/src/main/java/org/breezyweather/sources/here/json/HereGeocodingResult.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/json/HereGeocodingResult.kt
@@ -1,0 +1,8 @@
+package org.breezyweather.sources.here.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HereGeocodingResult(
+    val items: List<HereGeocodingData>?
+)

--- a/app/src/main/java/org/breezyweather/sources/here/json/HereGeocodingTimezone.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/json/HereGeocodingTimezone.kt
@@ -1,0 +1,9 @@
+package org.breezyweather.sources.here.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HereGeocodingTimezone(
+    val name: String,
+    val utcOffset: String
+)

--- a/app/src/main/java/org/breezyweather/sources/here/json/HereNWSAlertItem.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/json/HereNWSAlertItem.kt
@@ -1,0 +1,18 @@
+package org.breezyweather.sources.here.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HereNWSAlertItem(
+    val counties: List<HereNWSAlertRegion>?,
+    val zones: List<HereNWSAlertRegion>?,
+    val provinces: List<HereNWSAlertRegion>?,
+    val type: Int?,
+    val description: String?,
+    val severity: Int?,
+    val message: String?,
+    @SerialName("name") val locationName: String?,
+    @SerialName("validFromTimeLocal") val start: String?,
+    @SerialName("validUntilTimeLocal") val end: String?
+)

--- a/app/src/main/java/org/breezyweather/sources/here/json/HereNWSAlertRegion.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/json/HereNWSAlertRegion.kt
@@ -1,0 +1,16 @@
+package org.breezyweather.sources.here.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HereNWSAlertRegion(
+    @SerialName("country") val countryCode: String?,
+    val countryName: String?,
+    @SerialName("state") val stateCode: String?,
+    val stateName: String?,
+    @SerialName("province") val provinceCode: String?,
+    val provinceName: String?,
+    val name: String?,
+    val location: HereWeatherLocation?
+)

--- a/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherAlert.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherAlert.kt
@@ -1,0 +1,10 @@
+package org.breezyweather.sources.here.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HereWeatherAlert(
+    val timeSegments: List<HereWeatherAlertTimeSegment>?,
+    val type: Int?,
+    val description: String?
+)

--- a/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherAlertTimeSegment.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherAlertTimeSegment.kt
@@ -1,0 +1,10 @@
+package org.breezyweather.sources.here.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HereWeatherAlertTimeSegment(
+    @SerialName("segment") val timeOfDay: String?,
+    @SerialName("weekday") val dayOfWeek: String?
+)

--- a/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherAstronomy.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherAstronomy.kt
@@ -1,0 +1,13 @@
+package org.breezyweather.sources.here.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HereWeatherAstronomy(
+    val time: String?,
+    val sunRise: String?,
+    val sunSet: String?,
+    val moonRise: String?,
+    val moonSet: String?,
+    val moonPhase: Float?
+)

--- a/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherData.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherData.kt
@@ -1,0 +1,33 @@
+package org.breezyweather.sources.here.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HereWeatherData(
+    val time: String,
+    val weekday: String?,
+    @SerialName("daySegment") val timeOfDay: String?,
+    val skyDesc: String?,
+    val temperature: Float?,
+    @SerialName("comfort") val apparentTemperature: String?,
+    val highTemperature: String?,
+    val lowTemperature: String?,
+    val humidity: String?,
+    val dewPoint: Float?,
+    val precipitation1H: Float?,
+    val precipitation12H: Float?,
+    val precipitation24H: Float?,
+    val precipitationProbability: Int?,
+    val precipitationDesc: String?,
+    val rainFall: Float?,
+    val snowFall: Float?,
+    val airInfo: Int?,
+    val windSpeed: Float?,
+    val windDirection: Float?,
+    val uvIndex: Int?,
+    @SerialName("barometerPressure") val pressure: Float?,
+    val visibility: Float?,
+    val snowCover: Float?,
+    val iconId: Int?
+)

--- a/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherForecastResult.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherForecastResult.kt
@@ -1,0 +1,13 @@
+package org.breezyweather.sources.here.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * List of reports
+ * See https://developer.here.com/documentation/destination-weather/dev_guide/topics/resource-response-type-report.html
+ */
+@Serializable
+data class HereWeatherForecastResult(
+    @SerialName("places") val dataList: List<HereWeatherPlaceReport?>,
+)

--- a/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherForecasts.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherForecasts.kt
@@ -1,0 +1,8 @@
+package org.breezyweather.sources.here.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HereWeatherForecasts<T>(
+    val forecasts: List<T>?
+)

--- a/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherLocation.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherLocation.kt
@@ -1,0 +1,11 @@
+package org.breezyweather.sources.here.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HereWeatherLocation(
+    @SerialName("lat") val latitude: Float?,
+    @SerialName("lng") val longitude: Float?,
+    @SerialName("elv") val elevation: Float?
+)

--- a/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherNWSAlerts.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherNWSAlerts.kt
@@ -1,0 +1,9 @@
+package org.breezyweather.sources.here.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HereWeatherNWSAlerts(
+    val warnings: List<HereNWSAlertItem>?,
+    val watches: List<HereNWSAlertItem>?
+)

--- a/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherPlaceReport.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherPlaceReport.kt
@@ -1,0 +1,19 @@
+package org.breezyweather.sources.here.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents *possible* reported categories
+ * Is either empty or contains 1 category
+ */
+@Serializable
+data class HereWeatherPlaceReport(
+    @SerialName("observations") val currentForecasts: List<HereWeatherData>?,
+    val extendedDailyForecasts: List<HereWeatherForecasts<HereWeatherData>>?,
+    val dailyForecasts: List<HereWeatherForecasts<HereWeatherData>>?,
+    val hourlyForecasts: List<HereWeatherForecasts<HereWeatherData>>?,
+    val astronomyForecasts: List<HereWeatherForecasts<HereWeatherAstronomy>>?,
+    val alerts: List<HereWeatherAlert>?,
+    val nwsAlerts: HereWeatherNWSAlerts?
+)

--- a/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherStatusResult.kt
+++ b/app/src/main/java/org/breezyweather/sources/here/json/HereWeatherStatusResult.kt
@@ -1,0 +1,8 @@
+package org.breezyweather.sources.here.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HereWeatherStatusResult(
+    val status: String?
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -467,6 +467,7 @@
     <string name="settings_weather_provider_accu_api_key" translatable="false">@string/settings_source_api_key</string>
     <string name="settings_weather_provider_open_weather_api_key" translatable="false">@string/settings_source_api_key</string>
     <string name="settings_weather_provider_pirate_weather_api_key" translatable="false">@string/settings_source_api_key</string>
+    <string name="settings_weather_provider_here_api_key" translatable="false">@string/settings_source_api_key</string>
     <string name="settings_weather_provider_mf_api_key" translatable="false">@string/settings_source_api_key</string>
     <string name="settings_weather_source_open_weather_one_call_version">OneCall version</string>
     <string name="settings_weather_source_iqa_atmo_aura_key">ATMO AURA key</string>


### PR DESCRIPTION
| Name  | About  | Requires API key  | id  |
|---|---|---|---|
|  Here.com | Used  Here Destination Weather API to provide weather forecasts  | Yes | here  |

### Link to publicly available documentation of the API
https://developer.here.com/documentation/destination-weather/api-reference-v3.html

### Available and not available data
Available: current/hourly/daily forecasts, wind speed/direction, precipitation, alerts, astronomy, gecodoing*, reverse geocoding*.
Not available: air quality, enterprice alerts**

*Uses Here Geocoding & Search API

**The only difference (judging from the api spec) between enterprise alerts and reported alerts is the addition of (1) severtity and (2) exact start/end times. (1) can be manually inferred from alert type, (2) can be approximated.

### About PR:
Implements here.com weather using Here Destination Weather, gecodoing and reverse geocoding using Here Geocoding & Search API. I am not sure if geocoding will be of use as it requires an api key (same key works for weather and location).

Main concerns:
1. Weather api does not return precipitation for 1H/12H/24H, so right now falls back to rain + snow precipitation.
2. Date handling for reported weather alerts is ugly at best, as the api provides relative date of week and time of day per alert type instead of a timestamp.