### PR TITLE
Add Gadgetbridge support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,10 @@
             <!-- Chronus Icon Packs. -->
             <action android:name="android.intent.action.MAIN" />
         </intent>
+
+        <!-- Gadgetbridge -->
+        <package android:name="nodomain.freeyourgadget.gadgetbridge"/>
+        <package android:name="nodomain.freeyourgadget.gadgetbridge.nightly"/>
     </queries>
 
     <application

--- a/app/src/main/java/org/breezyweather/gadgetbridge/GadgetBridgeApi.kt
+++ b/app/src/main/java/org/breezyweather/gadgetbridge/GadgetBridgeApi.kt
@@ -1,0 +1,130 @@
+package org.breezyweather.gadgetbridge
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.pm.PackageManager.PackageInfoFlags
+import android.os.Build
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.breezyweather.common.basic.models.Location
+import org.breezyweather.common.basic.models.options.unit.TemperatureUnit
+import org.breezyweather.common.basic.models.weather.Temperature
+import org.breezyweather.common.basic.models.weather.WeatherCode
+import org.breezyweather.common.utils.helpers.LogHelper
+import org.breezyweather.gadgetbridge.json.GadgetBridgeDailyForecast
+import org.breezyweather.gadgetbridge.json.GadgetBridgeData
+import org.breezyweather.settings.SettingsManager
+import kotlin.math.roundToInt
+
+
+object GadgetBridgeApi {
+    private const val GB_INTENT_EXTRA = "WeatherJson"
+
+    private const val GB_INTENT_PACKAGE = "nodomain.freeyourgadget.gadgetbridge"
+    private const val GB_INTENT_PACKAGE_NIGHTLY = "$GB_INTENT_PACKAGE.nightly"
+    private const val GB_INTENT_ACTION = "$GB_INTENT_PACKAGE.ACTION_GENERIC_WEATHER"
+
+    private var GB_AVAILABLE = false
+
+    fun sendWeatherBroadcast(context: Context, location: Location) {
+        if (location.weather?.current == null) {
+            LogHelper.log(msg = "Not sending GadgetBridge data, current weather is null")
+            return
+        }
+
+        val weatherData = getWeatherData(context, location)
+        val encoded = Json.encodeToString(weatherData)
+
+        val intent = Intent(GB_INTENT_ACTION)
+            .putExtra(GB_INTENT_EXTRA, encoded)
+            .setFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES)
+
+        context.sendBroadcast(intent)
+    }
+
+    fun isEnabled(context: Context): Boolean {
+        return SettingsManager.getInstance(context).isGadgetBridgeSupportEnabled &&
+                isAvailable(context)
+    }
+
+    fun isAvailable(context: Context): Boolean {
+        val pm = context.packageManager
+        GB_AVAILABLE = isPackageAvailable(pm, GB_INTENT_PACKAGE) ||
+                isPackageAvailable(pm, GB_INTENT_PACKAGE_NIGHTLY)
+        return GB_AVAILABLE
+    }
+
+    private fun isPackageAvailable(pm: PackageManager, name: String): Boolean {
+        return try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                pm.getPackageInfo(name, PackageInfoFlags.of(PackageManager.GET_META_DATA.toLong()))
+            } else {
+                pm.getPackageInfo(name, PackageManager.GET_META_DATA)
+            }
+            true
+        } catch (exc: PackageManager.NameNotFoundException) {
+            false
+        }
+    }
+
+    private fun getWeatherData(
+        context: Context,
+        location: Location
+    ): GadgetBridgeData {
+        val dailyForecasts = location.weather?.dailyForecast?.mapIndexed { index, day ->
+            GadgetBridgeDailyForecast(
+                conditionCode = getWeatherCode(day.day?.weatherCode),
+                maxTemp = getTemp(day.day?.temperature),
+                minTemp = getTemp(day.night?.temperature),
+                // this is inefficient
+                humidity = location.weather.hourlyForecast.firstOrNull { it.date.after(day.date) }
+                    ?.relativeHumidity?.roundToInt()
+            )
+        }
+
+        val current = location.weather?.current
+        val today = location.weather?.today
+
+        return GadgetBridgeData(
+            timestamp = location.weather?.base?.mainUpdateTime?.time?.div(1000)?.toInt(),
+            location = location.getPlace(context),
+            currentTemp = getTemp(current?.temperature),
+            currentConditionCode = getWeatherCode(current?.weatherCode),
+            currentCondition = current?.weatherText,
+            currentHumidity = current?.relativeHumidity?.roundToInt(),
+            windSpeed = current?.wind?.speed,
+            windDirection = current?.wind?.degree?.roundToInt(),
+            uvIndex = current?.uV?.index,
+
+            todayMaxTemp = getTemp(today?.day?.temperature),
+            todayMinTemp = getTemp(today?.night?.temperature),
+            precipProbability = today?.day?.precipitationProbability?.total?.times(100)
+                ?.roundToInt(),
+
+            forecasts = dailyForecasts
+        )
+    }
+
+    private fun getTemp(temp: Temperature?): Int? {
+        return temp?.temperature?.let { TemperatureUnit.K.convertUnit(it).roundToInt() }
+    }
+
+    private fun getWeatherCode(code: WeatherCode?): Int {
+        return when (code) {
+            WeatherCode.CLEAR -> 800
+            WeatherCode.PARTLY_CLOUDY -> 801
+            WeatherCode.CLOUDY -> 803
+            WeatherCode.RAIN -> 500
+            WeatherCode.SNOW -> 600
+            WeatherCode.WIND -> 771
+            WeatherCode.FOG -> 741
+            WeatherCode.HAZE -> 751
+            WeatherCode.SLEET -> 611
+            WeatherCode.HAIL -> 511
+            WeatherCode.THUNDER -> 210
+            WeatherCode.THUNDERSTORM -> 211
+            else -> 3200
+        }
+    }
+}

