### PR TITLE
Add static backgrounds when animations are disabled

### DIFF
--- a/app/src/main/java/org/breezyweather/main/fragments/HomeFragment.kt
+++ b/app/src/main/java/org/breezyweather/main/fragments/HomeFragment.kt
@@ -91,7 +91,7 @@ class HomeFragment : MainModuleFragment() {
 
     override fun onResume() {
         super.onResume()
-        weatherView.setDrawable(isBackgroundAnimationEnabled() && !isHidden)
+        weatherView.setDrawable(!isHidden)
     }
 
     override fun onPause() {
@@ -108,7 +108,7 @@ class HomeFragment : MainModuleFragment() {
 
     override fun onHiddenChanged(hidden: Boolean) {
         super.onHiddenChanged(hidden)
-        weatherView.setDrawable(isBackgroundAnimationEnabled() && !hidden)
+        weatherView.setDrawable(!hidden)
     }
 
     override fun setSystemBarStyle() {
@@ -143,6 +143,10 @@ class HomeFragment : MainModuleFragment() {
 
         weatherView.setGravitySensorEnabled(
             SettingsManager.getInstance(requireContext()).isGravitySensorEnabled
+        )
+
+        weatherView.setAnimatable(
+            isBackgroundAnimationEnabled()
         )
 
         binding.toolbar.setNavigationOnClickListener {

--- a/app/src/main/java/org/breezyweather/theme/weatherView/WeatherView.kt
+++ b/app/src/main/java/org/breezyweather/theme/weatherView/WeatherView.kt
@@ -34,6 +34,7 @@ interface WeatherView {
     @get:WeatherKindRule
     val weatherKind: Int
     fun setDrawable(drawable: Boolean)
+    fun setAnimatable(animatable: Boolean)
     fun setGravitySensorEnabled(enabled: Boolean)
 
     companion object {

--- a/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/MaterialWeatherView.kt
+++ b/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/MaterialWeatherView.kt
@@ -24,6 +24,7 @@ class MaterialWeatherView(context: Context) : ViewGroup(context), WeatherView {
     private var mDaytime = false
     private var mFirstCardMarginTop = 0
     private var mGravitySensorEnabled: Boolean = true
+    private var mAnimatable: Boolean = true
     private var mDrawable: Boolean = false
 
     /**
@@ -115,7 +116,7 @@ class MaterialWeatherView(context: Context) : ViewGroup(context), WeatherView {
         mPreviousView = mCurrentView
         mCurrentView = prev
         mCurrentView?.let {
-            it.update(weatherKind, daytime, mGravitySensorEnabled)
+            it.update(weatherKind, daytime, mGravitySensorEnabled, mAnimatable)
             it.drawable = mDrawable
         } ?: run {
             mCurrentView = MaterialPainterView(
@@ -124,7 +125,8 @@ class MaterialWeatherView(context: Context) : ViewGroup(context), WeatherView {
                 daytime,
                 mDrawable,
                 mPreviousView?.scrollRate ?: 0f,
-                mGravitySensorEnabled
+                mGravitySensorEnabled,
+                mAnimatable
             )
             addView(mCurrentView)
         }
@@ -136,7 +138,12 @@ class MaterialWeatherView(context: Context) : ViewGroup(context), WeatherView {
                 interpolator = AccelerateDecelerateInterpolator()
                 playTogether(
                     ObjectAnimator.ofFloat(mCurrentView as MaterialPainterView, "alpha", 0f, 1f),
-                    ObjectAnimator.ofFloat(mPreviousView as MaterialPainterView, "alpha", it.alpha, 0f)
+                    ObjectAnimator.ofFloat(
+                        mPreviousView as MaterialPainterView,
+                        "alpha",
+                        it.alpha,
+                        0f
+                    )
                 )
             }.also { it.start() }
         } ?: run {
@@ -169,6 +176,10 @@ class MaterialWeatherView(context: Context) : ViewGroup(context), WeatherView {
         mPreviousView?.let {
             it.drawable = drawable
         }
+    }
+
+    override fun setAnimatable(animatable: Boolean) {
+        mAnimatable = animatable
     }
 
     override fun setGravitySensorEnabled(enabled: Boolean) {

--- a/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/WeatherImplementorFactory.kt
+++ b/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/WeatherImplementorFactory.kt
@@ -13,21 +13,25 @@ object WeatherImplementorFactory {
     fun getWeatherImplementor(
         @WeatherKindRule weatherKind: Int,
         daytime: Boolean,
-        @Size(2) sizes: IntArray
+        @Size(2) sizes: IntArray,
+        animate: Boolean
     ): WeatherAnimationImplementor? = when (weatherKind) {
         WeatherView.WEATHER_KIND_CLEAR -> if (daytime) {
             SunImplementor(
-                sizes
+                sizes,
+                animate
             )
         } else {
             MeteorShowerImplementor(
-                sizes
+                sizes,
+                animate
             )
         }
 
         WeatherView.WEATHER_KIND_CLOUDY ->
             CloudImplementor(
                 sizes,
+                animate,
                 CloudImplementor.TYPE_CLOUDY,
                 daytime
             )
@@ -35,6 +39,7 @@ object WeatherImplementorFactory {
         WeatherView.WEATHER_KIND_CLOUD ->
             CloudImplementor(
                 sizes,
+                animate,
                 CloudImplementor.TYPE_CLOUD,
                 daytime
             )
@@ -42,6 +47,7 @@ object WeatherImplementorFactory {
         WeatherView.WEATHER_KIND_FOG ->
             CloudImplementor(
                 sizes,
+                animate,
                 CloudImplementor.TYPE_FOG,
                 daytime
             )
@@ -49,12 +55,14 @@ object WeatherImplementorFactory {
         WeatherView.WEATHER_KIND_HAIL ->
             HailImplementor(
                 sizes,
+                animate,
                 daytime
             )
 
         WeatherView.WEATHER_KIND_HAZE ->
             CloudImplementor(
                 sizes,
+                animate,
                 CloudImplementor.TYPE_HAZE,
                 daytime
             )
@@ -62,6 +70,7 @@ object WeatherImplementorFactory {
         WeatherView.WEATHER_KIND_RAINY ->
             RainImplementor(
                 sizes,
+                animate,
                 RainImplementor.TYPE_RAIN,
                 daytime
             )
@@ -69,12 +78,14 @@ object WeatherImplementorFactory {
         WeatherView.WEATHER_KIND_SNOW ->
             SnowImplementor(
                 sizes,
+                animate,
                 daytime
             )
 
         WeatherView.WEATHER_KIND_THUNDERSTORM ->
             RainImplementor(
                 sizes,
+                animate,
                 RainImplementor.TYPE_THUNDERSTORM,
                 daytime
             )
@@ -82,6 +93,7 @@ object WeatherImplementorFactory {
         WeatherView.WEATHER_KIND_THUNDER ->
             CloudImplementor(
                 sizes,
+                animate,
                 CloudImplementor.TYPE_THUNDER,
                 daytime
             )
@@ -89,12 +101,14 @@ object WeatherImplementorFactory {
         WeatherView.WEATHER_KIND_WIND ->
             WindImplementor(
                 sizes,
+                animate,
                 daytime
             )
 
         WeatherView.WEATHER_KIND_SLEET ->
             RainImplementor(
                 sizes,
+                animate,
                 RainImplementor.TYPE_SLEET,
                 daytime
             )

--- a/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/CloudImplementor.kt
+++ b/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/CloudImplementor.kt
@@ -18,8 +18,12 @@ import kotlin.math.sqrt
 
 @SuppressLint("SwitchIntDef")
 class CloudImplementor(
-    @Size(2) canvasSizes: IntArray, @TypeRule type: Int, daylight: Boolean
+    @Size(2) canvasSizes: IntArray,
+    animate: Boolean,
+    @TypeRule type: Int,
+    daylight: Boolean
 ) : WeatherAnimationImplementor() {
+    private val mAnimate = animate
     private var mPaint = Paint().apply {
         style = Paint.Style.FILL
         isAntiAlias = true

--- a/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/HailImplementor.kt
+++ b/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/HailImplementor.kt
@@ -14,7 +14,12 @@ import kotlin.math.sin
 /**
  * Hail implementor.
  */
-class HailImplementor(@Size(2) canvasSizes: IntArray, daylight: Boolean) : WeatherAnimationImplementor() {
+class HailImplementor(
+    @Size(2) canvasSizes: IntArray,
+    animate: Boolean,
+    daylight: Boolean
+) : WeatherAnimationImplementor() {
+    private val mAnimate = animate
     private val mPaint = Paint().apply {
         style = Paint.Style.FILL
         isAntiAlias = true

--- a/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/MeteorShowerImplementor.kt
+++ b/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/MeteorShowerImplementor.kt
@@ -15,7 +15,11 @@ import kotlin.math.sin
 /**
  * Meteor shower implementor.
  */
-class MeteorShowerImplementor(@Size(2) canvasSizes: IntArray) : WeatherAnimationImplementor() {
+class MeteorShowerImplementor(
+    @Size(2) canvasSizes: IntArray,
+    animate: Boolean
+) : WeatherAnimationImplementor() {
+    private val mAnimate = animate
     private val mPaint = Paint().apply {
         style = Paint.Style.STROKE
         strokeCap = Paint.Cap.ROUND
@@ -143,7 +147,7 @@ class MeteorShowerImplementor(@Size(2) canvasSizes: IntArray) : WeatherAnimation
             Color.rgb(240, 220, 151)
         )
 
-        mMeteors = Array(10) {
+        mMeteors = Array(if(mAnimate) 10 else 0) {
             Meteor(
                 viewWidth, viewHeight,
                 colors[random.nextInt(colors.size)], random.nextFloat()

--- a/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/RainImplementor.kt
+++ b/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/RainImplementor.kt
@@ -20,8 +20,12 @@ import kotlin.math.sin
  * Rain implementor.
  */
 class RainImplementor(
-    @Size(2) canvasSizes: IntArray, @TypeRule type: Int, daylight: Boolean
+    @Size(2) canvasSizes: IntArray,
+    animate: Boolean,
+    @TypeRule type: Int,
+    daylight: Boolean
 ) : WeatherAnimationImplementor() {
+    private val mAnimate = animate
     private val mPaint = Paint().apply {
         style = Paint.Style.FILL
         isAntiAlias = true
@@ -213,6 +217,9 @@ class RainImplementor(
         @Size(2) canvasSizes: IntArray, interval: Long,
         rotation2D: Float, rotation3D: Float
     ) {
+        // do not display any rain effects if animations are turned off
+        if (!mAnimate) return
+
         for (r in mRains) {
             r.move(
                 interval,

--- a/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/SnowImplementor.kt
+++ b/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/SnowImplementor.kt
@@ -13,7 +13,12 @@ import kotlin.math.sin
 /**
  * Snow implementor.
  */
-class SnowImplementor(@Size(2) canvasSizes: IntArray, daylight: Boolean) : WeatherAnimationImplementor() {
+class SnowImplementor(
+    @Size(2) canvasSizes: IntArray,
+    animate: Boolean,
+    daylight: Boolean
+) : WeatherAnimationImplementor() {
+    private val mAnimate = animate
     private val mPaint = Paint().apply {
         style = Paint.Style.FILL
         isAntiAlias = true

--- a/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/SunImplementor.kt
+++ b/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/SunImplementor.kt
@@ -11,7 +11,11 @@ import kotlin.math.sin
 /**
  * Clear day implementor.
  */
-class SunImplementor(@Size(2) canvasSizes: IntArray) : WeatherAnimationImplementor() {
+class SunImplementor(
+    @Size(2) canvasSizes: IntArray,
+    animate: Boolean
+) : WeatherAnimationImplementor() {
+    private val mAnimate = animate
     private val mPaint = Paint().apply {
         style = Paint.Style.FILL
         isAntiAlias = true

--- a/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/WindImplementor.kt
+++ b/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/WindImplementor.kt
@@ -13,8 +13,11 @@ import kotlin.math.pow
 import kotlin.math.sin
 
 class WindImplementor(
-    @Size(2) canvasSizes: IntArray, daylight: Boolean
+    @Size(2) canvasSizes: IntArray,
+    animate: Boolean,
+    daylight: Boolean
 ) : WeatherAnimationImplementor() {
+    private val mAnimate = animate
     private val mPaint = Paint().apply {
         style = Paint.Style.FILL
         isAntiAlias = true


### PR DESCRIPTION
Tackles #195 
This is a crude solution, which is basically to set time for animations to 0. It is inefficient, as we still create all of the classes needed for live animations.
The reason why everything needs to be created is that basic View onDraw() function clears canvas before every frame, effectively making it imbossible to just stop updating it, as it will be empty on the next call. A more appropriate solution would be to use a SurfaceView, (TextureView?), or save first frame to a bitmap.

What this pr does:
Instantiates live animations even when they are disabled.
Gradually slows doen time to 0 for all animated backgrounds in span of 50 frames.
Adds additional parameter `animated` to all weather implementors, which allows for more control. (For example, water droplets and meteors are completely disabled) 

Tested: Sunny, cloudy, hazy, clear night, rain.