### PR TITLE
Fix #1291 Update surface colors

### DIFF
--- a/app/src/main/java/org/breezyweather/common/ui/composables/LocationPreferences.kt
+++ b/app/src/main/java/org/breezyweather/common/ui/composables/LocationPreferences.kt
@@ -22,6 +22,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialogDefaults
+import androidx.compose.material3.ListItemColors
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -77,7 +80,8 @@ fun LocationPreference(
             titleId = R.string.settings_weather_sources,
             iconId = R.drawable.ic_factory,
             summaryId = R.string.settings_weather_sources_per_location_summary,
-            card = false
+            card = false,
+            colors = ListItemDefaults.colors(containerColor = AlertDialogDefaults.containerColor)
         ) {
             dialogWeatherSourcesOpenState.value = true
         }
@@ -85,7 +89,8 @@ fun LocationPreference(
             titleId = R.string.settings_per_location,
             iconId = R.drawable.ic_settings,
             summaryId = R.string.settings_per_location_summary,
-            card = false
+            card = false,
+            colors = ListItemDefaults.colors(containerColor = AlertDialogDefaults.containerColor)
         ) {
             dialogAdditionalLocationPreferencesOpenState.value = true
         }
@@ -93,7 +98,8 @@ fun LocationPreference(
             titleId = R.string.settings_global,
             iconId = R.drawable.ic_home,
             summaryId = R.string.settings_main_summary,
-            card = false
+            card = false,
+            colors = ListItemDefaults.colors(containerColor = AlertDialogDefaults.containerColor)
         ) {
             IntentHelper.startMainScreenSettingsActivity(activity)
             onClose(null)
@@ -156,7 +162,8 @@ fun LocationPreference(
                             selectedKey = backgroundWeatherKind.value,
                             nameArrayId = R.array.live_wallpaper_weather_kinds,
                             valueArrayId = R.array.live_wallpaper_weather_kind_values,
-                            card = false
+                            card = false,
+                            colors = ListItemDefaults.colors(containerColor = AlertDialogDefaults.containerColor)
                         ) { newValue ->
                             if (newValue != backgroundWeatherKind.value) {
                                 backgroundWeatherKind.value = newValue
@@ -168,7 +175,8 @@ fun LocationPreference(
                             selectedKey = backgroundDayNightType.value,
                             nameArrayId = R.array.live_wallpaper_day_night_types,
                             valueArrayId = R.array.live_wallpaper_day_night_type_values,
-                            card = false
+                            card = false,
+                            colors = ListItemDefaults.colors(containerColor = AlertDialogDefaults.containerColor)
                         ) { newValue ->
                             if (newValue != backgroundDayNightType.value) {
                                 backgroundDayNightType.value = newValue
@@ -582,6 +590,7 @@ fun SourceView(
     enabled: Boolean = true,
     sourceList: Map<String, String>,
     card: Boolean = false,
+    colors: ListItemColors = ListItemDefaults.colors(AlertDialogDefaults.containerColor),
     withState: Boolean = true,
     onValueChanged: (String) -> Unit
 ) {
@@ -614,6 +623,7 @@ fun SourceView(
         },
         enabled = enabled,
         card = card,
+        colors = colors,
         withState = withState
     )
 

--- a/app/src/main/java/org/breezyweather/search/SearchActivity.kt
+++ b/app/src/main/java/org/breezyweather/search/SearchActivity.kt
@@ -18,7 +18,6 @@ package org.breezyweather.search
 
 import android.content.Intent
 import android.os.Bundle
-import android.window.OnBackInvokedDispatcher
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.clickable
@@ -44,6 +43,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.Surface
@@ -180,6 +180,8 @@ class SearchActivity : GeoActivity() {
                         ) {
                             items(listResourceState.value.first) { location ->
                                 ListItem(
+                                    colors = ListItemDefaults
+                                        .colors(containerColor = SearchBarDefaults.colors().containerColor),
                                     headlineContent = { Text(location.getPlace(context)) },
                                     supportingContent = { Text(location.administrationLevels()) },
                                     modifier = Modifier.clickable {

--- a/app/src/main/java/org/breezyweather/settings/compose/AppearanceSettingsScreen.kt
+++ b/app/src/main/java/org/breezyweather/settings/compose/AppearanceSettingsScreen.kt
@@ -28,9 +28,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -156,7 +158,7 @@ fun AppearanceSettingsScreen(
                 }
                 if (dialogIconPackOpenState.value) {
                     // TODO: async
-                listProviderState.value = ResourcesProviderFactory.getProviderList(BreezyWeather.instance)
+                    listProviderState.value = ResourcesProviderFactory.getProviderList(BreezyWeather.instance)
 
                     AlertDialogNoPadding(
                         onDismissRequest = {
@@ -203,6 +205,7 @@ fun AppearanceSettingsScreen(
                             ) {
                                 items(listProviderState.value) {
                                     ListItem(
+                                        colors = ListItemDefaults.colors(AlertDialogDefaults.containerColor),
                                         headlineContent = {
                                             Text(it.providerName ?: "")
                                         },

--- a/app/src/main/java/org/breezyweather/settings/compose/WeatherSourcesSettingsScreen.kt
+++ b/app/src/main/java/org/breezyweather/settings/compose/WeatherSourcesSettingsScreen.kt
@@ -105,11 +105,11 @@ fun WeatherSourcesSettingsScreen(
 
             sectionHeaderItem(R.string.settings_weather_sources_section_general)
             listPreferenceItem(R.string.settings_weather_sources_default_source) { id ->
-        val configuredWorldwideSourcesAssociated = configuredWorldwideSources.associate { it.id to it.name }
+                val configuredWorldwideSourcesAssociated = configuredWorldwideSources.associate { it.id to it.name }
                 val defaultWeatherSource = SettingsManager.getInstance(context).defaultWeatherSource
                 SourceView(
                     title = stringResource(id),
-            selectedKey = if (configuredWorldwideSourcesAssociated.contains(defaultWeatherSource)) {
+                    selectedKey = if (configuredWorldwideSourcesAssociated.contains(defaultWeatherSource)) {
                         defaultWeatherSource
                     } else "auto",
                     sourceList = mapOf(

--- a/app/src/main/java/org/breezyweather/settings/preference/composables/ListPreference.kt
+++ b/app/src/main/java/org/breezyweather/settings/preference/composables/ListPreference.kt
@@ -38,6 +38,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemColors
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -73,6 +75,7 @@ fun ListPreferenceView(
     selectedKey: String,
     enabled: Boolean = true,
     card: Boolean = true,
+    colors: ListItemColors = ListItemDefaults.colors(),
     withState: Boolean = true,
     onValueChanged: (String) -> Unit,
 ) {
@@ -88,6 +91,7 @@ fun ListPreferenceView(
         nameArray = names,
         enabled = enabled,
         card = card,
+        colors = colors,
         withState = withState,
         onValueChanged = onValueChanged,
     )
@@ -103,6 +107,7 @@ fun ListPreferenceView(
     nameArray: Array<String>,
     enabled: Boolean = true,
     card: Boolean = true,
+    colors: ListItemColors = ListItemDefaults.colors(),
     withState: Boolean = true,
     dismissButton: @Composable (() -> Unit)? = null,
     onValueChanged: (String) -> Unit,
@@ -170,6 +175,7 @@ fun ListPreferenceView(
         }
     } else {
         ListItem(
+            colors = colors,
             tonalElevation = 0.dp,
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/org/breezyweather/settings/preference/composables/Preference.kt
+++ b/app/src/main/java/org/breezyweather/settings/preference/composables/Preference.kt
@@ -35,6 +35,8 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemColors
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -60,6 +62,7 @@ fun PreferenceView(
     @DrawableRes iconId: Int? = null,
     enabled: Boolean = true,
     card: Boolean = true,
+    colors: ListItemColors = ListItemDefaults.colors(),
     onClick: () -> Unit,
 ) = PreferenceView(
     title = stringResource(titleId),
@@ -67,6 +70,7 @@ fun PreferenceView(
     iconId = iconId,
     enabled = enabled,
     card = card,
+    colors = colors,
     onClick = onClick
 )
 
@@ -77,6 +81,7 @@ fun PreferenceView(
     @DrawableRes iconId: Int? = null,
     enabled: Boolean = true,
     card: Boolean = true,
+    colors: ListItemColors = ListItemDefaults.colors(),
     onClose: (() -> Unit)? = null,
     onClick: () -> Unit,
 ) {
@@ -159,6 +164,7 @@ fun PreferenceView(
         }
     } else {
         ListItem(
+            colors = colors,
             tonalElevation = 0.dp,
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/org/breezyweather/settings/preference/composables/SwitchPreference.kt
+++ b/app/src/main/java/org/breezyweather/settings/preference/composables/SwitchPreference.kt
@@ -31,6 +31,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemColors
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
@@ -61,6 +63,7 @@ fun SwitchPreferenceView(
     withState: Boolean = true,
     enabled: Boolean = true,
     card: Boolean = true,
+    colors: ListItemColors = ListItemDefaults.colors(),
     onValueChanged: (Boolean) -> Unit,
 ) = SwitchPreferenceView(
     title = stringResource(titleId),
@@ -72,6 +75,7 @@ fun SwitchPreferenceView(
     withState = withState,
     enabled = enabled,
     card = card,
+    colors = colors,
     onValueChanged = onValueChanged,
 )
 
@@ -84,6 +88,7 @@ fun SwitchPreferenceView(
     withState: Boolean = true,
     enabled: Boolean = true,
     card: Boolean = true,
+    colors: ListItemColors = ListItemDefaults.colors(),
     onValueChanged: (Boolean) -> Unit,
 ) {
     val state = remember { mutableStateOf(checked) }
@@ -143,6 +148,7 @@ fun SwitchPreferenceView(
         }
     } else {
         ListItem(
+            colors = colors,
             tonalElevation = 0.dp,
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/org/breezyweather/sources/openmeteo/OpenMeteoService.kt
+++ b/app/src/main/java/org/breezyweather/sources/openmeteo/OpenMeteoService.kt
@@ -21,7 +21,9 @@ import android.graphics.Color
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -460,7 +462,8 @@ class OpenMeteoService @Inject constructor(
                 .joinToString(context.getString(R.string.comma_separator)) {
                     it.model.getName(context)
                 },
-            card = false
+            card = false,
+            colors = ListItemDefaults.colors(containerColor = AlertDialogDefaults.containerColor)
         ) {
             dialogModelsOpenState.value = true
         }
@@ -492,7 +495,8 @@ class OpenMeteoService @Inject constructor(
                                 title = model.model.getName(context),
                                 summary = { context, _ -> model.model.getDescription(context) },
                                 checked = model.enabled,
-                                card = false
+                                card = false,
+                                colors = ListItemDefaults.colors(AlertDialogDefaults.containerColor)
                             ) { checked ->
                                 if (checked) {
                                     model.model.incompatibleSources.forEach { incompatibleSource ->


### PR DESCRIPTION
Fixes #1291

It seems like this was happening due to [compose-material3 1.3](https://developer.android.com/jetpack/androidx/releases/compose-material3#1.3.0) changing the surface default color slightly:

> Small adjustments to surface and background color defaults in lightColorScheme and darkColorScheme. ([I9db52](https://android-review.googlesource.com/#/q/I9db5226e26371223bc46f37ddfe226acf7767041))

I just used xcolor to match the new colors. I'm not sure if there's any available documentation on the palette they're using. This issue was affecting the edit location dialog and the notification time dialog as well.