### PR TITLE
Fix theme issues in AlertActivity and PollenActivity

### DIFF
--- a/app/src/main/java/org/breezyweather/common/ui/activities/AlertActivity.kt
+++ b/app/src/main/java/org/breezyweather/common/ui/activities/AlertActivity.kt
@@ -134,32 +134,34 @@ class AlertActivity : GeoActivity() {
                 return@LaunchedEffect
             }
 
-            // Astro data is needed to check if the sun is still up or if it has set when day/night
-            // mode per location is enabled.
-            location.value = locationC.copy(
-                weather = weatherRepository.getWeatherByLocationId(
-                    locationC.formattedId,
-                    withDaily = true,
-                    withHourly = false,
-                    withMinutely = false,
-                    withAlerts = false
-                )
+            // Daily weather data is needed to check if the sun is still up or if it has set when
+            // day/night mode per location is enabled.
+            val weather = weatherRepository.getWeatherByLocationId(
+                locationC.formattedId,
+                withDaily = true,
+                withHourly = false,
+                withMinutely = false,
+                withAlerts = true
             )
 
-            val alerts = weatherRepository.getAlertListByLocationId(locationC.formattedId)
-            alertList.value = alerts
+            location.value = locationC.copy(weather = weather)
 
-            if (alerts.isNotEmpty()) {
-                val alertId = intent.getStringExtra(KEY_ALERT_ID)
-                if (!alertId.isNullOrEmpty()) {
-                    val alertIndex = alerts.indexOfFirst { it.alertId == alertId }
-                    if (alertIndex != -1) {
-                        listState.scrollToItem(alertIndex)
+            if (weather != null) {
+                val alerts = weather.alertList
+                alertList.value = alerts
+
+                if (alerts.isNotEmpty()) {
+                    val alertId = intent.getStringExtra(KEY_ALERT_ID)
+                    if (!alertId.isNullOrEmpty()) {
+                        val alertIndex = alerts.indexOfFirst { it.alertId == alertId }
+                        if (alertIndex != -1) {
+                            listState.scrollToItem(alertIndex)
+                        } else {
+                            listState.scrollToItem(0)
+                        }
                     } else {
                         listState.scrollToItem(0)
                     }
-                } else {
-                    listState.scrollToItem(0)
                 }
             }
         }

--- a/app/src/main/java/org/breezyweather/common/ui/activities/AlertActivity.kt
+++ b/app/src/main/java/org/breezyweather/common/ui/activities/AlertActivity.kt
@@ -133,7 +133,18 @@ class AlertActivity : GeoActivity() {
                 finish()
                 return@LaunchedEffect
             }
-            location.value = locationC
+
+            // Astro data is needed to check if the sun is still up or if it has set when day/night
+            // mode per location is enabled.
+            location.value = locationC.copy(
+                weather = weatherRepository.getWeatherByLocationId(
+                    locationC.formattedId,
+                    withDaily = true,
+                    withHourly = false,
+                    withMinutely = false,
+                    withAlerts = false
+                )
+            )
 
             val alerts = weatherRepository.getAlertListByLocationId(locationC.formattedId)
             alertList.value = alerts
@@ -152,6 +163,7 @@ class AlertActivity : GeoActivity() {
                 }
             }
         }
+
         val scrollBehavior = generateCollapsedScrollBehavior()
 
         val isLightTheme = MainThemeColorProvider.isLightTheme(context, location.value)

--- a/app/src/main/java/org/breezyweather/common/ui/activities/PollenActivity.kt
+++ b/app/src/main/java/org/breezyweather/common/ui/activities/PollenActivity.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -56,6 +57,7 @@ import org.breezyweather.common.ui.widgets.insets.bottomInsetItem
 import org.breezyweather.domain.weather.model.isIndexValid
 import org.breezyweather.main.utils.MainThemeColorProvider
 import org.breezyweather.sources.SourceManager
+import org.breezyweather.theme.ThemeManager
 import org.breezyweather.theme.compose.BreezyWeatherTheme
 import org.breezyweather.theme.compose.DayNightTheme
 import javax.inject.Inject
@@ -85,6 +87,7 @@ class PollenActivity : GeoActivity() {
     private fun ContentView() {
         val formattedId = intent.getStringExtra(KEY_POLLEN_ACTIVITY_LOCATION_FORMATTED_ID)
         val location = remember { mutableStateOf<Location?>(null) }
+        val context = LocalContext.current
 
         LaunchedEffect(formattedId) {
             var locationC: Location? = null
@@ -116,7 +119,21 @@ class PollenActivity : GeoActivity() {
 
         val scrollBehavior = generateCollapsedScrollBehavior()
 
-        BreezyWeatherTheme(lightTheme = MainThemeColorProvider.isLightTheme(this, location.value)) {
+        val isLightTheme = MainThemeColorProvider.isLightTheme(context, location.value)
+        BreezyWeatherTheme(lightTheme = isLightTheme) {
+            // re-setting the status bar color once the location is fetched above in the launched effect
+            ThemeManager
+                .getInstance(this)
+                .weatherThemeDelegate
+                .setSystemBarStyle(
+                    context = this,
+                    window = this.window,
+                    statusShader = false,
+                    lightStatus = isLightTheme,
+                    navigationShader = true,
+                    lightNavigation = false
+                )
+
             Material3Scaffold(
                 modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
                 topBar = {


### PR DESCRIPTION
This fixes #1138 by retrieving the weather data for the location to calculate the correct "[rise progress](https://github.com/breezy-weather/breezy-weather/blob/d59725585c518ca48e079ead6b6ac3bb29b36183/app/src/main/java/org/breezyweather/domain/weather/model/Astro.kt#L18)" of the sun. Previously it used defaults (sunrise at 6 am, sunset at 6 pm) as a fallback which caused the issue described in #1138.

The PR also fixes an issue with the color of the status bar in the PollenActivity when the location-based day/night mode is enabled. It now uses the same approach as PR #1022.

Tested on devices with Android 9 and 14.

<details>

<summary>screenshots</summary>

Tested with locations where the sun was still up. Location-based day/night mode was enabled and the dark theme was used in the app.

| location | old | new |
| --- | --- | --- |
| Beijing | ![alert_1](https://github.com/breezy-weather/breezy-weather/assets/97251923/1ab811a1-80fc-4b14-998a-ff992927d000) | ![alert_2](https://github.com/breezy-weather/breezy-weather/assets/97251923/82d263b7-4415-4fe1-8816-6bf4c44ab17b) |
| Hamburg | ![pollen_1](https://github.com/breezy-weather/breezy-weather/assets/97251923/665238a1-39ce-4635-9cc0-b79b178656ca) | ![pollen_2](https://github.com/breezy-weather/breezy-weather/assets/97251923/98e6481a-0f7d-47bb-98da-cac67a6c31e3) |

</details>