### PR TITLE
Location search FAB color

### DIFF
--- a/app/src/main/java/org/breezyweather/search/SearchActivity.kt
+++ b/app/src/main/java/org/breezyweather/search/SearchActivity.kt
@@ -128,7 +128,7 @@ class SearchActivity : GeoActivity() {
                         {
                             FloatingActionButton(
                                 onClick = { dialogLocationSearchSourceOpenState.value = true },
-                                containerColor = BottomAppBarDefaults.bottomAppBarFabColor,
+                                containerColor = FloatingActionButtonDefaults.containerColor,
                                 elevation = FloatingActionButtonDefaults.bottomAppBarFabElevation()
                             ) {
                                 Icon(Icons.Filled.Tune, stringResource(R.string.location_search_change_source))


### PR DESCRIPTION
This fixes #139 by using the default FAB color for the FAB in the BottomAppBar.

Tested on Android 9 (LG G6) and Android 14 (Pixel 6a) as well as on Android 7.1.1 via an emulator.

<details>

<summary>screenshots</summary>

| old | new | FAB (location management) |
| --- | --- | --- |
| ![Screenshot_20240411-225403](https://github.com/breezy-weather/breezy-weather/assets/97251923/3a013e46-2b86-465b-9baf-0e58c56a85ba) | ![Screenshot_20240411-225336](https://github.com/breezy-weather/breezy-weather/assets/97251923/a2afe629-7362-4e47-9ec3-8961429c7423) | ![Screenshot_20240411-225331](https://github.com/breezy-weather/breezy-weather/assets/97251923/87dbd49a-ad5d-45f7-a238-965dd06f9d50) |

</details>