### PR TITLE
Fix snackbar not appearing after recreating activities

### DIFF
--- a/app/src/main/java/org/breezyweather/BreezyWeather.kt
+++ b/app/src/main/java/org/breezyweather/BreezyWeather.kt
@@ -109,9 +109,12 @@ class BreezyWeather : Application(),
     }
 
     fun recreateAllActivities() {
+        val topA = topActivity
         for (a in activitySet) {
-            a.recreate()
+            if (a != topA) a.recreate()
         }
+        // ensure that top activity stays on top by recreating it last
+        topA?.recreate()
     }
 
     private fun setDayNightMode() {


### PR DESCRIPTION
This fixes an issue where snackbars would not be displayed anymore after recreating activities, e.g. in settings when changing the animation setting for the gravity sensor and tapping restart in the snackbar to apply the changes. Afterwards, when triggering another snackbar, for instance by changing the previous setting again, it would not be shown in some cases** because the [SnackbarHelper](https://github.com/breezy-weather/breezy-weather/blob/794e867e2f73ded921bbeb86b961e82e79dc0303/app/src/main/java/org/breezyweather/common/utils/helpers/SnackbarHelper.kt#L35) could not find the correct topActivity.

The issue was caused by the order in which the activities were recreated. As the activities are stored in a [HashSet](https://github.com/breezy-weather/breezy-weather/blob/794e867e2f73ded921bbeb86b961e82e79dc0303/app/src/main/java/org/breezyweather/BreezyWeather.kt#L64) (unordered), it was random at which point the current topActivity was recreated.

To ensure that the current topActivity stays the topActivity, it is now recreated last.

Tested on devices with Android 9, 14.

----

** The issue did not occur when switching apps after the activities had been recreated and then switching back to Breezy Weather as the topActivity is reset in [onResume](https://github.com/breezy-weather/breezy-weather/blob/794e867e2f73ded921bbeb86b961e82e79dc0303/app/src/main/java/org/breezyweather/common/basic/GeoActivity.kt#L79).