### PR TITLE
Fix belarussian translation

### DIFF
--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -68,7 +68,7 @@
     <string name="settings_weather_source_portal">Канал</string>
     <string name="weather_source_accu_preference_hours_72">72 гадзіны</string>
     <string name="locations">Месцазнаходжання</string>
-    <string name="location_current">Бягучы месцазнаходжанне</string>
+    <string name="location_current">Бягучае месцазнаходжанне</string>
     <string name="action_continue">Працягнуць</string>
     <string name="message_network_unavailable">Сетка недаступная</string>
     <string name="message_server_timeout">Скончыўся час запыту</string>


### PR DESCRIPTION
The term 'Бягучы месцазнаходжання' is incorrect because 'месцазнаходжання' is a neuter noun, therefore, the word 'Бягучы' should be in the neuter correct form, i.e., 'Бягучае'.

For example here https://my-current-location.com/be it is used in correct form