### PR TITLE
Fix color of overflow icon in toolbar

### DIFF
--- a/app/src/main/java/org/breezyweather/main/fragments/HomeFragment.kt
+++ b/app/src/main/java/org/breezyweather/main/fragments/HomeFragment.kt
@@ -20,6 +20,8 @@ import android.animation.Animator
 import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.graphics.Color
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.MotionEvent
@@ -185,6 +187,9 @@ class HomeFragment : MainModuleFragment() {
             true
         }
         binding.toolbar.menu.findItem(R.id.action_edit).setVisible(false)
+        binding.toolbar.overflowIcon?.colorFilter = PorterDuffColorFilter(
+            Color.WHITE, PorterDuff.Mode.SRC_ATOP
+        )
 
         binding.switchLayout.setOnSwitchListener(switchListener)
         binding.switchLayout.reset()


### PR DESCRIPTION
This fixes the color of the overflow icon in the toolbar of the home fragment which is visible when larger text/display sizes are used. It now matches the other icons and texts in the toolbar by using white as the icon color.

As there is no straightforward way to directly edit the color of the overflow icon, this seemed to be the easiest way to fix it.

Tested on Android 9 (LG G6) and Android 14 (Pixel 6a).

<details>

<summary>screenshots</summary>

| old | new |
| --- | --- |
| ![old](https://github.com/breezy-weather/breezy-weather/assets/97251923/17e8f734-5663-4a0b-8e97-e5553e669b31) | ![new](https://github.com/breezy-weather/breezy-weather/assets/97251923/e559d32d-65eb-4ff0-b7a2-cee3d563ab92) |

</details>