### PR TITLE
Fix #709 - Icon color in top app bars

### DIFF
--- a/app/src/main/java/org/breezyweather/common/ui/widgets/insets/FitSystemBarComposeWrappers.kt
+++ b/app/src/main/java/org/breezyweather/common/ui/widgets/insets/FitSystemBarComposeWrappers.kt
@@ -95,7 +95,7 @@ fun FitStatusBarTopAppBar(
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                 contentDescription = stringResource(R.string.action_back),
-                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                tint = MaterialTheme.colorScheme.onSurface,
             )
         }
     },
@@ -116,7 +116,7 @@ fun BWCenterAlignedTopAppBar(
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                 contentDescription = stringResource(R.string.action_back),
-                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                tint = MaterialTheme.colorScheme.onSurface,
             )
         }
     },

--- a/app/src/main/java/org/breezyweather/main/fragments/ManagementFragment.kt
+++ b/app/src/main/java/org/breezyweather/main/fragments/ManagementFragment.kt
@@ -168,7 +168,7 @@ open class ManagementFragment : MainModuleFragment(), TouchReactor {
                             Icon(
                                 imageVector = Icons.Outlined.Search,
                                 contentDescription = stringResource(R.string.action_add_new_location),
-                                tint = MaterialTheme.colorScheme.onPrimaryContainer
+                                tint = MaterialTheme.colorScheme.onSurface
                             )
                         }
                     }

--- a/app/src/main/java/org/breezyweather/settings/activities/SettingsActivity.kt
+++ b/app/src/main/java/org/breezyweather/settings/activities/SettingsActivity.kt
@@ -189,7 +189,7 @@ class SettingsActivity : GeoActivity() {
                             Icon(
                                 imageVector = Icons.Outlined.Info,
                                 contentDescription = stringResource(R.string.action_about),
-                                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                                tint = MaterialTheme.colorScheme.onSurface,
                             )
                         }
                     },


### PR DESCRIPTION
This fixes #709 by correcting the color used for the tint of the navigation icons and actions.

Successfully tested on my Google Pixel 6a (Android 14).

<details>

<summary>screenshots showing the fixed version (monochrome theme enable)</summary>

| light mode | dark mode |
| --- | --- |
| ![monochrome-light-mode](https://github.com/breezy-weather/breezy-weather/assets/97251923/18333b06-71e4-4d8d-adc1-ca9563ff01cd) | ![monochrome-dark-mode](https://github.com/breezy-weather/breezy-weather/assets/97251923/a4f0335f-9e0e-4ebe-bb02-a3ca1912959c) |


</details>