### PR TITLE
Fix trend widget crash

### DIFF
--- a/app/src/main/java/org/breezyweather/remoteviews/presenters/DailyTrendWidgetIMP.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/presenters/DailyTrendWidgetIMP.kt
@@ -61,6 +61,9 @@ object DailyTrendWidgetIMP : AbstractRemoteViewsPresenter() {
     @WorkerThread
     private fun innerUpdateWidget(context: Context, location: Location) {
         val config = getWidgetConfig(context, context.getString(R.string.sp_widget_daily_trend_setting))
+        if (config.cardStyle == "none") {
+            config.cardStyle = "auto"
+        }
         AppWidgetManager.getInstance(context).updateAppWidget(
             ComponentName(context, WidgetTrendDailyProvider::class.java),
             getRemoteViews(

--- a/app/src/main/java/org/breezyweather/remoteviews/presenters/HourlyTrendWidgetIMP.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/presenters/HourlyTrendWidgetIMP.kt
@@ -36,6 +36,7 @@ import org.breezyweather.common.basic.models.Location
 import org.breezyweather.common.basic.models.options.NotificationTextColor
 import org.breezyweather.common.extensions.getTabletListAdaptiveWidth
 import org.breezyweather.common.utils.helpers.AsyncHelper
+import org.breezyweather.common.utils.helpers.LogHelper
 import org.breezyweather.remoteviews.Widgets
 import org.breezyweather.remoteviews.trend.TrendLinearLayout
 import org.breezyweather.remoteviews.trend.WidgetItemView
@@ -63,6 +64,9 @@ object HourlyTrendWidgetIMP : AbstractRemoteViewsPresenter() {
             context,
             context.getString(R.string.sp_widget_hourly_trend_setting)
         )
+        if (config.cardStyle == "none") {
+            config.cardStyle = "auto"
+        }
         AppWidgetManager.getInstance(context).updateAppWidget(
             ComponentName(context, WidgetTrendHourlyProvider::class.java),
             getRemoteViews(


### PR DESCRIPTION
Sets cardStyle to "auto" for trend widgets if the value is "none". These checks were mistakenly removed in [this commit](https://github.com/breezy-weather/breezy-weather/commit/0cee98f08a343be7532836e4df22cb547ecea4af#diff-8a108782bc22ac86085bee6455a5a5db11692b5f8c07a7e2454661b812eceeaf).

Should fix #472. Tested on Android 13, GrapheneOS.
