### PR TITLE
Fixed the statusbar color in the alert screen by updating screen UI (#883)

### DIFF
--- a/app/src/main/java/org/breezyweather/common/ui/activities/AlertActivity.kt
+++ b/app/src/main/java/org/breezyweather/common/ui/activities/AlertActivity.kt
@@ -19,6 +19,7 @@ package org.breezyweather.common.ui.activities
 import android.content.Context
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -65,7 +66,6 @@ import org.breezyweather.common.ui.widgets.getCardListItemMarginDp
 import org.breezyweather.common.ui.widgets.insets.FitStatusBarTopAppBar
 import org.breezyweather.common.ui.widgets.insets.bottomInsetItem
 import org.breezyweather.common.utils.ColorUtils
-import org.breezyweather.main.utils.MainThemeColorProvider
 import org.breezyweather.theme.compose.BreezyWeatherTheme
 import org.breezyweather.theme.compose.DayNightTheme
 import javax.inject.Inject
@@ -154,7 +154,7 @@ class AlertActivity : GeoActivity() {
 
         val scrollBehavior = generateCollapsedScrollBehavior()
 
-        BreezyWeatherTheme(lightTheme = MainThemeColorProvider.isLightTheme(context, location.value)) {
+        BreezyWeatherTheme(lightTheme = !isSystemInDarkTheme()) {
             Material3Scaffold(
                 modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
                 topBar = {

--- a/app/src/main/java/org/breezyweather/common/ui/activities/AlertActivity.kt
+++ b/app/src/main/java/org/breezyweather/common/ui/activities/AlertActivity.kt
@@ -19,7 +19,6 @@ package org.breezyweather.common.ui.activities
 import android.content.Context
 import android.os.Bundle
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -66,6 +65,9 @@ import org.breezyweather.common.ui.widgets.getCardListItemMarginDp
 import org.breezyweather.common.ui.widgets.insets.FitStatusBarTopAppBar
 import org.breezyweather.common.ui.widgets.insets.bottomInsetItem
 import org.breezyweather.common.utils.ColorUtils
+import org.breezyweather.domain.location.model.isDaylight
+import org.breezyweather.main.utils.MainThemeColorProvider
+import org.breezyweather.theme.ThemeManager
 import org.breezyweather.theme.compose.BreezyWeatherTheme
 import org.breezyweather.theme.compose.DayNightTheme
 import javax.inject.Inject
@@ -151,10 +153,23 @@ class AlertActivity : GeoActivity() {
                 }
             }
         }
-
         val scrollBehavior = generateCollapsedScrollBehavior()
 
-        BreezyWeatherTheme(lightTheme = !isSystemInDarkTheme()) {
+        val isLightTheme = MainThemeColorProvider.isLightTheme(context, location.value)
+        BreezyWeatherTheme(lightTheme = isLightTheme) {
+            //re-setting the status bar color once the location is fetched above in the launched effect
+            ThemeManager
+                .getInstance(this)
+                .weatherThemeDelegate
+                .setSystemBarStyle(
+                    context = this,
+                    window = this.window,
+                    statusShader = false,
+                    lightStatus = location.value?.isDaylight ?: isLightTheme,
+                    navigationShader = true,
+                    lightNavigation = false
+                )
+
             Material3Scaffold(
                 modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
                 topBar = {

--- a/app/src/main/java/org/breezyweather/common/ui/activities/AlertActivity.kt
+++ b/app/src/main/java/org/breezyweather/common/ui/activities/AlertActivity.kt
@@ -65,7 +65,6 @@ import org.breezyweather.common.ui.widgets.getCardListItemMarginDp
 import org.breezyweather.common.ui.widgets.insets.FitStatusBarTopAppBar
 import org.breezyweather.common.ui.widgets.insets.bottomInsetItem
 import org.breezyweather.common.utils.ColorUtils
-import org.breezyweather.domain.location.model.isDaylight
 import org.breezyweather.main.utils.MainThemeColorProvider
 import org.breezyweather.theme.ThemeManager
 import org.breezyweather.theme.compose.BreezyWeatherTheme
@@ -165,7 +164,7 @@ class AlertActivity : GeoActivity() {
                     context = this,
                     window = this.window,
                     statusShader = false,
-                    lightStatus = location.value?.isDaylight ?: isLightTheme,
+                    lightStatus = isLightTheme,
                     navigationShader = true,
                     lightNavigation = false
                 )

--- a/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/MaterialWeatherThemeDelegate.kt
+++ b/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/MaterialWeatherThemeDelegate.kt
@@ -135,10 +135,10 @@ class MaterialWeatherThemeDelegate : WeatherThemeDelegate {
         lightNavigation: Boolean
     ) {
         window.setSystemBarStyle(
-            statusShader,
-            lightNavigation,
-            navigationShader,
-            lightNavigation
+            statusShaderP = statusShader,
+            lightStatusP = lightStatus,
+            navigationShaderP = navigationShader,
+            lightNavigationP = lightNavigation
         )
     }
 


### PR DESCRIPTION
Hello, I would like to contribute to breezy weather and this is my first PR.

**Issue**
https://github.com/breezy-weather/breezy-weather/issues/883

**Analysis**
After some brainstorming and debugging, I have found that when the `AlertActivity` is launched the `LaunchedEffect` at line 123 is triggered in the `AlertActivity`. Which tries to fetch the location from the repository meanwhile the flow continues in parallel and the `BreezyWeatherTheme` is set at line 157 which sends the location null to `MainThemeColorProvider`. Now at this point the status bar color and the screen UI are correct. Next, the location is fetched in the `LaunchedEffect` and this time again `BreezyWeatherTheme` sets the theme with the location fetched, and that messes up the screen UI. 

**Fix**
IMHO, the alert screen UI should not depend on the location, as similar to the settings screen UI which does not depend on location. If we depend on the location then there will be more combinations for the alert screen UI which decides how to fit in daylight `boolean`. I added a fix to keep things simple.

So I added a change to rely on `isSystemInDarkTheme`

**Screenshots**
Please check the screenshots attached below:


Scenario | Settings | Home | Alerts
------------- | ------------- | ------------- | -------------
Setting with Day/Night mode on and light theme  |  <img src="https://github.com/breezy-weather/breezy-weather/assets/7792665/88456abb-be08-418c-9de2-bb9ba4c6ae96" width="200"> | <img src="https://github.com/breezy-weather/breezy-weather/assets/7792665/e70c5d47-4d55-4884-9153-60ef83c1e730" width="200"> | <img src="https://github.com/breezy-weather/breezy-weather/assets/7792665/b4ddf902-51e0-4c0a-b592-373732ca62a9" width="200">
Setting with Day/Night mode on and dark | <img src="https://github.com/breezy-weather/breezy-weather/assets/7792665/1db3f946-43c5-4ad3-aefd-c9ed82ff3bb7" width="200"> | <img src="https://github.com/breezy-weather/breezy-weather/assets/7792665/f70efb42-c7cd-495b-9376-6c4b1e5c8197" width="200"> | <img src="https://github.com/breezy-weather/breezy-weather/assets/7792665/15bc5f98-f187-45b4-bd0b-f0e416e4c7ea" width="200">


Tested with Android 14 emulator






