### PR TITLE
Fix padding issues in compose layouts when IME is visible

### DIFF
--- a/app/src/main/java/org/breezyweather/common/basic/GeoActivity.kt
+++ b/app/src/main/java/org/breezyweather/common/basic/GeoActivity.kt
@@ -33,53 +33,6 @@ abstract class GeoActivity : AppCompatActivity() {
 
     lateinit var fitHorizontalSystemBarRootLayout: FitHorizontalSystemBarRootLayout
 
-    private class KeyboardResizeBugWorkaround private constructor(activity: GeoActivity) {
-        private val root = activity.fitHorizontalSystemBarRootLayout
-        private val rootParams: ViewGroup.LayoutParams
-        private var usableHeightPrevious = 0
-
-        private fun possiblyResizeChildOfContent() {
-            val usableHeightNow = computeUsableHeight()
-
-            if (usableHeightNow != usableHeightPrevious) {
-                val screenHeight = root.rootView.height
-                val keyboardExpanded: Boolean
-
-                if (screenHeight - usableHeightNow > screenHeight / 5) {
-                    // keyboard probably just became visible.
-                    keyboardExpanded = true
-                    rootParams.height = usableHeightNow
-                } else {
-                    // keyboard probably just became hidden.
-                    keyboardExpanded = false
-                    rootParams.height = screenHeight
-                }
-
-                usableHeightPrevious = usableHeightNow
-                root.setFitKeyboardExpanded(keyboardExpanded)
-            }
-        }
-
-        private fun computeUsableHeight(): Int {
-            val r = Rect()
-            root.getWindowVisibleDisplayFrame(r)
-            return r.bottom // - r.top --> Do not reduce the height of status bar.
-        }
-
-        companion object {
-            // For more information, see https://issuetracker.google.com/issues/36911528
-            // To use this class, simply invoke assistActivity() on an Activity that already has its content view set.
-            fun assistActivity(activity: GeoActivity) {
-                KeyboardResizeBugWorkaround(activity)
-            }
-        }
-
-        init {
-            root.viewTreeObserver.addOnGlobalLayoutListener { possiblyResizeChildOfContent() }
-            rootParams = root.layoutParams
-        }
-    }
-
     @CallSuper
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -108,8 +61,6 @@ abstract class GeoActivity : AppCompatActivity() {
 
         fitHorizontalSystemBarRootLayout.removeAllViews()
         fitHorizontalSystemBarRootLayout.addView(decorChild)
-
-        KeyboardResizeBugWorkaround.assistActivity(this)
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/java/org/breezyweather/search/SearchActivity.kt
+++ b/app/src/main/java/org/breezyweather/search/SearchActivity.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Tune
@@ -104,8 +105,8 @@ class SearchActivity : GeoActivity() {
         val locationSearchSource = sourceManager.getLocationSearchSourceOrDefault(locationSearchSourceState.value)
 
         Material3Scaffold(
+            modifier = Modifier.imePadding(),
             bottomBar = {
-                // Known padding issue when IME is open: https://issuetracker.google.com/issues/249727298
                 BottomAppBar(
                     actions = {
                         Box(
@@ -145,7 +146,6 @@ class SearchActivity : GeoActivity() {
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Column(
-                    // Known padding issue when IME is open: https://issuetracker.google.com/issues/249727298
                     modifier = Modifier.padding(paddings)
                 ) {
                     Material3SearchBarInputField(


### PR DESCRIPTION
This fixes the padding issue in the location search (#30).

A workaround to resize a view layout when IME is open was unintentionally applied in compose layouts which resulted in too much padding. As the workaround is only needed in the widget config layouts it is moved to the AbstractWidgetConfigActivity.

I tested the layouts with text input (location search, api key changes, widget subtitle text) on various devices:

- physical devices: Pixel 6a (Android 14), LG G6 (Android 9)
- emulators: Android 5, Android 7.1.1, Android 10 (tablet), Android 14 (tablet)

This also makes the animation of the bottom app bar much smoother when opening the IME:
| before | after |
| ---  | ---  |
| <video src="https://github.com/breezy-weather/breezy-weather/assets/97251923/2ec36347-af3a-4042-af79-f829e0adbfb7"> | <video src="https://github.com/breezy-weather/breezy-weather/assets/97251923/d9719fd2-1023-4c35-be56-7792e700710e"> |
