### PR TITLE
Fix F-Droid badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 # Download
 
 <a href="https://github.com/breezy-weather/fdroid-repo/blob/main/README.md">
-<img src="https://f-droid.org/badge/get-it-on.png"
+<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
 alt="Get it from Breezy Weather F-Droid repository" align="center" height="80" /></a>
 
 <a href="https://apt.izzysoft.de/fdroid/index/apk/org.breezyweather/">


### PR DESCRIPTION
The URL seems broken, use https://fdroid.gitlab.io/artwork/badge/get-it-on.png instead, see https://gitlab.com/fdroid/artwork/tree/master/badge