### PR TITLE
Fix #1297 Edit location dialog theme remains unchanged until the application is restarted.

### DIFF
--- a/app/src/main/java/org/breezyweather/main/MainActivity.kt
+++ b/app/src/main/java/org/breezyweather/main/MainActivity.kt
@@ -377,6 +377,10 @@ class MainActivity : GeoActivity(),
             }
         }
 
+        initPerLocationSettingsView()
+    }
+
+    private fun initPerLocationSettingsView() {
         binding.perLocationSettings.setContent {
             val validLocation = viewModel.currentLocation.collectAsState()
 
@@ -695,6 +699,7 @@ class MainActivity : GeoActivity(),
     // main fragment callback.
     override fun onEditIconClicked() {
         _dialogPerLocationSettingsOpen.value = true
+        initPerLocationSettingsView()
     }
 
     override fun onManageIconClicked() {


### PR DESCRIPTION
Fixes #1297 
The issue occurred because ComposeView declared in the XML layout did not automatically recompose when the system theme changed. Since setContent was only invoked once during initialization, it did not detect the dynamic theme updates **_(e.g. light/dark/system mode switches)_** unless the app was restarted.

**Fix:**
The problem was resolved by using setContent of ComposeView again when the user click on edit icon. This forces the UI to reflect the current system theme without restarting the app.