### PR TITLE
fix bug where trailing spaces would hide relevant results

### DIFF
--- a/app/src/main/java/org/breezyweather/search/SearchViewModel.kt
+++ b/app/src/main/java/org/breezyweather/search/SearchViewModel.kt
@@ -42,7 +42,7 @@ class SearchViewModel @Inject constructor(
         mRepository.cancel()
         mRepository.searchLocationList(
             getApplication(),
-            str,
+            str.trim(),
             locationSearchSource.value
         ) { result: Pair<List<Location>?, RefreshErrorType?>?, _: Boolean ->
             result?.second?.let { msg ->


### PR DESCRIPTION
Breezy Weather is very verbose in its search, giving back different results depending on whether a search term ends with a whitespace or not. For example, if I'm searching for "San Francisco" and use GBoard's autocomplete, it will write it out with a trailing whitespace at the end. Breezy Weather will not return the most important hit, San Francisco, but rather smaller, less relevant ones.

This fix removes any *trailing* whitespaces from the search entry before submitting it, eliminating the bug.

This is my first time coding in Kotlin, so feel free to point out better ways to achieve this fix or tell me if I've missed something! :)