### PR TITLE
Fix #216 - Location dialog being triggered multiple times

### DIFF
--- a/app/src/main/java/org/breezyweather/main/MainActivity.kt
+++ b/app/src/main/java/org/breezyweather/main/MainActivity.kt
@@ -24,6 +24,7 @@ import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
 import android.view.View
+import androidx.appcompat.app.AlertDialog
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -83,6 +84,7 @@ class MainActivity : GeoActivity(),
 
     private val _dialogPerLocationSettingsOpen = MutableStateFlow(false)
     val dialogPerLocationSettingsOpen = _dialogPerLocationSettingsOpen.asStateFlow()
+    private var dialogPerLocationAlert: AlertDialog? = null
 
     companion object {
         const val SEARCH_ACTIVITY = 4
@@ -241,6 +243,11 @@ class MainActivity : GeoActivity(),
         updateDayNightColors()
     }
 
+    override fun onPause() {
+        super.onPause()
+        dialogPerLocationAlert?.dismiss()
+    }
+
     override fun onStart() {
         super.onStart()
         viewModel.checkToUpdate()
@@ -327,8 +334,7 @@ class MainActivity : GeoActivity(),
                         }
 
                         if (showLocationPermissionDialog && !viewModel.statementManager.isLocationPermissionDialogAlreadyShown) {
-                            // only show dialog once.
-                            MaterialAlertDialogBuilder(this@MainActivity)
+                            dialogPerLocationAlert = MaterialAlertDialogBuilder(this@MainActivity)
                                 .setTitle(R.string.dialog_permissions_location_title)
                                 .setMessage(R.string.dialog_permissions_location_content)
                                 .setPositiveButton(R.string.action_next) { _, _ ->


### PR DESCRIPTION
As far as I can tell, what was happening here was that the activity was repeatedly creating new dialogs whenever the activity resumed from a pause. This should fix the issue by dismissing the existing dialogs on pauses instead. I'm fairly new to Kotlin, Compose, and android development as a whole so if there's a better way to handle this please let me know. Any feedback is appreciated!