### PR TITLE
Replace deprecated onBackPressed method

### DIFF
--- a/app/src/main/java/org/breezyweather/search/SearchActivity.kt
+++ b/app/src/main/java/org/breezyweather/search/SearchActivity.kt
@@ -18,6 +18,8 @@ package org.breezyweather.search
 
 import android.content.Intent
 import android.os.Bundle
+import android.window.OnBackInvokedDispatcher
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -90,6 +92,8 @@ class SearchActivity : GeoActivity() {
                 ContentView()
             }
         }
+
+        onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
     }
 
     @Composable
@@ -289,9 +293,10 @@ class SearchActivity : GeoActivity() {
         }
     }
 
-    @Deprecated("Deprecated in Java")
-    override fun onBackPressed() {
-        finishSelf(null)
+    private val onBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            finishSelf(null)
+        }
     }
 
     // init.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -359,7 +359,6 @@
     <!-- Free as in “libre -->
     <string name="message_source_not_installed_error_content_tip_1">This can happen when you added your location in the Standard flavor of Breezy Weather and then switched to the flavor with only free network sources. Going back to the Standard flavor may solve this problem.</string>
     <string name="message_source_not_installed_error_content_tip_2">Either change the weather sources for this location or delete and re-add this location.</string>
-    <!-- Update refers to weather update -->
     <string name="message_tap_again_to_exit">Tap again to exit</string>
     <!-- Widgets -->
     <string name="widget_day">Daily</string>


### PR DESCRIPTION
This replaces all occurrences of `onBackPressed` which is deprecated with `onBackPressedCallback`.

As a result, this also fixes an issue on Android >= 13 where a single back press in the widget config would always exit the config while it should either close the bottom sheet if extended or ask for a second back press to exit.

I also adjusted the time in which a second back press would exit the activity to match the time while the [snackbar](https://github.com/breezy-weather/breezy-weather/compare/main...min7-i:onbackpressed?expand=1#diff-1d22ac2f5e7195483806eb1fe8cc503e10adc89882a4fb47c26a0ccaf7709fb2R210) is visible.

Additionally, this removes a comment in strings currently associated with `message_tap_again_to_exit` which was originally related to a [string that was removed a while ago](https://github.com/breezy-weather/breezy-weather/commit/91eedf1e55411a95617edb186e9b1e1eee2f79e9#diff-5e01f7d37a66e4ca03deefc205d8e7008661cdd0284a05aaba1858e6b7bf9103L326-L327).

Tested on devices with Android 9 and 14.