--- a/app/src/main/java/org/breezyweather/gadgetbridge/json/GadgetBridgeDailyForecast.kt
+++ b/app/src/main/java/org/breezyweather/gadgetbridge/json/GadgetBridgeDailyForecast.kt
@@ -1,0 +1,11 @@
+package org.breezyweather.gadgetbridge.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GadgetBridgeDailyForecast(
+    val minTemp: Int? = null,
+    val maxTemp: Int? = null,
+    val conditionCode: Int? = null,
+    val humidity: Int? = null
+)

--- a/app/src/main/java/org/breezyweather/gadgetbridge/json/GadgetBridgeData.kt
+++ b/app/src/main/java/org/breezyweather/gadgetbridge/json/GadgetBridgeData.kt
@@ -1,0 +1,25 @@
+package org.breezyweather.gadgetbridge.json
+
+import kotlinx.serialization.Serializable
+
+
+/**
+ * Refer to
+ * https://codeberg.org/Freeyourgadget/Gadgetbridge/src/branch/master/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/model/WeatherSpec.java
+ */
+@Serializable
+data class GadgetBridgeData (
+    val timestamp: Int? = null,
+    val location: String? = null,
+    val currentTemp: Int? = null,
+    val currentConditionCode : Int? = null,
+    val currentCondition: String? = null,
+    val currentHumidity: Int? = null,
+    val todayMaxTemp: Int? = null,
+    val todayMinTemp:  Int? = null,
+    val windSpeed: Float? = null,
+    val windDirection: Int? = null,
+    val uvIndex: Float? = null,
+    val precipProbability: Int? = null,
+    val forecasts: List<GadgetBridgeDailyForecast>? = null
+)

--- a/app/src/main/java/org/breezyweather/remoteviews/Widgets.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/Widgets.kt
@@ -24,6 +24,7 @@ import org.breezyweather.common.basic.models.options.unit.TemperatureUnit
 import org.breezyweather.common.basic.models.weather.Weather
 import org.breezyweather.db.repositories.LocationEntityRepository
 import org.breezyweather.db.repositories.WeatherEntityRepository
+import org.breezyweather.gadgetbridge.GadgetBridgeApi
 import org.breezyweather.remoteviews.presenters.*
 import java.util.*
 
