### PR TITLE
added Servizio Meteo AM as a new source

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ alt="Get it on F-Droid" align="center" height="80" /></a>
   - HERE (no API key provided)
   - Météo France
   - Danmarks Meteorologiske Institut (DMI)
+  - Servizio Meteorologico dell’Aeronautica Militare (Meteo AM)
   - Mixed China sources
   - National Weather Service (NWS)
   - Bright Sky (DWD)

--- a/app/src/main/java/org/breezyweather/common/source/LocationPreset.kt
+++ b/app/src/main/java/org/breezyweather/common/source/LocationPreset.kt
@@ -55,6 +55,7 @@ enum class LocationPreset(
     FRANCE("mf", airQuality = "openmeteo", pollen = "recosante"),
     FRANCE_FREENET("openmeteo", pollen = "recosante"),
     IRELAND("metie", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo", normals = "accu"),
+    ITALY("meteoam", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo", normals = "accu"),
     NORWAY("metno", pollen = "openmeteo", alert = "accu", normals = "accu"),
     SWEDEN("smhi", airQuality = "openmeteo", pollen = "openmeteo", minutely = "metno", alert = "accu", normals = "accu"),
 
@@ -80,6 +81,7 @@ enum class LocationPreset(
                     "FI" -> FINLAND
                     "FR" -> FRANCE
                     "IE" -> IRELAND
+                    "IT", "SM", "VA" -> ITALY
                     "NO" -> NORWAY
                     "SE" -> SWEDEN
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -860,6 +860,17 @@
     <string name="metno_weather_text_sleetshowers" translatable="false">@string/common_weather_text_rain_snow_mixed_showers</string>
     <string name="metno_weather_text_snow" translatable="false">@string/common_weather_text_snow</string>
     <string name="metno_weather_text_snowshowers" translatable="false">@string/common_weather_text_snow_showers</string>
+    <!-- Weather texts for Meteo AM -->
+    <string name="meteoam_weather_text_clear_sky" translatable="false">@string/common_weather_text_clear_sky</string>
+    <string name="meteoam_weather_text_partly_cloudy" translate="false">@string/common_weather_text_partly_cloudy</string>
+    <string name="meteoam_weather_text_cloudy" translate="false">@string/common_weather_text_cloudy</string>
+    <string name="meteoam_weather_text_overcast" translatable="false">@string/common_weather_text_overcast</string>
+    <string name="meteoam_weather_text_rain_light" translatable="false">@string/common_weather_text_rain_light</string>
+    <string name="meteoam_weather_text_rain_heavy" translatable="false">@string/common_weather_text_rain_heavy</string>
+    <string name="meteoam_weather_text_rain_snow_mixed" translatable="false">@string/common_weather_text_rain_snow_mixed</string>
+    <string name="meteoam_weather_text_rain_freezing" translatable="false">@string/common_weather_text_rain_freezing</string>
+    <string name="meteoam_weather_text_fog" translatable="false">@string/common_weather_text_fog</string>
+    <string name="meteoam_weather_text_snow" translatable="false">@string/common_weather_text_snow</string>
     <!-- Example: Heavy rain and thunder -->
     <string name="metno_weather_text_andthunder">%s and thunder</string>
     <!-- Do NOT translate everything below -->

--- a/app/src/src_nonfreenet/org/breezyweather/sources/SourceManager.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/SourceManager.kt
@@ -47,6 +47,7 @@ import org.breezyweather.sources.geosphereat.GeoSphereAtService
 import org.breezyweather.sources.here.HereService
 import org.breezyweather.sources.ims.ImsService
 import org.breezyweather.sources.ipsb.IpSbLocationService
+import org.breezyweather.sources.meteoam.MeteoAmService
 import org.breezyweather.sources.metie.MetIeService
 import org.breezyweather.sources.metno.MetNoService
 import org.breezyweather.sources.mf.MfService
@@ -76,6 +77,7 @@ class SourceManager @Inject constructor(
     hereService: HereService,
     imsService: ImsService,
     ipSbService: IpSbLocationService,
+    meteoAmService: MeteoAmService,
     metIeService: MetIeService,
     metNoService: MetNoService,
     mfService: MfService,
@@ -113,6 +115,7 @@ class SourceManager @Inject constructor(
         // National sources supporting worldwide
         mfService,
         dmiService,
+        meteoAmService,
 
         // National-only sources (sorted by population)
         chinaService,

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/MeteoAmApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/MeteoAmApi.kt
@@ -1,0 +1,44 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteoam
+
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.sources.meteoam.json.MeteoAmForecastResult
+import org.breezyweather.sources.meteoam.json.MeteoAmObservationResult
+import org.breezyweather.sources.meteoam.json.MeteoAmReverseLocationResult
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface MeteoAmApi {
+    @GET("deda-meteograms/api/GetMeteogram/preset1/{lat},{lon}")
+    fun getForecast(
+        @Path("lat") lat: Double,
+        @Path("lon") lon: Double
+    ): Observable<MeteoAmForecastResult>
+
+    @GET("deda-ows/api/GetStationRadius/{lat}/{lon}")
+    fun getCurrent(
+        @Path("lat") lat: Double,
+        @Path("lon") lon: Double
+    ): Observable<MeteoAmObservationResult>
+
+    @GET("geocoder/r/{lon}/{lat}")
+    fun getReverseLocation(
+        @Path("lat") lat: Double,
+        @Path("lon") lon: Double
+    ): Observable<MeteoAmReverseLocationResult>
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/MeteoAmResultConverter.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/MeteoAmResultConverter.kt
@@ -1,0 +1,233 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteoam
+
+import android.content.Context
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.weather.model.Current
+import breezyweather.domain.weather.model.Daily
+import breezyweather.domain.weather.model.HalfDay
+import breezyweather.domain.weather.model.PrecipitationProbability
+import breezyweather.domain.weather.model.Temperature
+import breezyweather.domain.weather.model.WeatherCode
+import breezyweather.domain.weather.model.Wind
+import breezyweather.domain.weather.wrappers.HourlyWrapper
+import breezyweather.domain.weather.wrappers.WeatherWrapper
+import org.breezyweather.R
+import org.breezyweather.common.exceptions.InvalidOrIncompleteDataException
+import org.breezyweather.sources.meteoam.json.MeteoAmForecastResult
+import org.breezyweather.sources.meteoam.json.MeteoAmForecastStats
+import org.breezyweather.sources.meteoam.json.MeteoAmObservationResult
+import org.breezyweather.sources.meteoam.json.MeteoAmReverseLocation
+import java.util.Date
+
+fun convert(
+    location: Location,
+    reverseLocation: MeteoAmReverseLocation,
+    timezone: String
+): Location {
+    return location.copy(
+        timeZone = timezone,
+        country = reverseLocation.country,
+        countryCode = reverseLocation.country_code,
+        province = reverseLocation.county,
+        city = reverseLocation.city
+    )
+}
+
+fun convert(
+    context: Context,
+    forecastResult: MeteoAmForecastResult,
+    observationResult: MeteoAmObservationResult
+): WeatherWrapper {
+    val timeseries = forecastResult.timeseries
+    val params = forecastResult.paramlist
+    val stats = forecastResult.extrainfo?.stats
+    val data = forecastResult.datasets?.data
+    val oParams = observationResult.paramlist
+    val observation = observationResult.datasets?.getOrElse("0") { null }
+
+    if (timeseries == null || params == null || stats == null || data == null || oParams == null) {
+        throw InvalidOrIncompleteDataException()
+    }
+
+    return WeatherWrapper(
+        current = if (observation != null) getCurrent(context, oParams, observation) else null,
+        dailyForecast = getDailyForecast(context, stats),
+        hourlyForecast = getHourlyForecast(context, timeseries, params, data)
+    )
+}
+
+private fun getCurrent(
+    context: Context,
+    params: List<String>,
+    currentResult: Map<String, Map<String, Any?>>
+): Current {
+    val keys = mutableMapOf<String, String>()
+    for (i in params.indices) {
+        keys[params[i]] = i.toString()
+    }
+    val icon = currentResult.getOrElse(keys["icon"].toString()) { null }?.getOrElse("0") { null }.toString()
+    val temp = currentResult.getOrElse(keys["2t"].toString()) { null }?.getOrElse("0") { null } as Double?
+    val wdir = when (currentResult.getOrElse(keys["wdir"].toString()) { null }?.getOrElse("0") { null }) {
+        is Double -> currentResult.getOrElse(keys["wdir"].toString()) { null }?.get("0") as Double
+        "VRB" -> -1.0
+        else -> null // sometimes returned as "-"
+    }
+    val wspd = when (currentResult.getOrElse(keys["wkmh"].toString()) { null }?.getOrElse("0") { null }) {
+        is Double -> currentResult.getOrElse(keys["wkmh"].toString()) { null }?.get("0") as Double / 3.6
+        else -> null // sometimes returned as "-"
+    }
+    val rhum = currentResult.getOrElse(keys["r"].toString()) { null }?.getOrElse("0") { null } as Double?
+    val pres = currentResult.getOrElse(keys["pmsl"].toString()) { null }?.getOrElse("0") { null } as Double?
+
+    return Current(
+        weatherText = getWeatherText(context, icon),
+        weatherCode = getWeatherCode(icon),
+        temperature = Temperature(
+            temperature = temp
+        ),
+        wind = Wind(
+            degree = wdir,
+            speed = wspd
+        ),
+        relativeHumidity = rhum,
+        pressure = pres
+    )
+}
+
+private fun getDailyForecast(
+    context: Context,
+    dailyResult: List<MeteoAmForecastStats>
+): List<Daily> {
+    val dailyForecast = mutableListOf<Daily>()
+    dailyResult.forEach {
+        if (it.icon != "-") {
+            dailyForecast.add(
+                Daily(
+                    date = it.localDate,
+                    day = HalfDay(
+                        weatherText = getWeatherText(context, it.icon),
+                        weatherCode = getWeatherCode(it.icon)
+                    ),
+                    night = HalfDay(
+                        weatherText = getWeatherText(context, it.icon),
+                        weatherCode = getWeatherCode(it.icon)
+                    )
+                )
+            )
+        }
+    }
+    return dailyForecast
+}
+
+private fun getHourlyForecast(
+    context: Context,
+    timeseries: List<Date>,
+    params: List<String>,
+    data: Map<String, Map<String, Any?>>
+): List<HourlyWrapper> {
+    val hourlyForecast = mutableListOf<HourlyWrapper>()
+    val keys = mutableMapOf<String, String>()
+    var icon: String
+    var temp: Double?
+    var tpop: Double?
+    var wdir: Double?
+    var wspd: Double?
+    var rhum: Double?
+    var pres: Double?
+    for (i in params.indices) {
+        keys[params[i]] = i.toString()
+    }
+    for (i in timeseries.indices) {
+        icon = data.getOrElse(keys["icon"].toString()) { null }?.getOrElse(i.toString()) { null }.toString()
+        temp = data.getOrElse(keys["2t"].toString()) { null }?.getOrElse(i.toString()) { null } as Double?
+        tpop = data.getOrElse(keys["tpp"].toString()) { null }?.getOrElse(i.toString()) { null } as Double?
+        wdir = data.getOrElse(keys["wdir"].toString()) { null }?.getOrElse(i.toString()) { null } as Double?
+        wspd = (data.getOrElse(keys["wkmh"].toString()) { null }?.getOrElse(i.toString()) { null } as Double?)?.div(3.6)
+        rhum = data.getOrElse(keys["r"].toString()) { null }?.getOrElse(i.toString()) { null } as Double?
+        pres = data.getOrElse(keys["pmsl"].toString()) { null }?.getOrElse(i.toString()) { null } as Double?
+
+        hourlyForecast.add(
+            HourlyWrapper(
+                date = timeseries[i],
+                weatherText = getWeatherText(context, icon),
+                weatherCode = getWeatherCode(icon),
+                temperature = Temperature(
+                    temperature = temp
+                ),
+                precipitationProbability = PrecipitationProbability(
+                    total = tpop
+                ),
+                wind = Wind(
+                    degree = wdir,
+                    speed = wspd
+                ),
+                relativeHumidity = rhum,
+                pressure = pres
+            )
+        )
+    }
+    return hourlyForecast
+}
+
+// Icon definitions can be found at https://www.meteoam.it/it/legenda-simboli
+// Icon sources can be found at https://www-static.meteoam.it/maps/img/icon_web_v4/{icon}.svg
+// Icons 06 and 07 are duplicates
+private fun getWeatherCode(icon: String?): WeatherCode? {
+    return when (icon) {
+        "01", "31" -> WeatherCode.CLEAR
+        "02", "03", "04", "32", "33", "34" -> WeatherCode.PARTLY_CLOUDY
+        "05", "06", "07", "35" -> WeatherCode.CLOUDY
+        "08", "09" -> WeatherCode.RAIN
+        "10" -> WeatherCode.THUNDERSTORM
+        "11", "12" -> WeatherCode.SLEET
+        "13", "18", "36" -> WeatherCode.HAZE
+        "14" -> WeatherCode.FOG
+        "15" -> WeatherCode.HAIL
+        "16" -> WeatherCode.SNOW
+        "17", "19" -> WeatherCode.WIND
+        else -> null
+    }
+}
+
+// Icon definitions can be found at https://www.meteoam.it/it/legenda-simboli
+// Icon sources can be found at https://www-static.meteoam.it/maps/img/icon_web_v4/{icon}.svg
+// Icons 06 and 07 are duplicates
+private fun getWeatherText(context: Context, icon: String?): String? {
+    return when (icon) {
+        "01", "31" -> context.getString(R.string.meteoam_weather_text_clear_sky)     // "Sereno"
+        "02", "32" -> "Parzialmente velato"                                          // (either this or the line below could be "mostly clear")
+        "03", "33" -> "Velato"                                                       // (either this or the line above could be "mostly clear")
+        "04", "34" -> context.getString(R.string.meteoam_weather_text_partly_cloudy) // "Poco nuvoloso"
+        "05", "35" -> context.getString(R.string.meteoam_weather_text_cloudy)        // "Molto nuvoloso"
+        "06", "07" -> context.getString(R.string.meteoam_weather_text_overcast)      // "Coperto"
+        "08" -> context.getString(R.string.meteoam_weather_text_rain_light)          // "Pioggia debole"
+        "09" -> context.getString(R.string.meteoam_weather_text_rain_heavy)          // "Pioggia forte"
+        "10" -> "Temporale"                                                          // (thunderstorm: use weather_kind_thunderstorm?)
+        "11" -> context.getString(R.string.meteoam_weather_text_rain_snow_mixed)     // "Pioggia mista a neve"
+        "12" -> context.getString(R.string.meteoam_weather_text_rain_freezing)       // "Pioggia che gela"
+        "13", "36" -> "Foschia"                                                      // (haze: use weather_kind_haze?)
+        "14" -> context.getString(R.string.meteoam_weather_text_fog)                 // "Nebbia"
+        "15" -> "Grandine"                                                           // (hail: use weather_kind_hail?)
+        "16" -> context.getString(R.string.meteoam_weather_text_snow)                // "Neve"
+        "17" -> "Tromba d’aria o marina"                                             // (tornado or waterspout)
+        "18" -> "Fumo"                                                               // (smoke)
+        "19" -> "Tempesta di sabbia"                                                 // (sand storm)
+        else -> null
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/MeteoAmService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/MeteoAmService.kt
@@ -1,0 +1,100 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteoam
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Color
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.weather.wrappers.WeatherWrapper
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.reactivex.rxjava3.core.Observable
+import javax.inject.Inject
+import org.breezyweather.common.source.HttpSource
+import org.breezyweather.common.source.MainWeatherSource
+import org.breezyweather.common.source.ReverseGeocodingSource
+import org.breezyweather.common.source.SecondaryWeatherSourceFeature
+import org.breezyweather.sources.meteoam.json.MeteoAmForecastResult
+import org.breezyweather.sources.meteoam.json.MeteoAmObservationResult
+import org.breezyweather.sources.meteoam.json.MeteoAmReverseLocationResult
+import retrofit2.Retrofit
+
+class MeteoAmService @Inject constructor(
+    @ApplicationContext context: Context,
+    client: Retrofit.Builder
+) : HttpSource(), MainWeatherSource, ReverseGeocodingSource {
+
+    override val id = "meteoam"
+    override val name = "Servizio Meteo AM"
+    override val privacyPolicyUrl = "https://www.meteoam.it/it/privacy-policy"
+
+    override val color = Color.rgb(20, 122, 179)
+    // Required wording for third-party use taken from https://www.meteoam.it/it/condizioni-utilizzo
+    override val weatherAttribution = "Servizio Meteorologico dell’Aeronautica Militare. Informazioni elaborate utilizzando, tra l’altro, dati e prodotti del Servizio Meteorologico dell’Aeronautica Militare pubblicati sul sito www.meteoam.it"
+
+    private val mApi by lazy {
+        client
+            .baseUrl(METEOAM_BASE_URL)
+            .build()
+            .create(MeteoAmApi::class.java)
+    }
+
+    override val supportedFeaturesInMain = listOf<SecondaryWeatherSourceFeature>()
+
+    @SuppressLint("CheckResult")
+    override fun requestWeather(
+        context: Context, location: Location, ignoreFeatures: List<SecondaryWeatherSourceFeature>
+    ): Observable<WeatherWrapper> {
+        val forecast = mApi.getForecast(
+            location.latitude,
+            location.longitude
+        )
+        val observation = mApi.getCurrent(
+            location.latitude,
+            location.longitude
+        )
+        return Observable.zip(forecast, observation) {
+            forecastResult: MeteoAmForecastResult,
+            observationResult: MeteoAmObservationResult
+            ->
+            convert(context, forecastResult, observationResult)
+        }
+    }
+
+    // Reverse geocoding
+    override fun requestReverseGeocodingLocation(
+        context: Context,
+        location: Location
+    ): Observable<List<Location>> {
+        val reverseLocation = mApi.getReverseLocation(location.latitude, location.longitude)
+        val forecast = mApi.getForecast(location.latitude, location.longitude)
+        val locationList = mutableListOf<Location>()
+        return Observable.zip(reverseLocation, forecast) {
+            reverseLocationResult: MeteoAmReverseLocationResult,
+            forecastResult: MeteoAmForecastResult
+            ->
+            if (!reverseLocationResult.results.isNullOrEmpty() && !forecastResult.extrainfo?.timezone.isNullOrEmpty()) {
+                locationList.add(convert(location, reverseLocationResult.results[0], forecastResult.extrainfo?.timezone!!))
+            }
+            locationList
+        }
+    }
+
+    companion object {
+        private const val METEOAM_BASE_URL = "https://api.meteoam.it/"
+   }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/json/MeteoAmForecastDatasets.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/json/MeteoAmForecastDatasets.kt
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteoam.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.breezyweather.sources.meteoam.serializers.MeteoAmAnySerializer
+
+@Serializable
+data class MeteoAmForecastDatasets(
+    @SerialName("0") val data: Map<String, Map<String, @Serializable(with = MeteoAmAnySerializer::class) Any?>>?
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/json/MeteoAmForecastExtraInfo.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/json/MeteoAmForecastExtraInfo.kt
@@ -1,0 +1,25 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteoam.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MeteoAmForecastExtraInfo(
+    val timezone: String?,
+    val stats: List<MeteoAmForecastStats>?
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/json/MeteoAmForecastResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/json/MeteoAmForecastResult.kt
@@ -1,0 +1,29 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteoam.json
+
+import kotlinx.serialization.Serializable
+import org.breezyweather.common.serializer.DateSerializer
+import java.util.Date
+
+@Serializable
+data class MeteoAmForecastResult(
+    val timeseries: List<@Serializable(DateSerializer::class) Date>?,
+    val paramlist: List<String>?,
+    val extrainfo: MeteoAmForecastExtraInfo?,
+    val datasets: MeteoAmForecastDatasets?
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/json/MeteoAmForecastStats.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/json/MeteoAmForecastStats.kt
@@ -1,0 +1,27 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteoam.json
+
+import kotlinx.serialization.Serializable
+import org.breezyweather.common.serializer.DateSerializer
+import java.util.Date
+
+@Serializable
+data class MeteoAmForecastStats(
+    @Serializable(DateSerializer::class) val localDate: Date,
+    val icon: String?
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/json/MeteoAmObservationResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/json/MeteoAmObservationResult.kt
@@ -1,0 +1,27 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteoam.json
+
+import kotlinx.serialization.Serializable
+import org.breezyweather.sources.meteoam.serializers.MeteoAmAnySerializer
+
+@Serializable
+data class MeteoAmObservationResult(
+    val paramlist: List<String>?,
+    val timeseries: List<List<String>>?,
+    val datasets: Map<String, Map<String, Map<String, @Serializable(with = MeteoAmAnySerializer::class) Any?>>>?
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/json/MeteoAmReverseLocation.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/json/MeteoAmReverseLocation.kt
@@ -1,0 +1,27 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteoam.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MeteoAmReverseLocation(
+    val city: String,
+    val county: String?,
+    val country: String,
+    val country_code: String?
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/json/MeteoAmReverseLocationResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/json/MeteoAmReverseLocationResult.kt
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteoam.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MeteoAmReverseLocationResult(
+    val results: List<MeteoAmReverseLocation>?
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/serializers/MeteoAmAnySerializer.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/serializers/MeteoAmAnySerializer.kt
@@ -1,0 +1,35 @@
+package org.breezyweather.sources.meteoam.serializers
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.Serializer
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.double
+
+@Serializer(forClass = Any::class)
+object MeteoAmAnySerializer : KSerializer<Any?> {
+    override fun deserialize(decoder: Decoder): Any? {
+        if (decoder is JsonDecoder) {
+            val element = decoder.decodeJsonElement()
+            if (element is JsonNull) {
+                return null
+            }
+            if (element is JsonPrimitive) {
+                if (element.isString) {
+                    return element.content
+                }
+                return try {
+                    element.boolean
+                } catch (e: Throwable) {
+                    element.double
+                }
+            }
+            throw SerializationException("Invalid Json element $element")
+        }
+        throw SerializationException("Unknown serialization type")
+    }
+}

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -13,9 +13,9 @@ Below, you can find details about the support and implementation status for feat
 
 ## Status
 
-| Worldwide sources² | Open-Meteo | AccuWeather | MET Norway | OpenWeather   | Pirate Weather | HERE     | Météo-France | DMI  |
-|--------------------|------------|-------------|------------|---------------|----------------|----------|--------------|------|
-| **API key**        | None       | Optional    | None       | Rate-limited¹ | Required       | Required | Optional     | None |
+| Worldwide sources² | Open-Meteo | AccuWeather | MET Norway | OpenWeather   | Pirate Weather | HERE     | Météo-France | DMI  | Meteo AM |
+|--------------------|------------|-------------|------------|---------------|----------------|----------|--------------|------|----------|
+| **API key**        | None       | Optional    | None       | Rate-limited¹ | Required       | Required | Optional     | None | None     |
 
 | National sources | China³ | NWS  | GeoSphere Austria  | Bright Sky | ECCC   | CWA      | IMS                           | SMHI   | MET Éireann |
 |------------------|--------|------|--------------------|------------|--------|----------|-------------------------------|--------|-------------|
@@ -31,17 +31,17 @@ Below, you can find details about the support and implementation status for feat
 
 Sources with mandatory API key to use are at the bottom of this page.
 
-| Worldwide sources             | Open-Meteo | AccuWeather | MET Norway | OpenWeather | Météo-France | DMI |
-|-------------------------------|------------|-------------|------------|-------------|--------------|-----|
-| **Daily (days)**              | 15         | 15          | ~10        | 5           | 14           | 10  |
-| **Hourly (days)**             | 16         | 10          | ~10        | 5           | 15           | 10  |
-| **Weather**                   | ✅          | ✅           | ✅          | ✅           | ✅            | ✅   |
-| **Temperature**               | ✅          | ✅           | ✅          | ✅           | ✅            | ✅   |
-| **Precipitation**             | ✅          | ✅ (RSI)     | ✅          | ✅ (RS)      | ✅ (RS)       | ✅   |
-| **Precipitation probability** | ✅          | ✅ (TRSI)    | ✅ (T)      | ✅           | ✅ (RSI)      | ❌   |
-| **Wind**                      | ✅          | ✅           | ✅          | ✅           | ✅            | ✅   |
-| **UV**                        | ✅          | ✅           | ✅          | ❌           | ✅            | ❌   |
-| **Sun & Moon & Moon phase**   | ✅          | ✅           | ✅          | ✅           | ✅            | ✅   |
+| Worldwide sources             | Open-Meteo | AccuWeather | MET Norway | OpenWeather | Météo-France | DMI | Meteo AM |
+|-------------------------------|------------|-------------|------------|-------------|--------------|-----|----------|
+| **Daily (days)**              | 15         | 15          | ~10        | 5           | 14           | 10  | 5        |
+| **Hourly (days)**             | 16         | 10          | ~10        | 5           | 15           | 10  | 5        |
+| **Weather**                   | ✅          | ✅           | ✅          | ✅           | ✅            | ✅   | ✅        |
+| **Temperature**               | ✅          | ✅           | ✅          | ✅           | ✅            | ✅   | ✅        |
+| **Precipitation**             | ✅          | ✅ (RSI)     | ✅          | ✅ (RS)      | ✅ (RS)       | ✅   | ❌        |
+| **Precipitation probability** | ✅          | ✅ (TRSI)    | ✅ (T)      | ✅           | ✅ (RSI)      | ❌   | ✅        |
+| **Wind**                      | ✅          | ✅           | ✅          | ✅           | ✅            | ✅   | ✅        |
+| **UV**                        | ✅          | ✅           | ✅          | ❌           | ✅            | ❌   | ❌        |
+| **Sun & Moon & Moon phase**   | ✅          | ✅           | ✅          | ✅           | ✅            | ✅   | ❌        |
 
 | National sources              | China | NWS    | GeoSphere Austria | Bright Sky | ECCC | IMS           | SMHI | MET Éireann |
 |-------------------------------|-------|--------|-------------------|------------|------|---------------|------|-------------|
@@ -62,13 +62,13 @@ Note that no forecast above 7 days is reliable, so you should not decide based o
 
 The following features, if not available from your selected source, can be added from another source.
 
-| Worldwide sources            | Open-Meteo | AccuWeather   | MET Norway    | OpenWeather | Météo-France | DMI     |
-|------------------------------|------------|---------------|---------------|-------------|--------------|---------|
-| **Air quality**              | ✅          | ✅             | Norway        | ✅           | ❌            | ❌       |
-| **Pollen**                   | ✅          | North America | ❌             | ❌           | ❌            | ❌       |
-| **Precipitation nowcasting** | ✅          | ✅             | Nordic area   | ❌           | France       | ❌       |
-| **Alerts**                   | ❌          | ✅             | *In progress* | ❌           | France       | Denmark |
-| **Normals**                  | Average    | ✅             | Average       | Average     | ✅            | Average |
+| Worldwide sources            | Open-Meteo | AccuWeather   | MET Norway    | OpenWeather | Météo-France | DMI     | Meteo AM |
+|------------------------------|------------|---------------|---------------|-------------|--------------|---------|----------|
+| **Air quality**              | ✅          | ✅             | Norway        | ✅           | ❌            | ❌       | ❌        |
+| **Pollen**                   | ✅          | North America | ❌             | ❌           | ❌            | ❌       | ❌        |
+| **Precipitation nowcasting** | ✅          | ✅             | Nordic area   | ❌           | France       | ❌       | ❌        |
+| **Alerts**                   | ❌          | ✅             | *In progress* | ❌           | France       | Denmark | ❌        |
+| **Normals**                  | Average    | ✅             | Average       | Average     | ✅            | Average | ❌        |
 
 | National sources             | China   | NWS           | GeoSphere Austria  | Bright Sky | ECCC   | IMS     | SMHI    | MET Éireann |
 |------------------------------|---------|---------------|--------------------|------------|--------|---------|---------|-------------|
@@ -91,16 +91,16 @@ Legend:
 
 ## Other weather data
 
-| Worldwide sources          | Open-Meteo | AccuWeather | MET Norway | OpenWeather | Météo-France | DMI |
-|----------------------------|------------|-------------|------------|-------------|--------------|-----|
-| **Humidity**               | ✅          | ✅           | ✅          | ✅           | ✅            | ✅   |
-| **Dew point**              | ✅          | ✅           | ✅          | ✅           | ✅            | ✅   |
-| **Pressure**               | ✅          | Current     | ✅          | ✅           | ✅            | ✅   |
-| **Cloud cover**            | ✅          | ✅           | ✅          | ✅           | ✅            | ❌   |
-| **Visibility**             | ✅          | ✅           | ❌          | ✅           | ❌            | ✅   |
-| **Ceiling**                | ❌          | ✅           | ❌          | ❌           | ❌            | ❌   |
-| **Precipitation duration** | ❌          | ✅ (RSI)     | ❌          | ❌           | ❌            | ❌   |
-| **Sunshine duration**      | ✅          | ✅           | ❌          | ❌           | ❌            | ❌   |
+| Worldwide sources          | Open-Meteo | AccuWeather | MET Norway | OpenWeather | Météo-France | DMI | Meteo AM |
+|----------------------------|------------|-------------|------------|-------------|--------------|-----|----------|
+| **Humidity**               | ✅          | ✅           | ✅          | ✅           | ✅            | ✅   | ✅        |
+| **Dew point**              | ✅          | ✅           | ✅          | ✅           | ✅            | ✅   | ❌        |
+| **Pressure**               | ✅          | Current     | ✅          | ✅           | ✅            | ✅   | ✅        |
+| **Cloud cover**            | ✅          | ✅           | ✅          | ✅           | ✅            | ❌   | ❌        |
+| **Visibility**             | ✅          | ✅           | ❌          | ✅           | ❌            | ✅   | ❌        |
+| **Ceiling**                | ❌          | ✅           | ❌          | ❌           | ❌            | ❌   | ❌        |
+| **Precipitation duration** | ❌          | ✅ (RSI)     | ❌          | ❌           | ❌            | ❌   | ❌        |
+| **Sunshine duration**      | ✅          | ✅           | ❌          | ❌           | ❌            | ❌   | ❌        |
 
 | National sources           | China   | NWS | GeoSphere Austria | Bright Sky | ECCC    | IMS | SMHI | MET Éireann |
 |----------------------------|---------|-----|-------------------|------------|---------|-----|------|-------------|
@@ -118,10 +118,10 @@ Legend:
 
 ## Location
 
-| Worldwide sources     | Open-Meteo | AccuWeather | MET Norway | OpenWeather | Météo-France | DMI     |
-|-----------------------|------------|-------------|------------|-------------|--------------|---------|
-| **Search**            | ✅          | ✅           | Default    | Default     | Default      | Default |
-| **Reverse geocoding** | ❌²         | ✅           | ❌²         | ❌²          | ✅²           | ✅       |
+| Worldwide sources     | Open-Meteo | AccuWeather | MET Norway | OpenWeather | Météo-France | DMI     | Meteo AM |
+|-----------------------|------------|-------------|------------|-------------|--------------|---------|----------|
+| **Search**            | ✅          | ✅           | Default    | Default     | Default      | Default | Default  |
+| **Reverse geocoding** | ❌²         | ✅           | ❌²         | ❌²          | ✅²           | ✅       | ✅        |
 
 | National sources      | China | NWS     | GeoSphere Austria | Bright Sky | ECCC    | IMS     | SMHI    | MET Éireann |
 |-----------------------|-------|---------|-------------------|------------|---------|---------|---------|-------------|
@@ -227,13 +227,13 @@ Legend:
 
 # Combinable sources
 
-| Worldwide sources            | Open-Meteo | AccuWeather | MET Norway    | OpenWeather | Pirate Weather | Météo-France | DMI           |
-|------------------------------|------------|-------------|---------------|-------------|----------------|--------------|---------------|
-| **Air quality**              | ✅          | ✅           | Norway        | ✅           | ❌              | ❌            | ❌             |
-| **Pollen**                   | ✅²         | ✅           | ❌             | ❌           | ❌              | ❌            | ❌             |
-| **Precipitation nowcasting** | ✅³         | ✅           | Nordic area   | ❌           | ✅              | France       | ❌             |
-| **Alerts**                   | ❌          | ✅           | *In progress* | ❌           | ✅              | France       | *In progress* |
-| **Normals**                  | ❌          | ✅           | ❌             | ❌           | ❌              | ✅⁴           | ❌             |
+| Worldwide sources            | Open-Meteo | AccuWeather | MET Norway    | OpenWeather | Pirate Weather | Météo-France | DMI           | Meteo AM |
+|------------------------------|------------|-------------|---------------|-------------|----------------|--------------|---------------|----------|
+| **Air quality**              | ✅          | ✅           | Norway        | ✅           | ❌              | ❌            | ❌             | ❌        |
+| **Pollen**                   | ✅²         | ✅           | ❌             | ❌           | ❌              | ❌            | ❌             | ❌        |
+| **Precipitation nowcasting** | ✅³         | ✅           | Nordic area   | ❌           | ✅              | France       | ❌             | ❌        |
+| **Alerts**                   | ❌          | ✅           | *In progress* | ❌           | ✅              | France       | *In progress* | ❌        |
+| **Normals**                  | ❌          | ✅           | ❌             | ❌           | ❌              | ✅⁴           | ❌             | ❌        |
 
 | National sources             | China | NWS           | GeoSphere Austria  | WMO Severe Weather | Bright Sky | ECCC   | CWA    | IMS                           | MET Éireann | ATMO AuRA     |
 |------------------------------|-------|---------------|--------------------|--------------------|------------|--------|--------|-------------------------------|-------------|---------------|


### PR DESCRIPTION
I have added Servizio Meteorologico dell’Aeronautica Militare (Servizio Meteo AM) as a new national source for Italy (and by extension San Marino and the Vatican). I have implemented the following:
- Hourly/Daily Forecasts
- Current Observations
- Reverse Geocoding

I have not implemented its search-by-name endpoint after all. I am almost certain it is powered by a (truncated?) instance of Nominatim though, since it returns OSM IDs and no time zone info.