### PR TITLE
Fix widgets not respecting yesterday lines setting

### DIFF
--- a/app/src/main/java/org/breezyweather/remoteviews/presenters/DailyTrendWidgetIMP.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/presenters/DailyTrendWidgetIMP.kt
@@ -93,6 +93,8 @@ object DailyTrendWidgetIMP : AbstractRemoteViewsPresenter() {
             else -> location.isDaylight
         }
 
+
+
         // TODO: Redundant with DailyTemperatureAdapter
         val daytimeTemperatures: Array<Float?> = arrayOfNulls(max(0, itemCount * 2 - 1))
         run {
@@ -165,6 +167,9 @@ object DailyTrendWidgetIMP : AbstractRemoteViewsPresenter() {
                 true
             )
             trendParent.setColor(lightTheme)
+            trendParent.setKeyLineVisibility(
+                SettingsManager.getInstance(context).isTrendHorizontalLinesEnabled
+            )
         }
 
         val colors = ThemeManager.getInstance(context).weatherThemeDelegate.getThemeColors(

--- a/app/src/main/java/org/breezyweather/remoteviews/presenters/HourlyTrendWidgetIMP.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/presenters/HourlyTrendWidgetIMP.kt
@@ -140,6 +140,9 @@ object HourlyTrendWidgetIMP : AbstractRemoteViewsPresenter() {
                 false
             )
             trendParent.setColor(lightTheme)
+            trendParent.setKeyLineVisibility(
+                SettingsManager.getInstance(context).isTrendHorizontalLinesEnabled
+            )
         }
 
         val colors = ThemeManager.getInstance(context).weatherThemeDelegate.getThemeColors(

--- a/app/src/main/java/org/breezyweather/remoteviews/trend/TrendLinearLayout.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/trend/TrendLinearLayout.kt
@@ -48,6 +48,8 @@ class TrendLinearLayout @JvmOverloads constructor(
     private var mLowestTemp: Float? = null
     private var mTemperatureUnit: TemperatureUnit
 
+    private var mKeyLineVisibility: Boolean = false
+
     @ColorInt
     private var mLineColor = 0
 
@@ -79,19 +81,22 @@ class TrendLinearLayout @JvmOverloads constructor(
         if (mHistoryTemps.isEmpty()) return
         computeCoordinates()
         if (mHistoryTempYs.isEmpty()) return
-        mPaint.style = Paint.Style.STROKE
-        mPaint.strokeWidth = CHART_LINE_SIZE
-        mPaint.color = mLineColor
-        canvas.drawLine(
-            0f, mHistoryTempYs[0],
-            measuredWidth.toFloat(), mHistoryTempYs[0],
-            mPaint
-        )
-        canvas.drawLine(
-            0f, mHistoryTempYs[1],
-            measuredWidth.toFloat(), mHistoryTempYs[1],
-            mPaint
-        )
+
+        if (mKeyLineVisibility) {
+            mPaint.style = Paint.Style.STROKE
+            mPaint.strokeWidth = CHART_LINE_SIZE
+            mPaint.color = mLineColor
+            canvas.drawLine(
+                0f, mHistoryTempYs[0],
+                measuredWidth.toFloat(), mHistoryTempYs[0],
+                mPaint
+            )
+            canvas.drawLine(
+                0f, mHistoryTempYs[1],
+                measuredWidth.toFloat(), mHistoryTempYs[1],
+                mPaint
+            )
+        }
         mPaint.style = Paint.Style.FILL
         mPaint.textSize = TEXT_SIZE
         mPaint.textAlign = Paint.Align.LEFT
@@ -167,5 +172,10 @@ class TrendLinearLayout @JvmOverloads constructor(
     private fun computeSingleCoordinate(value: Float, max: Float, min: Float): Float {
         val canvasHeight = TREND_ITEM_HEIGHT - TREND_MARGIN_TOP - TREND_MARGIN_BOTTOM
         return (measuredHeight - BOTTOM_MARGIN - TREND_MARGIN_BOTTOM - canvasHeight * (value - min) / (max - min))
+    }
+
+    fun setKeyLineVisibility(visibility: Boolean) {
+        mKeyLineVisibility = visibility
+        invalidate()
     }
 }


### PR DESCRIPTION
Works for daily/hourly trend widgets. Updates the same as the cards in app - after a refresh.
Closes #306 