### PR TITLE
Gadgetbridge: Add missing fields to daily and hourly forecasts

### DIFF
--- a/app/src/main/java/org/breezyweather/sources/gadgetbridge/GadgetbridgeService.kt
+++ b/app/src/main/java/org/breezyweather/sources/gadgetbridge/GadgetbridgeService.kt
@@ -93,7 +93,10 @@ class GadgetbridgeService @Inject constructor() : BroadcastSource {
             todayMaxTemp = today?.day?.temperature?.temperature?.roundCelsiusToKelvin(),
             todayMinTemp = today?.night?.temperature?.temperature?.roundCelsiusToKelvin(),
             feelsLikeTemp = current?.temperature?.feelsLikeTemperature?.roundCelsiusToKelvin(),
-            precipProbability = today?.day?.precipitationProbability?.total?.roundToInt(),
+            precipProbability = maxOfNullable(
+                today?.day?.precipitationProbability?.total,
+                today?.night?.precipitationProbability?.total
+            )?.roundToInt(),
 
             dewPoint = current?.dewPoint?.roundCelsiusToKelvin(),
             pressure = current?.pressure?.toFloat(),


### PR DESCRIPTION
Add some missing fields from #422

Daily:
- Wind speed, direction
- UV Index
- Precipitation probability

Hourly:
- UV Index
- Precipitation probability

(Unsure how I missed these in the original PR.. were not available back then? Only now do we support devices that display those, so it went unnoticed)

<details>
  <summary>Gadgetbridge</summary>

![daily](https://github.com/user-attachments/assets/12952a0a-ca72-4112-ad3e-f780765d192e)

![hourly](https://github.com/user-attachments/assets/99616639-25dc-4084-94a2-85257cad2f2a)

</details>