### PR TITLE
Fix text color in marker of precipitation chart

### DIFF
--- a/app/src/main/java/org/breezyweather/main/adapters/main/holder/PrecipitationNowcastViewHolder.kt
+++ b/app/src/main/java/org/breezyweather/main/adapters/main/holder/PrecipitationNowcastViewHolder.kt
@@ -323,21 +323,13 @@ private class MarkerLabelFormatterMinutelyDecorator(
             .precipitationIntensityUnit
             .getValueText(context, minutely[model.entry.x.toInt()].precipitationIntensity!!.toDouble())
 
-        return SpannableStringBuilder().apply {
-            append(
-                startTime,
-                "-",
-                endTime,
-                context.getString(R.string.colon_separator),
-                quantityFormatted
-            )
-            setSpan(
-                ForegroundColorSpan(model.color),
-                0,
-                this.length,
-                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
-            )
-        }
+        return SpannableStringBuilder().append(
+            startTime,
+            "-",
+            endTime,
+            context.getString(R.string.colon_separator),
+            quantityFormatted
+        )
     }
 }
 


### PR DESCRIPTION
This fixes the text color used in the marker of the new precipitation chart.

The text color [set for the marker](https://github.com/breezy-weather/breezy-weather/blob/a122b805f44050568e744b857b8398eb2eafd877/app/src/main/java/org/breezyweather/main/adapters/main/holder/PrecipitationNowcastViewHolder.kt#L196-L200) was overriden [here](https://github.com/breezy-weather/breezy-weather/blob/a122b805f44050568e744b857b8398eb2eafd877/app/src/main/java/org/breezyweather/main/adapters/main/holder/PrecipitationNowcastViewHolder.kt#L334-L339).

Tested on Android 9 (LG G6) and Android 14 (Pixel 6a).

<details>

<summary>screenshots</summary>

| old | new |
| --- | --- |
| ![vico precipitation dark_old](https://github.com/breezy-weather/breezy-weather/assets/97251923/65a98fa4-7aed-4a8f-8b0a-82ec5872df89) | ![dark_new](https://github.com/breezy-weather/breezy-weather/assets/97251923/6790088c-905d-405a-a7b5-4698045b8058) |
| ![vico precipitation light_old](https://github.com/breezy-weather/breezy-weather/assets/97251923/720f6fef-a0d8-477c-808e-c2f2125f6e04) | ![light_new](https://github.com/breezy-weather/breezy-weather/assets/97251923/cff67ca4-03ca-4374-9e89-eda462b90a0e) |

</details>

