### PR TITLE
Fix day/night widget background setting

### DIFF
--- a/app/src/main/java/org/breezyweather/main/utils/MainThemeColorProvider.kt
+++ b/app/src/main/java/org/breezyweather/main/utils/MainThemeColorProvider.kt
@@ -117,7 +117,7 @@ class MainThemeColorProvider(
             daylight = location?.isDaylight,
         )
 
-        private fun isLightTheme(
+        fun isLightTheme(
             context: Context,
             daylight: Boolean?,
         ): Boolean = if (SettingsManager.getInstance(context).dayNightModeForLocations

--- a/app/src/main/java/org/breezyweather/remoteviews/config/DailyTrendWidgetConfigActivity.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/config/DailyTrendWidgetConfigActivity.kt
@@ -29,9 +29,9 @@ class DailyTrendWidgetConfigActivity : AbstractWidgetConfigActivity() {
         super.initData()
         val cardStyles = resources.getStringArray(R.array.widget_card_styles)
         val cardStyleValues = resources.getStringArray(R.array.widget_card_style_values)
-        cardStyleValueNow = "light"
-        this.cardStyles = arrayOf(cardStyles[2], cardStyles[3], cardStyles[1])
-        this.cardStyleValues = arrayOf(cardStyleValues[2], cardStyleValues[3], cardStyleValues[1])
+        cardStyleValueNow = "app"
+        this.cardStyles = arrayOf(cardStyles[1], cardStyles[2], cardStyles[3], cardStyles[4])
+        this.cardStyleValues = arrayOf(cardStyleValues[1], cardStyleValues[2], cardStyleValues[3], cardStyleValues[4])
     }
 
     override fun initView() {

--- a/app/src/main/java/org/breezyweather/remoteviews/config/HourlyTrendWidgetConfigActivity.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/config/HourlyTrendWidgetConfigActivity.kt
@@ -29,9 +29,9 @@ class HourlyTrendWidgetConfigActivity : AbstractWidgetConfigActivity() {
         super.initData()
         val cardStyles = resources.getStringArray(R.array.widget_card_styles)
         val cardStyleValues = resources.getStringArray(R.array.widget_card_style_values)
-        cardStyleValueNow = "light"
-        this.cardStyles = arrayOf(cardStyles[2], cardStyles[3], cardStyles[1])
-        this.cardStyleValues = arrayOf(cardStyleValues[2], cardStyleValues[3], cardStyleValues[1])
+        cardStyleValueNow = "app"
+        this.cardStyles = arrayOf(cardStyles[1], cardStyles[2], cardStyles[3], cardStyles[4])
+        this.cardStyleValues = arrayOf(cardStyleValues[1], cardStyleValues[2], cardStyleValues[3], cardStyleValues[4])
     }
 
     override fun initView() {

--- a/app/src/main/java/org/breezyweather/remoteviews/presenters/ClockDayDetailsWidgetIMP.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/presenters/ClockDayDetailsWidgetIMP.kt
@@ -54,7 +54,7 @@ object ClockDayDetailsWidgetIMP : AbstractRemoteViewsPresenter() {
         context: Context, location: Location?,
         cardStyle: String?, cardAlpha: Int, textColor: String?, textSize: Int, clockFont: String?, hideLunar: Boolean
     ): RemoteViews {
-        val color = WidgetColor(context, cardStyle!!, textColor!!)
+        val color = WidgetColor(context, cardStyle!!, textColor!!, location?.isDaylight ?: false)
         val views = RemoteViews(
             context.packageName,
             if (!color.showCard) R.layout.widget_clock_day_details else R.layout.widget_clock_day_details_card
@@ -154,7 +154,7 @@ object ClockDayDetailsWidgetIMP : AbstractRemoteViewsPresenter() {
 
         }
         if (color.showCard) {
-            views.setImageViewResource(R.id.widget_clock_day_card, getCardBackgroundId(color.cardColor))
+            views.setImageViewResource(R.id.widget_clock_day_card, getCardBackgroundId(color))
             views.setInt(R.id.widget_clock_day_card, "setImageAlpha", (cardAlpha / 100.0 * 255).toInt())
         }
         when (clockFont) {

--- a/app/src/main/java/org/breezyweather/remoteviews/presenters/ClockDayHorizontalWidgetIMP.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/presenters/ClockDayHorizontalWidgetIMP.kt
@@ -51,7 +51,7 @@ object ClockDayHorizontalWidgetIMP : AbstractRemoteViewsPresenter() {
         context: Context, location: Location?,
         cardStyle: String?, cardAlpha: Int, textColor: String?, textSize: Int, clockFont: String?, hideLunar: Boolean
     ): RemoteViews {
-        val color = WidgetColor(context, cardStyle!!, textColor!!)
+        val color = WidgetColor(context, cardStyle!!, textColor!!, location?.isDaylight ?: false)
         val views = RemoteViews(
             context.packageName,
             if (!color.showCard) R.layout.widget_clock_day_horizontal else R.layout.widget_clock_day_horizontal_card
@@ -114,7 +114,7 @@ object ClockDayHorizontalWidgetIMP : AbstractRemoteViewsPresenter() {
             }
         }
         if (color.showCard) {
-            views.setImageViewResource(R.id.widget_clock_day_card, getCardBackgroundId(color.cardColor))
+            views.setImageViewResource(R.id.widget_clock_day_card, getCardBackgroundId(color))
             views.setInt(R.id.widget_clock_day_card, "setImageAlpha", (cardAlpha / 100.0 * 255).toInt())
         }
         when (clockFont) {

--- a/app/src/main/java/org/breezyweather/remoteviews/presenters/ClockDayVerticalWidgetIMP.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/presenters/ClockDayVerticalWidgetIMP.kt
@@ -26,6 +26,7 @@ import android.widget.RemoteViews
 import org.breezyweather.R
 import org.breezyweather.background.receiver.widget.WidgetClockDayVerticalProvider
 import org.breezyweather.common.basic.models.Location
+import org.breezyweather.common.basic.models.options.NotificationTextColor
 import org.breezyweather.common.basic.models.options.unit.SpeedUnit
 import org.breezyweather.common.basic.models.options.unit.TemperatureUnit
 import org.breezyweather.common.basic.models.weather.Temperature
@@ -60,7 +61,7 @@ object ClockDayVerticalWidgetIMP : AbstractRemoteViewsPresenter() {
         viewStyle: String?, cardStyle: String?, cardAlpha: Int, textColor: String?, textSize: Int,
         hideSubtitle: Boolean, subtitleData: String?, clockFont: String?
     ): RemoteViews {
-        val color = WidgetColor(context, cardStyle!!, textColor!!)
+        val color = WidgetColor(context, cardStyle!!, textColor!!, location?.isDaylight ?: false)
         val settings = SettingsManager.getInstance(context)
         val temperatureUnit = settings.temperatureUnit
         val speedUnit = settings.speedUnit
@@ -70,7 +71,7 @@ object ClockDayVerticalWidgetIMP : AbstractRemoteViewsPresenter() {
             color, textSize, minimalIcon, clockFont, viewStyle, hideSubtitle, subtitleData
         )
         if (color.showCard) {
-            views.setImageViewResource(R.id.widget_clock_day_card, getCardBackgroundId(color.cardColor))
+            views.setImageViewResource(R.id.widget_clock_day_card, getCardBackgroundId(color))
             views.setInt(R.id.widget_clock_day_card, "setImageAlpha", (cardAlpha / 100.0 * 255).toInt())
         }
         location?.let { setOnClickPendingIntent(context, views, it, subtitleData) }
@@ -207,15 +208,24 @@ object ClockDayVerticalWidgetIMP : AbstractRemoteViewsPresenter() {
                     setViewVisibility(R.id.widget_clock_day_clock_blackContainer, View.GONE)
                     setViewVisibility(
                         R.id.widget_clock_day_clock_analogContainer_auto,
-                        if (color.showCard && color.cardColor === WidgetColor.ColorType.AUTO) View.VISIBLE else View.GONE
+                        if (color.backgroundType === WidgetColor.WidgetBackgroundType.APP ||
+                            color.backgroundType == WidgetColor.WidgetBackgroundType.DAY_NIGHT) {
+                            View.VISIBLE
+                        } else View.GONE
                     )
                     setViewVisibility(
                         R.id.widget_clock_day_clock_analogContainer_light,
-                        if (color.showCard && color.cardColor === WidgetColor.ColorType.AUTO) View.GONE else if (color.darkText) View.GONE else View.VISIBLE
+                        if (color.backgroundType == WidgetColor.WidgetBackgroundType.APP ||
+                            color.backgroundType == WidgetColor.WidgetBackgroundType.DAY_NIGHT) {
+                            View.GONE
+                        } else if (color.textType == NotificationTextColor.DARK) View.GONE else View.VISIBLE
                     )
                     setViewVisibility(
                         R.id.widget_clock_day_clock_analogContainer_dark,
-                        if (color.showCard && color.cardColor === WidgetColor.ColorType.AUTO) View.GONE else if (color.darkText) View.VISIBLE else View.GONE
+                        if (color.backgroundType == WidgetColor.WidgetBackgroundType.APP ||
+                            color.backgroundType == WidgetColor.WidgetBackgroundType.DAY_NIGHT) {
+                            View.GONE
+                        } else if (color.textType == NotificationTextColor.DARK) View.VISIBLE else View.GONE
                     )
                 }
             }

--- a/app/src/main/java/org/breezyweather/remoteviews/presenters/ClockDayWeekWidgetIMP.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/presenters/ClockDayWeekWidgetIMP.kt
@@ -52,7 +52,7 @@ object ClockDayWeekWidgetIMP : AbstractRemoteViewsPresenter() {
         context: Context, location: Location?,
         cardStyle: String?, cardAlpha: Int, textColor: String?, textSize: Int, clockFont: String?, hideLunar: Boolean
     ): RemoteViews {
-        val color = WidgetColor(context, cardStyle!!, textColor!!)
+        val color = WidgetColor(context, cardStyle!!, textColor!!, location?.isDaylight ?: false)
         val views = RemoteViews(
             context.packageName,
             if (!color.showCard) R.layout.widget_clock_day_week else R.layout.widget_clock_day_week_card
@@ -187,7 +187,7 @@ object ClockDayWeekWidgetIMP : AbstractRemoteViewsPresenter() {
             }
         }
         if (color.showCard) {
-            views.setImageViewResource(R.id.widget_clock_day_week_card, getCardBackgroundId(color.cardColor))
+            views.setImageViewResource(R.id.widget_clock_day_week_card, getCardBackgroundId(color))
             views.setInt(R.id.widget_clock_day_week_card, "setImageAlpha", (cardAlpha / 100.0 * 255).toInt())
         }
         when (clockFont) {

--- a/app/src/main/java/org/breezyweather/remoteviews/presenters/DayWeekWidgetIMP.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/presenters/DayWeekWidgetIMP.kt
@@ -66,7 +66,7 @@ object DayWeekWidgetIMP : AbstractRemoteViewsPresenter() {
         val speedUnit = settings.speedUnit
         val weekIconMode = settings.widgetWeekIconMode
         val minimalIcon = settings.isWidgetUsingMonochromeIcons
-        val color = WidgetColor(context, cardStyle!!, textColor!!)
+        val color = WidgetColor(context, cardStyle!!, textColor!!, location?.isDaylight ?: false)
         val views = buildWidgetViewDayPart(
             context, provider, location, temperatureUnit, speedUnit,
             color, textSize, minimalIcon, viewStyle, hideSubtitle, subtitleData
@@ -159,7 +159,7 @@ object DayWeekWidgetIMP : AbstractRemoteViewsPresenter() {
 
         // set card.
         if (color.showCard) {
-            views.setImageViewResource(R.id.widget_day_week_card, getCardBackgroundId(color.cardColor))
+            views.setImageViewResource(R.id.widget_day_week_card, getCardBackgroundId(color))
             views.setInt(R.id.widget_day_week_card, "setImageAlpha", (cardAlpha / 100.0 * 255).toInt())
         }
 

--- a/app/src/main/java/org/breezyweather/remoteviews/presenters/DayWidgetIMP.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/presenters/DayWidgetIMP.kt
@@ -70,14 +70,15 @@ object DayWidgetIMP : AbstractRemoteViewsPresenter() {
             if (viewStyle == "pixel" || viewStyle == "nano" || viewStyle == "oreo" || viewStyle == "oreo_google_sans" || viewStyle == "temp") {
                 "none"
             } else cardStyle!!,
-            textColor!!
+            textColor!!,
+            location?.isDaylight ?: false
         )
         val views = buildWidgetView(
             context, location, temperatureUnit, speedUnit,
             color, minimalIcon, viewStyle, textSize, hideSubtitle, subtitleData
         )
         if (color.showCard) {
-            views.setImageViewResource(R.id.widget_day_card, getCardBackgroundId(color.cardColor))
+            views.setImageViewResource(R.id.widget_day_card, getCardBackgroundId(color))
             views.setInt(R.id.widget_day_card, "setImageAlpha", (cardAlpha / 100.0 * 255).toInt())
         }
         location?.let { setOnClickPendingIntent(context, views, it, viewStyle, subtitleData) }

--- a/app/src/main/java/org/breezyweather/remoteviews/presenters/MultiCityWidgetIMP.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/presenters/MultiCityWidgetIMP.kt
@@ -55,7 +55,7 @@ object MultiCityWidgetIMP : AbstractRemoteViewsPresenter() {
         val settings = SettingsManager.getInstance(context)
         val temperatureUnit = settings.temperatureUnit
         val minimalIcon = settings.isWidgetUsingMonochromeIcons
-        val color = WidgetColor(context, cardStyle!!, textColor!!)
+        val color = WidgetColor(context, cardStyle!!, textColor!!, locationList.first().isDaylight)
         val views = RemoteViews(
             context.packageName,
             if (!color.showCard) R.layout.widget_multi_city_horizontal else R.layout.widget_multi_city_horizontal_card
@@ -145,7 +145,7 @@ object MultiCityWidgetIMP : AbstractRemoteViewsPresenter() {
             }
         }
         if (color.showCard) {
-            views.setImageViewResource(R.id.widget_multi_city_horizontal_card, getCardBackgroundId(color.cardColor))
+            views.setImageViewResource(R.id.widget_multi_city_horizontal_card, getCardBackgroundId(color))
             views.setInt(
                 R.id.widget_multi_city_horizontal_card, "setImageAlpha", (cardAlpha / 100.0 * 255).toInt()
             )

--- a/app/src/main/java/org/breezyweather/remoteviews/presenters/TextWidgetIMP.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/presenters/TextWidgetIMP.kt
@@ -21,7 +21,6 @@ import android.content.ComponentName
 import android.content.Context
 import android.util.TypedValue
 import android.widget.RemoteViews
-import androidx.core.content.ContextCompat
 import org.breezyweather.R
 import org.breezyweather.background.receiver.widget.WidgetTextProvider
 import org.breezyweather.common.basic.models.Location
@@ -50,10 +49,14 @@ object TextWidgetIMP : AbstractRemoteViewsPresenter() {
         val weather = location?.weather ?: return views
         val settings = SettingsManager.getInstance(context)
         val temperatureUnit = settings.temperatureUnit
-        val darkText = textColor == "dark" || textColor == "auto" && isLightWallpaper(context)
-        val textColorInt: Int = ContextCompat.getColor(
-            context, if (darkText) R.color.colorTextDark else R.color.colorTextLight
+
+        val color = WidgetColor(
+            context,
+            "none",
+            textColor!!,
+            location.isDaylight
         )
+
         views.apply {
             setTextViewText(
                 R.id.widget_text_weather,
@@ -64,9 +67,9 @@ object TextWidgetIMP : AbstractRemoteViewsPresenter() {
                 R.id.widget_text_temperature,
                 weather.current?.temperature?.getShortTemperature(context, temperatureUnit)
             )
-            setTextColor(R.id.widget_text_date, textColorInt)
-            setTextColor(R.id.widget_text_weather, textColorInt)
-            setTextColor(R.id.widget_text_temperature, textColorInt)
+            setTextColor(R.id.widget_text_date, color.textColor)
+            setTextColor(R.id.widget_text_weather, color.textColor)
+            setTextColor(R.id.widget_text_temperature, color.textColor)
         }
         if (textSize != 100) {
             val contentSize = context.resources.getDimensionPixelSize(R.dimen.widget_content_text_size)

--- a/app/src/main/java/org/breezyweather/remoteviews/presenters/WeekWidgetIMP.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/presenters/WeekWidgetIMP.kt
@@ -49,7 +49,7 @@ object WeekWidgetIMP : AbstractRemoteViewsPresenter() {
         context: Context, location: Location?, viewStyle: String?,
         cardStyle: String?, cardAlpha: Int, textColor: String?, textSize: Int
     ): RemoteViews {
-        val color = WidgetColor(context, cardStyle!!, textColor!!)
+        val color = WidgetColor(context, cardStyle!!, textColor!!, location?.isDaylight ?: false)
         val views = RemoteViews(
             context.packageName,
             if ("3_days" == viewStyle) {
@@ -167,7 +167,7 @@ object WeekWidgetIMP : AbstractRemoteViewsPresenter() {
 
         // set card visibility.
         if (color.showCard) {
-            views.setImageViewResource(R.id.widget_week_card, getCardBackgroundId(color.cardColor))
+            views.setImageViewResource(R.id.widget_week_card, getCardBackgroundId(color))
             views.setInt(R.id.widget_week_card, "setImageAlpha", (cardAlpha / 100.0 * 255).toInt())
         }
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -230,12 +230,14 @@
     <!-- widget card style. -->
     <string-array name="widget_card_styles">
         <item>@string/settings_none</item>
+        <item>@string/settings_color_app</item>
         <item>@string/settings_color_day_night</item>
         <item>@string/settings_color_light</item>
         <item>@string/settings_color_dark</item>
     </string-array>
     <string-array name="widget_card_style_values">
         <item>none</item>
+        <item>app</item>
         <item>auto</item>
         <item>light</item>
         <item>dark</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -570,6 +570,7 @@
     <string name="settings_follow_system">Follow system</string>
     <string name="settings_none">None</string>
     <string name="settings_color_day_night">Day / Night</string>
+    <string name="settings_color_app">Follow app</string>
     <string name="settings_color_day_always">Always day</string>
     <string name="settings_color_night_always">Always night</string>
     <string name="settings_color_light">Light</string>


### PR DESCRIPTION
day/night now uses first location's day/night value (previously followed system)
added "Follow app" option to follow app's dark mode
Fixes #409 