### PR TITLE
Gadgetbridge: Send all locations

### DIFF
--- a/app/src/main/java/org/breezyweather/background/weather/WeatherUpdateJob.kt
+++ b/app/src/main/java/org/breezyweather/background/weather/WeatherUpdateJob.kt
@@ -291,8 +291,9 @@ class WeatherUpdateJob @AssistedInject constructor(
                 // TODO: We only send alert and precipitation forecast for first location for historical reason, but this should be reworked
                 Notifications.checkAndSendAlert(applicationContext, location, locationsToUpdate.firstOrNull { it.formattedId == location.formattedId }?.weather)
                 Notifications.checkAndSendPrecipitation(applicationContext, location)
-                Gadgets.updateGadgetIfNecessary(context, location)
             }
+
+            Gadgets.updateGadgetIfNecessary(context, locationList)
 
             // Inform main activity that we updated location
             newUpdates.forEach {

--- a/app/src/main/java/org/breezyweather/main/MainActivityViewModel.kt
+++ b/app/src/main/java/org/breezyweather/main/MainActivityViewModel.kt
@@ -573,7 +573,7 @@ class MainActivityViewModel @Inject constructor(
                         Widgets.updateWidgetIfNecessary(context, it[0])
                         Notifications.updateNotificationIfNecessary(context, it)
                         Widgets.updateWidgetIfNecessary(context, it)
-                        Gadgets.updateGadgetIfNecessary(context, it[0])
+                        Gadgets.updateGadgetIfNecessary(context, it)
                     }, 1000)
 
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {

--- a/app/src/main/java/org/breezyweather/remoteviews/Gadgets.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/Gadgets.kt
@@ -22,9 +22,9 @@ import org.breezyweather.remoteviews.gadgetbridge.GadgetBridgeService
 
 object Gadgets {
 
-    fun updateGadgetIfNecessary(context: Context, location: Location) {
+    fun updateGadgetIfNecessary(context: Context, locations: List<Location>) {
         if (GadgetBridgeService.isEnabled(context)) {
-            GadgetBridgeService.sendWeatherBroadcast(context, location);
+            GadgetBridgeService.sendWeatherBroadcast(context, locations);
         }
     }
 }

--- a/app/src/main/java/org/breezyweather/sources/RefreshHelper.kt
+++ b/app/src/main/java/org/breezyweather/sources/RefreshHelper.kt
@@ -699,19 +699,21 @@ class RefreshHelper @Inject constructor(
     suspend fun updateGadgetIfNecessary(context: Context) {
         if (GadgetBridgeService.isEnabled(context)) {
             val locationList =
-                locationRepository.getXLocations(1, withParameters = false)//.toMutableList()
+                locationRepository.getAllLocations(withParameters = false)//.toMutableList()
             if (locationList.isNotEmpty()) {
                 Gadgets.updateGadgetIfNecessary(
                     context,
-                    locationList[0].copy(
-                        weather = weatherRepository.getWeatherByLocationId(
-                            locationList[0].formattedId,
-                            withDaily = true,
-                            withHourly = true,
-                            withMinutely = false,
-                            withAlerts = false
+                    locationList.map {
+                        it.copy(
+                            weather = weatherRepository.getWeatherByLocationId(
+                                it.formattedId,
+                                withDaily = true,
+                                withHourly = true,
+                                withMinutely = false,
+                                withAlerts = false
+                            )
                         )
-                    )
+                    }
                 )
             }
         }


### PR DESCRIPTION
Send all locations to Gadgetbridge. The first location is sent exactly as before, as the primary location, keeping the changes backwards compatible. Extra locations are sent in a list on a secondary extra.

PR in Gadgetbridge: https://codeberg.org/Freeyourgadget/Gadgetbridge/pulls/3349
