### PR TITLE
Fix silent forecast notifications

### DIFF
--- a/app/src/main/java/org/breezyweather/background/forecast/ForecastNotificationNotifier.kt
+++ b/app/src/main/java/org/breezyweather/background/forecast/ForecastNotificationNotifier.kt
@@ -51,20 +51,13 @@ class ForecastNotificationNotifier(private val context: Context) {
         setAutoCancel(false)
     }
 
-    private fun NotificationCompat.Builder.show(id: Int) {
-        context.notify(id, build())
-    }
-
-    fun showProgress(today: Boolean): NotificationCompat.Builder {
-        val builder = with(progressNotificationBuilder) {
-            setContentTitle(context.getString(R.string.notification_running_in_background))
-
-            setProgress(0, 0, true)
-        }
-
-        builder.show(if (today) Notifications.ID_UPDATING_TODAY_FORECAST else Notifications.ID_UPDATING_TOMORROW_FORECAST)
-
-        return builder
+    fun showProgress(): Notification {
+        return progressNotificationBuilder
+            // prevent Android from muting notifications ('muting recently noisy')
+            // and only play a sound for the actual forecast notification
+            .setSilent(true)
+            .setContentTitle(context.getString(R.string.notification_running_in_background))
+            .build()
     }
 
     fun showComplete(location: Location, today: Boolean) {

--- a/app/src/main/java/org/breezyweather/background/forecast/TodayForecastNotificationJob.kt
+++ b/app/src/main/java/org/breezyweather/background/forecast/TodayForecastNotificationJob.kt
@@ -83,7 +83,7 @@ class TodayForecastNotificationJob @AssistedInject constructor(
     override suspend fun getForegroundInfo(): ForegroundInfo {
         return ForegroundInfo(
             Notifications.ID_UPDATING_TODAY_FORECAST,
-            notifier.showProgress(today = true).build(),
+            notifier.showProgress(),
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
             } else {

--- a/app/src/main/java/org/breezyweather/background/forecast/TomorrowForecastNotificationJob.kt
+++ b/app/src/main/java/org/breezyweather/background/forecast/TomorrowForecastNotificationJob.kt
@@ -83,7 +83,7 @@ class TomorrowForecastNotificationJob @AssistedInject constructor(
     override suspend fun getForegroundInfo(): ForegroundInfo {
         return ForegroundInfo(
             Notifications.ID_UPDATING_TOMORROW_FORECAST,
-            notifier.showProgress(today = false).build(),
+            notifier.showProgress(),
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                 ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
             } else {


### PR DESCRIPTION
This fixes #880.

As mentioned [here](https://github.com/breezy-weather/breezy-weather/issues/880#issuecomment-2043321548), the progress notification was triggered before trying to start the foreground service due to the `notify` [call](https://github.com/breezy-weather/breezy-weather/blob/031ffd2a26c2073d7e91e296c1fcd89bf64a0ced/app/src/main/java/org/breezyweather/background/forecast/ForecastNotificationNotifier.kt#L65) in the `showProgress` function. This and the way the notification was built seems to have caused Android to mute the forecast notifications on Android version 9 and higher.

With this PR the progress notification is only created when Android allows start the foreground service. The progress notification is set silent and only the actual forecast notification plays a sound.

It also removes the progress bar from the progress notification as it is only displayed for a very short amount of time. On Android 12 and higher it will not be displayed at all under normal circumstances as the service is running for less than 10 seconds.

**Tests**
_with sounds turned on_
| Android version | device | 5.2.3 | PR |
| --- | --- | --- | --- |
| 5 | emulator | plays sound | plays sound |
| 6 | emulator | plays sound | plays sound |
| 8 | emulator | plays sound <sup>1</sup> | plays sound |
| 9 | device | muted | plays sound |
| 10-13 | emulator | muted | plays sound |
| 14 | device | muted | plays sound <sup>2</sup> |

<sup>1</sup> Plays a sound for both the progress and the actual forecast notification. Not sure if this is just a sound bug in the emulator.
<sup>2</sup> Tested with battery optimization being enabled and disabled to verify that the notificiation sounds work properly with and without allowing to start the foreground service.

**Note for users**
Forecast notifications on Android version 9 and higher will now play a sound/vibrate (depending on sound settings) with default settings for the forecast notification channel. You can still permanently mute those notifications by manually setting the notification channel to "silent".