### PR TITLE
Fix back navigation via TopAppBar in settings

### DIFF
--- a/app/src/main/java/org/breezyweather/settings/activities/SettingsActivity.kt
+++ b/app/src/main/java/org/breezyweather/settings/activities/SettingsActivity.kt
@@ -190,7 +190,7 @@ class SettingsActivity : GeoActivity() {
             topBar = {
                 FitStatusBarTopAppBar(
                     title = stringResource(R.string.action_settings),
-                    onBackPressed = { finish() },
+                    onBackPressed = { onBackPressedDispatcher.onBackPressed() },
                     actions = {
                         IconButton(
                             onClick = {


### PR DESCRIPTION
This fixes #53 by replacing the `finish` call for the back button in the TopAppBar with `onBackPressed` which harmonizes the behavior with the Android back navigation button/gesture. The SettingsActivity is still properly finished when going back to the MainActivity.

Tested on Android 9 (LG G6) and Android 14 (Pixel 6a) as well as on Android 7.1.1 and Android 12 via an emulator.