### PR TITLE
Move system bar setup into onCreate, remove onPostCreate call

### DIFF
--- a/app/src/main/java/org/breezyweather/common/basic/GeoActivity.kt
+++ b/app/src/main/java/org/breezyweather/common/basic/GeoActivity.kt
@@ -46,10 +46,6 @@ abstract class GeoActivity : AppCompatActivity() {
             true,
             !this.isDarkMode
         )
-    }
-
-    override fun onPostCreate(savedInstanceState: Bundle?) {
-        super.onPostCreate(savedInstanceState)
 
         // decor -> fit horizontal system bar -> decor child.
         val decorView = window.decorView as ViewGroup


### PR DESCRIPTION
Fix #717

My assumption is that the view hierarchy was changing after the NavHost was created causing some sort of disconnect. I'm not sure why the behavior is different before SDK 31 though. 

I tested all of the activities that inherit GeoActivity and didn't notice any differences. Tested on a physical Pixel 6 Pro running SDK 34 and an emulated Pixel 8 Pro on SDK 30.

A possible alternate fix, if changing GeoActivity.kt impacts too many other parts of the code, is to move the setContent call in SettingsActivity.kt into its own onPostCreate method.