### PR TITLE
Add "APP_WEATHER" category to the manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -102,6 +102,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.APP_WEATHER" />
             </intent-filter>
             <intent-filter>
                 <!--<action android:name="org.breezyweather.ICON_PROVIDER" />-->


### PR DESCRIPTION
This patch adds the APP_WEATHER category to the manifest. This is useful in my [digital assistant app](https://github.com/devycarol/Emilla) for example, which has a command to open weather apps.