### PR TITLE
Notification time dialog - center time picker horizontally

### DIFF
--- a/app/src/main/java/org/breezyweather/settings/preference/composables/TimePickerPreference.kt
+++ b/app/src/main/java/org/breezyweather/settings/preference/composables/TimePickerPreference.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -34,6 +35,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
@@ -142,7 +144,10 @@ fun TimePickerPreferenceView(
                         )
 
                         timePicker
-                    }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .wrapContentWidth(Alignment.CenterHorizontally)
                 )
             },
             confirmButton = {


### PR DESCRIPTION
This centers the time picker in the dialog to select the notification time (settings -> notifications -> notification time for ...) instead of being aligned to the left.

There is no issue for this, but I had the impression that left-aligning the time picker was still an unintended behavior.

I tested this change on my smartphones with Android 14 and Android 9. Additionally, I also verified that it behaves correctly on a tablet (tested via an emulator with Android 13).

<details>

<summary>screenshots</summary>

You might notice that the dialog on the tablet became a little wider in the new version, but this matches the width of the other dialogs in the settings, e.g. for the dark mode or the refresh interval.

| device | orientation | current version | new version |
| --- | --- | --- | --- |
| Pixel 6a Android 14 | portrait | ![14_p_o](https://github.com/breezy-weather/breezy-weather/assets/97251923/72ad6762-4be9-4512-a861-a68adefaf205) | ![14_p_n](https://github.com/breezy-weather/breezy-weather/assets/97251923/e16a992d-ec33-413c-8e7b-4c6ee1ae8ae7) |
| Pixel 6a Android 14 | landscape | ![14_l_o](https://github.com/breezy-weather/breezy-weather/assets/97251923/ee562b0c-7a7b-47bb-a2f4-472ccf1e5512) | ![14_l_n](https://github.com/breezy-weather/breezy-weather/assets/97251923/5664632f-0327-479b-9b1c-2f6d122bd0dd) |
| LG G6 Android 9 | portrait | ![9_p_o](https://github.com/breezy-weather/breezy-weather/assets/97251923/4b944e99-b5b8-4d29-b77a-58868e91eba8) | ![9_p](https://github.com/breezy-weather/breezy-weather/assets/97251923/4fde3d8e-b797-4d01-8395-bb3b315d17f4) |
| LG G6 Android 9 | landscape | ![9_l_o](https://github.com/breezy-weather/breezy-weather/assets/97251923/5a46072d-fd23-43b8-9f11-7967437f23dc) | ![9_l](https://github.com/breezy-weather/breezy-weather/assets/97251923/641c00d1-5435-4f4d-af6b-85af158bd836) |
| tablet (Android 13) | portrait | ![tablet_dialog_current_landscape_old](https://github.com/breezy-weather/breezy-weather/assets/97251923/d0e10f62-094a-441d-a714-68bd8096f944) | ![tablet_dialog_new_portrait](https://github.com/breezy-weather/breezy-weather/assets/97251923/70a5f926-d962-4de5-bce2-879cb2721fd2) |
| tablet (Android 13) | landscape | ![tablet_dialog_current_handheld_old](https://github.com/breezy-weather/breezy-weather/assets/97251923/98fd3a21-82b0-489d-b00c-24bc4c357ff5) | ![tablet_dialog_new_landscape](https://github.com/breezy-weather/breezy-weather/assets/97251923/f3bd647d-aefb-458e-a0f6-387c68fef23d) |

</details>