### PR TITLE
Show full multiline forecast in expanded notification

### DIFF
--- a/app/src/main/java/org/breezyweather/background/forecast/ForecastNotificationNotifier.kt
+++ b/app/src/main/java/org/breezyweather/background/forecast/ForecastNotificationNotifier.kt
@@ -20,12 +20,15 @@ import android.app.Notification
 import android.content.Context
 import android.graphics.drawable.Icon
 import android.os.Build
+import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
 import cancelNotification
 import notificationBuilder
 import notify
 import org.breezyweather.R
 import org.breezyweather.common.basic.models.Location
+import org.breezyweather.common.basic.models.options.unit.TemperatureUnit
+import org.breezyweather.common.basic.models.weather.Daily
 import org.breezyweather.common.basic.models.weather.WeatherCode
 import org.breezyweather.common.extensions.setLanguage
 import org.breezyweather.common.extensions.toBitmap
@@ -98,16 +101,12 @@ class ForecastNotificationNotifier(private val context: Context) {
                     ).toBitmap()
                 )
             }
-            setContentTitle(
-                context.getString(R.string.daytime)
-                        + " " + daily.day?.weatherText
-                        + " " + daily.day?.temperature?.getTemperature(context, temperatureUnit, 0)
-            )
-            setContentText(
-                context.getString(R.string.nighttime)
-                        + " " + daily.night?.weatherText
-                        + " " + daily.night?.temperature?.getTemperature(context, temperatureUnit, 0)
-            )
+
+            val remoteViews = getBigView(daily, temperatureUnit)
+            setCustomBigContentView(remoteViews)
+
+            setContentTitle(getDayString(daily, temperatureUnit))
+            setContentText(getNightString(daily, temperatureUnit))
             setContentIntent(
                 AbstractRemoteViewsPresenter.getWeatherPendingIntent(
                     context,
@@ -137,4 +136,25 @@ class ForecastNotificationNotifier(private val context: Context) {
             notification
         )
     }
+
+    private fun getBigView(daily: Daily, temperatureUnit: TemperatureUnit): RemoteViews {
+        val view = RemoteViews(context.packageName, R.layout.notification_forecast)
+        view.setTextViewText(
+            R.id.notification_forecast_day, getDayString(daily, temperatureUnit)
+        )
+        view.setTextViewText(
+            R.id.notification_forecast_night, getNightString(daily, temperatureUnit)
+        )
+        return view
+    }
+
+    private fun getDayString(daily: Daily, temperatureUnit: TemperatureUnit) =
+        context.getString(R.string.daytime) +
+                " " + daily.day?.weatherText +
+                " " + daily.day?.temperature?.getTemperature(context, temperatureUnit, 0)
+
+    private fun getNightString(daily: Daily, temperatureUnit: TemperatureUnit) =
+        context.getString(R.string.nighttime) +
+                " " + daily.night?.weatherText +
+                " " + daily.night?.temperature?.getTemperature(context, temperatureUnit, 0)
 }

--- a/app/src/main/res/layout/notification_forecast.xml
+++ b/app/src/main/res/layout/notification_forecast.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/notification_forecast_day"
+        style="@style/TextAppearance.Compat.Notification.Title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <TextView
+        android:id="@+id/notification_forecast_night"
+        style="@style/notification_content_text"
+        android:textColor="@color/colorNotificationSecondary" />
+
+</LinearLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -9,6 +9,8 @@
 
     <color name="colorMainCardBackground">#1C1B1F</color>
 
+    <color name="colorNotificationSecondary">@color/secondary_text_default_material_dark</color>
+
     <!-- widget S. -->
 
     <color name="colorWidgetM3TextPrimary">@android:color/white</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -58,6 +58,8 @@
     <color name="colorMainCardBackground">#FDFCFF</color>
     <color name="colorPrecipitationProbability">@color/md_theme_primary</color>
 
+    <color name="colorNotificationSecondary">@color/secondary_text_default_material_light</color>
+
     <!-- widget. -->
 
     <color name="colorWidgetRoot">@color/md_theme_surface</color>


### PR DESCRIPTION
The daily forecast string can be quite long. Show multiline string in expanded notification, instead of the default truncated with ellipse (...) behavior.

before

![image](https://github.com/breezy-weather/breezy-weather/assets/37479705/3115e3a7-ae68-4147-9d6e-6b2f1936164e)

after

![image](https://github.com/breezy-weather/breezy-weather/assets/37479705/418da0be-827f-43f4-91c1-5f7b858ec1a3)

