### PR TITLE
Fix activation of notification widget in settings

### DIFF
--- a/app/src/main/java/org/breezyweather/settings/activities/SettingsActivity.kt
+++ b/app/src/main/java/org/breezyweather/settings/activities/SettingsActivity.kt
@@ -261,19 +261,17 @@ class SettingsActivity : GeoActivity() {
                         todayForecastEnabled = remember { todayForecastEnabledState }.value,
                         tomorrowForecastEnabled = remember { tomorrowForecastEnabledState }.value,
                         postNotificationPermissionEnsurer = { succeedCallback ->
-                            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-                                succeedCallback()
-                                return@NotificationsSettingsScreen
-                            }
-                            if (this@SettingsActivity.hasPermission(Manifest.permission.POST_NOTIFICATIONS)) {
-                                return@NotificationsSettingsScreen
-                            }
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                                !this@SettingsActivity.hasPermission(Manifest.permission.POST_NOTIFICATIONS)) {
 
-                            requestPostNotificationPermissionSucceedCallback = succeedCallback
-                            requestPermissions(
-                                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
-                                PERMISSION_CODE_POST_NOTIFICATION
-                            )
+                                requestPostNotificationPermissionSucceedCallback = succeedCallback
+                                requestPermissions(
+                                    arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                                    PERMISSION_CODE_POST_NOTIFICATION
+                                )
+                            } else {
+                                succeedCallback()
+                            }
                         }
                     )
                 }
@@ -284,19 +282,17 @@ class SettingsActivity : GeoActivity() {
                         notificationTemperatureIconEnabled = remember { notificationTemperatureIconEnabledState }.value,
                         paddingValues = paddings,
                         postNotificationPermissionEnsurer = { succeedCallback ->
-                            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-                                succeedCallback()
-                                return@WidgetsSettingsScreen
-                            }
-                            if (this@SettingsActivity.hasPermission(Manifest.permission.POST_NOTIFICATIONS)) {
-                                return@WidgetsSettingsScreen
-                            }
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                                !this@SettingsActivity.hasPermission(Manifest.permission.POST_NOTIFICATIONS)) {
 
-                            requestPostNotificationPermissionSucceedCallback = succeedCallback
-                            requestPermissions(
-                                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
-                                PERMISSION_CODE_POST_NOTIFICATION
-                            )
+                                requestPostNotificationPermissionSucceedCallback = succeedCallback
+                                requestPermissions(
+                                    arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                                    PERMISSION_CODE_POST_NOTIFICATION
+                                )
+                            } else {
+                                succeedCallback()
+                            }
                         },
                         updateWidgetIfNecessary = { context: Context ->
                             scope.launch {


### PR DESCRIPTION
This fixes an issue where the notification widget would not immediately appear after enabling it on Android 13 and above (related to #1049).

`succeedCallback` which eventually calls `notify` for the notification widget was [missing](https://github.com/breezy-weather/breezy-weather/blob/df01dccf838d643da48e781255842f142988936a/app/src/main/java/org/breezyweather/settings/activities/SettingsActivity.kt#L292) on Android 13 and above when notifications had already been permitted.

Tested on devices with Android 9 and 14 with and without allowing notifications in advance. Additionally tested on an emulator with Android 6 and 13.