### PR TITLE
Add gradle generated directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gradle
+.kotlin
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/


### PR DESCRIPTION
Since [Kotlin 2.0.0](https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects) the `.kotlin` directory was moved out of the `.gradle` directory and is now in the root directory of the project by default. This just adds that directory to the `.gitignore` file. 