### PR TITLE
[WIP] Slightly increase canvas size for shooting stars

### DIFF
--- a/app/src/main/java/org/breezyweather/main/adapters/main/holder/PrecipitationNowcastViewHolder.kt
+++ b/app/src/main/java/org/breezyweather/main/adapters/main/holder/PrecipitationNowcastViewHolder.kt
@@ -274,6 +274,7 @@ class PrecipitationNowcastViewHolder(
                     rangeProvider = cartesianLayerRangeProvider
                 ),
                 bottomAxis = HorizontalAxis.rememberBottom(
+                    itemPlacer = HorizontalAxis.ItemPlacer.aligned(addExtremeLabelPadding = false),
                     guideline = null,
                     tick = null, // Workaround: no custom ticks
                     label = null, // Workaround: no custom ticks

--- a/app/src/main/java/org/breezyweather/main/adapters/main/holder/PrecipitationNowcastViewHolder.kt
+++ b/app/src/main/java/org/breezyweather/main/adapters/main/holder/PrecipitationNowcastViewHolder.kt
@@ -274,7 +274,6 @@ class PrecipitationNowcastViewHolder(
                     rangeProvider = cartesianLayerRangeProvider
                 ),
                 bottomAxis = HorizontalAxis.rememberBottom(
-                    itemPlacer = HorizontalAxis.ItemPlacer.aligned(addExtremeLabelPadding = false),
                     guideline = null,
                     tick = null, // Workaround: no custom ticks
                     label = null, // Workaround: no custom ticks

--- a/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/MaterialPainterView.kt
+++ b/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/MaterialPainterView.kt
@@ -28,7 +28,6 @@ import android.view.View
 import androidx.annotation.FloatRange
 import androidx.annotation.Size
 import androidx.core.content.res.ResourcesCompat
-import org.breezyweather.common.extensions.getTabletListAdaptiveWidth
 import org.breezyweather.common.extensions.isLandscape
 import org.breezyweather.common.extensions.sensorManager
 import org.breezyweather.theme.weatherView.WeatherView.WeatherKindRule
@@ -172,6 +171,14 @@ class MaterialPainterView(
     ) {
         override fun onOrientationChanged(orientation: Int) {
             mDeviceOrientation = getDeviceOrientation(orientation)
+
+            val metrics = resources.displayMetrics
+            canvasSize = intArrayOf(
+                metrics.widthPixels,
+                metrics.heightPixels
+            )
+
+            setWeatherImplementor()
         }
 
         private fun getDeviceOrientation(orientation: Int): DeviceOrientation {
@@ -196,7 +203,7 @@ class MaterialPainterView(
 
         val metrics = resources.displayMetrics
         canvasSize = intArrayOf(
-            context.getTabletListAdaptiveWidth(metrics.widthPixels),
+            metrics.widthPixels,
             metrics.heightPixels
         )
 
@@ -226,21 +233,6 @@ class MaterialPainterView(
         }
 
         background = getWeatherBackgroundDrawable(weatherKind, daylight)
-    }
-
-    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
-        super.onSizeChanged(w, h, oldw, oldh)
-
-        if (measuredWidth != 0 && measuredHeight != 0) {
-            val width = context.getTabletListAdaptiveWidth(measuredWidth)
-            val height = measuredHeight
-
-            if (canvasSize[0] != width || canvasSize[1] != height) {
-                canvasSize[0] = width
-                canvasSize[1] = height
-                setWeatherImplementor()
-            }
-        }
     }
 
     // this is inefficient for cases when animations are disabled,

--- a/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/MeteorShowerImplementor.kt
+++ b/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/MeteorShowerImplementor.kt
@@ -26,6 +26,7 @@ import org.breezyweather.theme.weatherView.materialWeatherView.MaterialWeatherVi
 import java.util.Random
 import kotlin.math.cos
 import kotlin.math.pow
+import kotlin.math.roundToInt
 import kotlin.math.sin
 import kotlin.time.Duration.Companion.seconds
 
@@ -70,9 +71,9 @@ class MeteorShowerImplementor(
         init { // 1, 0.7, 0.4
             mCanvasSize =
                 (mViewWidth * mViewWidth + mViewHeight * mViewHeight).toDouble().pow(0.5).toInt()
-            width = (mViewWidth * 0.0088 * scale).toFloat()
+            width = (mViewWidth * 0.005 * scale).toFloat()
             speed = mViewWidth / 200f
-            MAX_HEIGHT = (1.1 * mViewWidth / cos(60.0 * Math.PI / 180.0)).toFloat()
+            MAX_HEIGHT = (mViewWidth / cos(60.0 * Math.PI / 180.0)).toFloat()
             MIN_HEIGHT = (MAX_HEIGHT * 0.7).toFloat()
 
             init(true)
@@ -128,7 +129,7 @@ class MeteorShowerImplementor(
         var progress: Long = 0
 
         init {
-            this.radius = (radius * (0.7 + 0.3 * Random().nextFloat())).toFloat()
+            this.radius = (radius * (0.6 + 0.3 * Random().nextFloat())).toFloat()
             computeAlpha(duration, progress)
         }
 
@@ -175,7 +176,7 @@ class MeteorShowerImplementor(
         val width = (1.0 * canvasSize).toInt()
         val height = ((canvasSize - viewHeight) * 0.5 + viewWidth * 1.1111).toInt()
         val radius = (0.00125 * canvasSize * (0.5 + random.nextFloat())).toFloat()
-        mStars = Array(70) { i ->
+        mStars = Array(80) { i ->
             val x = (random.nextInt(width) - 0.5 * (canvasSize - viewWidth)).toInt()
             val y = (random.nextInt(height) - 0.5 * (canvasSize - viewHeight)).toInt()
             val duration = (2500 + random.nextFloat() * 2500).toLong()

--- a/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/MeteorShowerImplementor.kt
+++ b/app/src/main/java/org/breezyweather/theme/weatherView/materialWeatherView/implementor/MeteorShowerImplementor.kt
@@ -26,7 +26,6 @@ import org.breezyweather.theme.weatherView.materialWeatherView.MaterialWeatherVi
 import java.util.Random
 import kotlin.math.cos
 import kotlin.math.pow
-import kotlin.math.roundToInt
 import kotlin.math.sin
 import kotlin.time.Duration.Companion.seconds
 


### PR DESCRIPTION
Fix #1024

Tested on a physical Pixel 6 Pro and an emulated Pixel tablet.

Anything under ~1.25x scale would still have some artifacts in the corners while testing on the tablet.

*Edit: Bumped the scale up to 1.5x after testing on an emulated version of the device in the original issue.