### PR TITLE
fix: refresh lag (coroutine is better launched in io dispatcher)

### DIFF
--- a/app/src/main/java/org/breezyweather/main/MainActivityViewModel.kt
+++ b/app/src/main/java/org/breezyweather/main/MainActivityViewModel.kt
@@ -295,7 +295,7 @@ class MainActivityViewModel @Inject constructor(
             updating = true
             SettingsManager.getInstance(getApplication()).weatherManualUpdateLastTimestamp = Date().time
             SettingsManager.getInstance(getApplication()).weatherManualUpdateLastLocationId = locationToCheck.formattedId
-            viewModelScope.launch {
+            viewModelScope.launchIO {
                 getWeather(
                     getApplication(),
                     locationToCheck,
@@ -317,7 +317,7 @@ class MainActivityViewModel @Inject constructor(
             updating = true
             SettingsManager.getInstance(getApplication()).weatherManualUpdateLastTimestamp = Date().time
             SettingsManager.getInstance(getApplication()).weatherManualUpdateLastLocationId = locationToCheck.formattedId
-            viewModelScope.launch {
+            viewModelScope.launchIO {
                 getWeather(
                     getApplication(),
                     locationToCheck,


### PR DESCRIPTION
test in xiaomi11 and iqoo neo7, found lagging in refresh. reason is take too much time in RefreshHelper#getLocation (avg in 166ms, max 592ms)