@@ -119,6 +120,10 @@ object Widgets {
     }
 
     fun updateWidgetIfNecessary(context: Context, location: Location) {
+        if (GadgetBridgeApi.isEnabled(context)) {
+            GadgetBridgeApi.sendWeatherBroadcast(context, location);
+        }
+
         if (DayWidgetIMP.isInUse(context)) {
             DayWidgetIMP.updateWidgetView(context, location)
         }

--- a/app/src/main/java/org/breezyweather/settings/SettingsManager.kt
+++ b/app/src/main/java/org/breezyweather/settings/SettingsManager.kt
@@ -28,7 +28,6 @@ import org.breezyweather.common.basic.models.options.unit.PressureUnit
 import org.breezyweather.common.basic.models.options.unit.SpeedUnit
 import org.breezyweather.common.basic.models.options.unit.TemperatureUnit
 import org.breezyweather.common.bus.EventBus
-import org.breezyweather.sources.SourceManager
 
 class SettingsChangedMessage
 
@@ -418,6 +417,13 @@ class SettingsManager private constructor(context: Context) {
             notifySettingsChanged()
         }
         get() = config.getBoolean("notification_widget_feelslike", false)
+
+    var isGadgetBridgeSupportEnabled: Boolean
+        set(value) {
+            config.edit().putBoolean("gadgetbridge_support_switch", value).apply()
+            notifySettingsChanged()
+        }
+        get() = config.getBoolean("gadgetbridge_support_switch", false)
 
     private fun notifySettingsChanged() {
         EventBus

--- a/app/src/main/java/org/breezyweather/settings/compose/WidgetsSettingsScreen.kt
+++ b/app/src/main/java/org/breezyweather/settings/compose/WidgetsSettingsScreen.kt
@@ -29,6 +29,7 @@ import org.breezyweather.common.basic.models.options.NotificationStyle
 import org.breezyweather.common.basic.models.options.WidgetWeekIconMode
 import org.breezyweather.common.basic.models.weather.Temperature
 import org.breezyweather.common.utils.helpers.SnackbarHelper
+import org.breezyweather.gadgetbridge.GadgetBridgeApi
 import org.breezyweather.remoteviews.Notifications
 import org.breezyweather.remoteviews.Widgets
 import org.breezyweather.remoteviews.config.*
@@ -323,6 +324,27 @@ fun WidgetsSettingsScreen(
         )
     }
     sectionFooterItem(R.string.settings_widgets_section_notification_widget)
+
+    if (GadgetBridgeApi.isAvailable(context)) {
+        sectionHeaderItem(R.string.settings_widgets_gadgetbridge_title)
+        switchPreferenceItem(R.string.settings_widgets_gadgetbridge_switch) { id ->
+            SwitchPreferenceView(
+                titleId = id,
+                summaryOnId = R.string.settings_enabled,
+                summaryOffId = R.string.settings_disabled,
+                checked = SettingsManager
+                    .getInstance(context)
+                    .isGadgetBridgeSupportEnabled,
+                onValueChanged = {
+                    SettingsManager
+                        .getInstance(context)
+                        .isGadgetBridgeSupportEnabled = it
+                    Widgets.updateWidgetIfNecessary(context)
+                }
+            )
+        }
+        sectionFooterItem(R.string.settings_widgets_gadgetbridge_title)
+    }
 
     bottomInsetItem()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -549,6 +549,8 @@
     <string name="settings_widgets_notification_style_title">Style</string>
     <string name="settings_widgets_notification_temp_icon_switch">Temperature as status bar icon</string>
     <string name="settings_widgets_notification_feels_like_switch">Use Feels like temperature</string>
+    <string name="settings_widgets_gadgetbridge_title">Gadgetbridge</string>
+    <string name="settings_widgets_gadgetbridge_switch">Send data to Gadgetbridge</string>
     <string name="about_privacy_policy">Privacy policy</string>
     <string name="settings_debug">Debug</string>
     <string name="settings_debug_summary">Crash logs</string>


### PR DESCRIPTION
Tested on Gadgetbridge Nightly 0.75.1-7c55f5df8
Supports all available gadgetbridge weather data
Implementation is similar to a widget. The option is located in Settings -> Widgets -> Scroll down -> Send data to Gadgetbridge. Option available ONLY if either the stable or nightly build of the gadgetbridge app is installed.
Closes #93