### PR TITLE
Fix #571 - Alignment of text in status bar

### DIFF
--- a/app/src/main/java/org/breezyweather/theme/resource/ResourceHelper.kt
+++ b/app/src/main/java/org/breezyweather/theme/resource/ResourceHelper.kt
@@ -163,13 +163,14 @@ object ResourceHelper {
             getTextBounds(temperatureFormatted, 0, temperatureFormatted.length, bounds)
         }
 
-        val conf = Bitmap.Config.ARGB_8888
-        val bitmap = Bitmap.createBitmap(bounds.width(), iconSize, conf)
+        // Consider leading whitespace and descenders to properly center the text.
+        // Thanks to https://stackoverflow.com/a/32081250.
+        val bitmap = Bitmap.createBitmap(bounds.right, iconSize, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(bitmap)
         canvas.drawText(
             temperatureFormatted,
-            (bitmap.getWidth() - bounds.width()) / 2f,
-            (bitmap.getHeight() + bounds.height()) / 2f,
+            (bitmap.getWidth() - bounds.width()) / 2f - bounds.left,
+            (bitmap.getHeight() + bounds.height()) / 2f - bounds.bottom,
             paint
         )
 


### PR DESCRIPTION
This fixes the text of the notification widget being cut in the status bar (#571) by taking leading whitespace into account both for setting the width of the canvas and for calculating the horizontal starting position where the text is drawn.

I also slightly adjusted the formula for calculating the vertical starting position by considering [descenders](https://en.wikipedia.org/wiki/Descender). Depending on the font used some digits might be affected. This ensures that the text is still centered correctly.

I tested this successfully on a Google Pixel 6a (Android 14) and on an LG G6 (Android 9).

_This is my first PR containing code changes. So if anything is missing or should be adjusted, just let me know._