### PR TITLE
Implement Gadgetbridge WeatherSecondaryJson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [GeoSphere Austria] Added as secondary source for air quality in Europe and nearby
 - [GeoSphere Austria] Added as secondary source for precipitation nowcasting in Austria and nearby
 - [GeoSphere Austria] Added as secondary source for alerts in Austria
+- [Gadgetbridge] We are now able to send data for secondary locations
 - [AccuWeather] Fix fail to refresh when using a language not supported by AccuWeather (noticed on Central Kurdish, Esperanto and Interlingua), now fallbacks to English
 - [Open-Meteo] Fix workaround location search issue when result list is empty (will show instructions instead of an error)
 - [Open-Meteo] Fix issues related to DST

--- a/app/src/main/java/org/breezyweather/common/source/BroadcastSource.kt
+++ b/app/src/main/java/org/breezyweather/common/source/BroadcastSource.kt
@@ -17,6 +17,7 @@
 package org.breezyweather.common.source
 
 import android.content.Context
+import android.os.Bundle
 import breezyweather.domain.location.model.Location
 
 /**
@@ -26,12 +27,11 @@ interface BroadcastSource : Source {
 
     // Make sure to also add it to the Manifest!
     val intentAction: String
-    val intentExtra: String
 
     /**
      * Return null if anything happens and you no longer want to send any data
      */
-    fun getData(
+    fun getExtras(
         context: Context, locations: List<Location>
-    ): String?
+    ): Bundle?
 }

--- a/app/src/main/java/org/breezyweather/sources/RefreshHelper.kt
+++ b/app/src/main/java/org/breezyweather/sources/RefreshHelper.kt
@@ -754,7 +754,7 @@ class RefreshHelper @Inject constructor(
                     }
 
                     if (enabledAndAvailablePackages.isNotEmpty()) {
-                        val data = source.getData(context, locationList)
+                        val data = source.getExtras(context, locationList)
                         if (data != null) {
                             enabledAndAvailablePackages.forEach {
                                 if (BreezyWeather.instance.debugMode) {
@@ -763,7 +763,7 @@ class RefreshHelper @Inject constructor(
                                 context.sendBroadcast(
                                     Intent(source.intentAction)
                                         .setPackage(it)
-                                        .putExtra(source.intentExtra, data)
+                                        .putExtras(data)
                                         .setFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES)
                                 )
                             }


### PR DESCRIPTION
Supersedes #501 after refactoring.

Currently only supports the multiple locations intent. However, it seems Gadgetbridge expects:
- `WeatherJson` for the first location
- `WeatherSecondaryJson` for locations 2+

I strongly advise against making two intents due to Android limitations: https://developer.android.com/about/versions/oreo/background#broadcasts Not counting that some OEM might put even stricter limitations

Even with one intent, the app already sends the intent rather often due to many cases having to be covered besides the weather refresh.

I suggest deprecating `WeatherJson` for the single-location intent, and make `WeatherSecondaryJson` the multiple-location intent with all locations. So it becomes:
- `WeatherJson` for the first location (deprecated)
- `WeatherSecondaryJson` for all locations

If not possible, we will have to make 2 different `BroadcastSource`.