### PR TITLE
Bugfix-454 - Unreadable text in dark theme in about page updated

### DIFF
--- a/app/src/main/java/org/breezyweather/theme/compose/Theme.kt
+++ b/app/src/main/java/org/breezyweather/theme/compose/Theme.kt
@@ -74,7 +74,7 @@ class BreezyWeatherColors {
         val DarkContentText = LightText2nd
 
         val LightSubtitleText = GreyText2nd
-        val DarkSubtitleText = GreyText
+        val DarkSubtitleText = LightText2nd
     }
 }
 

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -5,7 +5,7 @@
 
     <color name="colorTextTitle">#ffffff</color>
     <color name="colorTextContent">#999999</color>
-    <color name="colorTextSubtitle">#4d4d4d</color>
+    <color name="colorTextSubtitle">@color/colorTextLight2nd</color>
 
     <color name="colorMainCardBackground">#1C1B1F</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -60,7 +60,7 @@
 
     <color name="colorTextTitle">#000000</color>
     <color name="colorTextContent">#666666</color>
-    <color name="colorTextSubtitle">@color/colorTextLight2nd</color>
+    <color name="colorTextSubtitle">#b2b2b2</color>
 
     <color name="colorMainCardBackground">#FDFCFF</color>
     <color name="colorPrecipitationProbability">@color/md_theme_primary</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -60,7 +60,7 @@
 
     <color name="colorTextTitle">#000000</color>
     <color name="colorTextContent">#666666</color>
-    <color name="colorTextSubtitle">#b2b2b2</color>
+    <color name="colorTextSubtitle">@color/colorTextLight2nd</color>
 
     <color name="colorMainCardBackground">#FDFCFF</color>
     <color name="colorPrecipitationProbability">@color/md_theme_primary</color>


### PR DESCRIPTION
**Issue**
https://github.com/breezy-weather/breezy-weather/issues/454

**Analysis**
I checked the light color section title text in the about us screen and found that it's because of the `captionColor ` we use in the `BreezyWeatherDayNightColors`. The `captionColor `  in this class is used by the alert screen to show a range of dates in the alert view and the section title in the About Us screen. These are only two places where the `captionColor ` is used so if we change it then we need to check these two places.

**Fix**
 I made the shade of grey lighter than before by reusing the color in `Theme.kt` and used `LightText2nd` instead of `GreyText`. Please check the before-after screenshots below:

**Screenshots**
Please check the screenshots attached below:


Screen | Alert | About Us
------------- | ------------- | -------------
Before | <img src="https://github.com/breezy-weather/breezy-weather/assets/7792665/54cd38b6-fdba-4a95-881a-6b1480f8a213" width="250"> | <img src="https://github.com/breezy-weather/breezy-weather/assets/7792665/9af49c88-036a-461d-89e1-f2aaa6c15d14" width="250">
After | <img src="https://github.com/breezy-weather/breezy-weather/assets/7792665/f07795bd-6191-4513-9772-2636d093a36d" width="250"> | <img src="https://github.com/breezy-weather/breezy-weather/assets/7792665/3cd468da-1230-4f97-853f-56a4b36c2dfc" width="250">


Tested with Android 14 emulator






