### PR TITLE
Fix theme of "per location settings"-dialog

### DIFF
--- a/app/src/main/java/org/breezyweather/main/MainActivity.kt
+++ b/app/src/main/java/org/breezyweather/main/MainActivity.kt
@@ -371,20 +371,24 @@ class MainActivity : GeoActivity(),
             }
         }
 
-        binding.perLocationSettings?.setContent {
-            BreezyWeatherTheme(lightTheme = MainThemeColorProvider.isLightTheme(this, isDaylight)) {
-                ComposeView()
+        binding.perLocationSettings.setContent {
+            val validLocation = viewModel.currentLocation.collectAsState()
+
+            BreezyWeatherTheme(
+                lightTheme = MainThemeColorProvider.isLightTheme(this, validLocation.value?.daylight)
+            ) {
+                PerLocationSettingsDialog(location = validLocation.value?.location)
             }
         }
     }
 
-
     @Composable
-    fun ComposeView() {
+    fun PerLocationSettingsDialog(
+        location: Location?
+    ) {
         val dialogPerLocationSettingsOpenState = dialogPerLocationSettingsOpen.collectAsState()
         if (dialogPerLocationSettingsOpenState.value) {
-            val validLocation = viewModel.currentLocation.collectAsState()
-            validLocation.value?.location?.let { location ->
+            location?.let {
                 val dialogDeleteLocationOpenState = remember { mutableStateOf(false) }
                 AlertDialogNoPadding(
                     onDismissRequest = {
@@ -398,7 +402,7 @@ class MainActivity : GeoActivity(),
                         )
                     },
                     text = {
-                        LocationPreference(this, location) { newLocation: Location? ->
+                        LocationPreference(this, it) { newLocation: Location? ->
                             if (newLocation != null) {
                                 updateLocation(newLocation)
                             }
@@ -449,10 +453,10 @@ class MainActivity : GeoActivity(),
                         },
                         text = {
                             Text(
-                                text = if (location.city.isNotEmpty()) {
+                                text = if (it.city.isNotEmpty()) {
                                     stringResource(
                                         R.string.location_delete_location_dialog_message,
-                                        location.city
+                                        it.city
                                     )
                                 } else {
                                     stringResource(R.string.location_delete_location_dialog_message_no_name)
@@ -466,7 +470,7 @@ class MainActivity : GeoActivity(),
                                 onClick = {
                                     dialogDeleteLocationOpenState.value = false
                                     _dialogPerLocationSettingsOpen.value = false
-                                    deleteLocation(location)
+                                    deleteLocation(it)
                                 }
                             ) {
                                 Text(


### PR DESCRIPTION
This fixes #1107.

Previously `isDaylight` was passed in `BreezyWeatherTheme` to determine the theme. However, when switching to a different location it wasn't updated. Hence, the dialog's theme always matched the one of the primary location.

The fix uses the [currentLocation](https://github.com/breezy-weather/breezy-weather/compare/main...min7-i:breezy-weather:theme-per-location-settings-dialog?expand=1#diff-fd5e4eb4a8e0de6715a31984780cd0338f00ec5bb6ff3f4028b74415327736e9R375) instead which is already collected as a state and therefore updated whenever the location is switched. I just moved this up in the hierarchy to use it as input for the `BreezyWeatherTheme`.

Tested on devices with Android 9 and 14.