### PR TITLE
Add QWeather API

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,7 @@ android {
         it.buildConfigField("String", "MF_WSFT_KEY", "\"${properties.getProperty("breezy.mf.key") ?: ""}\"")
         it.buildConfigField("String", "OPEN_WEATHER_KEY", "\"${properties.getProperty("breezy.openweather.key") ?: ""}\"")
         it.buildConfigField("String", "PIRATE_WEATHER_KEY", "\"${properties.getProperty("breezy.pirateweather.key") ?: ""}\"")
+        it.buildConfigField("String", "QWEATHER_KEY", "\"${properties.getProperty("breezy.qweather.key") ?: ""}\"")
     }
 
     flavorDimensions.add("default")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -533,6 +533,7 @@
     <string name="settings_weather_source_mf_api_key" translatable="false">@string/settings_source_api_key</string>
     <string name="settings_weather_source_atmo_aura_api_key" translatable="false">@string/settings_source_api_key</string>
     <string name="settings_weather_source_cwa_api_key" translatable="false">@string/settings_source_api_key</string>
+    <string name="settings_weather_source_qweather_api_key" translatable="false">@string/settings_source_api_key</string>
     <!-- Synonym of instance: Server -->
     <string name="settings_source_instance">Instance</string>
     <string name="settings_source_instance_invalid">Must be an https URL ending with a /</string>

--- a/app/src/src_nonfreenet/org/breezyweather/sources/SourceManager.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/SourceManager.kt
@@ -56,6 +56,7 @@ import org.breezyweather.sources.nws.NwsService
 import org.breezyweather.sources.openmeteo.OpenMeteoService
 import org.breezyweather.sources.openweather.OpenWeatherService
 import org.breezyweather.sources.pirateweather.PirateWeatherService
+import org.breezyweather.sources.qweather.QWeatherService
 import org.breezyweather.sources.recosante.RecosanteService
 import org.breezyweather.sources.smhi.SmhiService
 import org.breezyweather.sources.wmosevereweather.WmoSevereWeatherService
@@ -68,6 +69,7 @@ class SourceManager @Inject constructor(
     baiduIPService: BaiduIPLocationService,
     brightSkyService: BrightSkyService,
     chinaService: ChinaService,
+    qWeatherService: QWeatherService,
     cwaService: CwaService,
     dmiService: DmiService,
     ecccService: EcccService,
@@ -119,6 +121,7 @@ class SourceManager @Inject constructor(
 
         // National-only sources (sorted by population)
         chinaService,
+        qWeatherService,
         nwsService,
         geoSphereAtService, // Austria and nearby
         brightSkyService,

--- a/app/src/src_nonfreenet/org/breezyweather/sources/qweather/QWeatherApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/qweather/QWeatherApi.kt
@@ -1,0 +1,55 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.qweather
+
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.sources.qweather.json.QWeatherAirResult
+import org.breezyweather.sources.qweather.json.QWeatherMinuteResult
+import org.breezyweather.sources.qweather.json.QWeatherNowResult
+import org.breezyweather.sources.qweather.json.QWeatherWarningResult
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface QWeatherApi {
+    @GET("weather/now")
+    fun getWeatherNow(
+        @Query("location") location: String,
+        @Query("key") key: String,
+        @Query("lang") lang: String = "en"
+    ): Observable<QWeatherNowResult>
+
+    @GET("air/now")
+    fun getAirNow(
+        @Query("location") location: String,
+        @Query("key") key: String,
+        @Query("lang") lang: String = "en"
+    ): Observable<QWeatherAirResult>
+
+    @GET("warning/now")
+    fun getWarningNow(
+        @Query("location") location: String,
+        @Query("key") key: String,
+        @Query("lang") lang: String = "en"
+    ): Observable<QWeatherWarningResult>
+
+    @GET("minutely/5m")
+    fun getMinutely(
+        @Query("location") location: String,
+        @Query("key") key: String,
+        @Query("lang") lang: String = "en"
+    ): Observable<QWeatherMinuteResult>
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/qweather/QWeatherConverter.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/qweather/QWeatherConverter.kt
@@ -1,0 +1,270 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.qweather
+
+import android.graphics.Color
+import androidx.annotation.ColorInt
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.weather.model.AirQuality
+import breezyweather.domain.weather.model.Alert
+import breezyweather.domain.weather.model.AlertSeverity
+import breezyweather.domain.weather.model.Minutely
+import breezyweather.domain.weather.model.WeatherCode
+import breezyweather.domain.weather.wrappers.AirQualityWrapper
+import breezyweather.domain.weather.wrappers.SecondaryWeatherWrapper
+import org.breezyweather.sources.qweather.json.QWeatherAirResult
+import org.breezyweather.sources.qweather.json.QWeatherLocation
+import org.breezyweather.sources.qweather.json.QWeatherMinuteResult
+import org.breezyweather.sources.qweather.json.QWeatherWarningResult
+
+fun convertLocation(
+    location: Location?, // Null if location search, current location if reverse geocoding
+    result: QWeatherLocation
+): Location {
+    return (location ?: Location())
+        .copy(
+            cityId = result.id,
+            latitude = location?.latitude ?: result.lat!!.toDouble(),
+            longitude = location?.longitude ?: result.lon!!.toDouble(),
+            timeZone = result.tz!!,
+            country = result.country!!,
+            countryCode = "CN",
+            admin1 = result.adm1,
+            admin2 = result.adm2,
+            city = result.name!!
+        )
+}
+
+fun convertSecondary(
+    airResult: QWeatherAirResult,
+    warningResult: QWeatherWarningResult,
+    minutelyResult: QWeatherMinuteResult
+): SecondaryWeatherWrapper {
+    return SecondaryWeatherWrapper(
+        airQuality = airResult.now?.let {
+            AirQualityWrapper(
+                current = AirQuality(
+                    pM25 = it.pm2p5?.toDoubleOrNull(),
+                    pM10 = it.pm10?.toDoubleOrNull(),
+                    sO2 = it.so2?.toDoubleOrNull(),
+                    nO2 = it.no2?.toDoubleOrNull(),
+                    o3 = it.o3?.toDoubleOrNull(),
+                    cO = it.co?.toDoubleOrNull()
+                )
+            )
+        },
+        alertList = getWarningList(warningResult),
+        minutelyForecast = getMinutelyList(minutelyResult),
+    )
+}
+
+private fun getMinutelyList(
+    minutelyResult: QWeatherMinuteResult
+): List<Minutely> {
+    if (minutelyResult.minutely.isNullOrEmpty()) return emptyList()
+    val minutelyList: MutableList<Minutely> = ArrayList(minutelyResult.minutely.size)
+
+    minutelyResult.minutely.forEachIndexed { _, precipitation ->
+        minutelyList.add(
+            Minutely(
+                date = precipitation.fxTime,
+                minuteInterval = 5,
+                precipitationIntensity = precipitation.precip?.toDouble()?.times(12) // mm/min -> mm/h
+            )
+        )
+    }
+    return minutelyList
+}
+
+private fun getWarningList(result: QWeatherWarningResult): List<Alert> {
+    if (result.warning.isNullOrEmpty()) return emptyList()
+    return result.warning.map { warning ->
+        Alert(
+            alertId = warning.id ?: System.currentTimeMillis().toString(),
+            startDate = warning.pubTime,
+            headline = warning.title,
+            description = warning.text,
+            severity = getWarningSeverity(warning.severity),
+            color = getWarningColor(warning.severityColor)
+        )
+    }.sortedWith(compareByDescending<Alert> { it.severity.id }.thenByDescending(Alert::startDate))
+}
+
+private fun getWarningSeverity(severity: String?): AlertSeverity {
+    if (severity.isNullOrEmpty()) return AlertSeverity.UNKNOWN
+    return when (severity) {
+        "Cancel", "None", "Unknown", "Standard", "Minor" -> AlertSeverity.MINOR
+        "Moderate" -> AlertSeverity.MODERATE
+        "Major", "Severe" -> AlertSeverity.SEVERE
+        "Extreme" -> AlertSeverity.EXTREME
+        else -> AlertSeverity.UNKNOWN
+    }
+}
+
+@ColorInt
+private fun getWarningColor(severityColor: String?): Int? {
+    if (severityColor.isNullOrEmpty()) return null
+    return when (severityColor) {
+        "White" -> Color.rgb(200, 200, 200)
+        "Blue" -> Color.rgb(66, 151, 231)
+        "Yellow" -> Color.rgb(255, 242, 184)
+        "Orange" -> Color.rgb(255, 145, 0)
+        "Red" -> Color.rgb(255, 86, 86)
+        "Black" -> Color.rgb(0, 0, 0)
+        else -> null
+    }
+}
+
+fun getWeatherText(icon: String?): String? {
+    return if (icon.isNullOrEmpty()) {
+        null
+    } else when (icon) {
+        "100" -> "Sunny"
+        "101" -> "Cloudy"
+        "102" -> "Few Clouds"
+        "103" -> "Partly Cloudy"
+        "104" -> "Overcast"
+        "150" -> "Clear"
+        "151" -> "Cloudy"
+        "152" -> "Few Clouds"
+        "153" -> "Partly Cloudy"
+        "300" -> "Shower"
+        "301" -> "Heavy Shower"
+        "302" -> "Thundershower"
+        "303" -> "Heavy Thunderstorm"
+        "304" -> "Hail"
+        "305" -> "Light Rain"
+        "306" -> "Moderate Rain"
+        "307" -> "Heavy Rain"
+        "308" -> "Extreme Rain"
+        "309" -> "Drizzle Rain"
+        "310" -> "Rainstorm"
+        "311" -> "Heavy Rainstorm"
+        "312" -> "Severe Rainstorm"
+        "313" -> "Freezing Rain"
+        "314" -> "Light to Moderate Rain"
+        "315" -> "Moderate to Heavy Rain"
+        "316" -> "Heavy Rain to Rainstorm"
+        "317" -> "Rainstorm to Heavy Rainstorm"
+        "318" -> "Heavy to Severe Rainstorm"
+        "350" -> "Shower"
+        "351" -> "Heavy Shower"
+        "399" -> "Rain"
+        "400" -> "Light Snow"
+        "401" -> "Moderate Snow"
+        "402" -> "Heavy Snow"
+        "403" -> "Snowstorm"
+        "404" -> "Sleet"
+        "405" -> "Rain and Snow"
+        "406" -> "Shower Rain and Snow"
+        "407" -> "Snow Flurry"
+        "408" -> "Light to Moderate Snow"
+        "409" -> "Moderate to Heavy Snow"
+        "410" -> "Heavy Snow to Snowstorm"
+        "456" -> "Shower Rain and Snow"
+        "457" -> "Snow Flurry"
+        "499" -> "Snow"
+        "500" -> "Mist"
+        "501" -> "Fog"
+        "502" -> "Haze"
+        "503" -> "Sand"
+        "504" -> "Dust"
+        "507" -> "Sandstorm"
+        "508" -> "Severe Sandstorm"
+        "509" -> "Dense Fog"
+        "510" -> "Strong Fog"
+        "511" -> "Moderate Haze"
+        "512" -> "Heavy Haze"
+        "513" -> "Severe Haze"
+        "514" -> "Heavy Fog"
+        "515" -> "Extra Heavy Fog"
+        "900" -> "Hot"
+        "901" -> "Cold"
+        "999" -> "Unknown"
+        else -> "Unknown"
+    }
+}
+
+fun getWeatherCode(icon: String?): WeatherCode? {
+    return if (icon.isNullOrEmpty()) {
+        null
+    } else when (icon) {
+        "100" -> WeatherCode.CLEAR
+        "101" -> WeatherCode.PARTLY_CLOUDY
+        "102" -> WeatherCode.PARTLY_CLOUDY
+        "103" -> WeatherCode.PARTLY_CLOUDY
+        "104" -> WeatherCode.CLOUDY
+        "150" -> WeatherCode.CLEAR
+        "151" -> WeatherCode.PARTLY_CLOUDY
+        "152" -> WeatherCode.PARTLY_CLOUDY
+        "153" -> WeatherCode.PARTLY_CLOUDY
+        "300" -> WeatherCode.RAIN
+        "301" -> WeatherCode.RAIN
+        "302" -> WeatherCode.THUNDERSTORM
+        "303" -> WeatherCode.THUNDERSTORM
+        "304" -> WeatherCode.HAIL
+        "305" -> WeatherCode.RAIN
+        "306" -> WeatherCode.RAIN
+        "307" -> WeatherCode.RAIN
+        "308" -> WeatherCode.RAIN
+        "309" -> WeatherCode.RAIN
+        "310" -> WeatherCode.RAIN
+        "311" -> WeatherCode.RAIN
+        "312" -> WeatherCode.RAIN
+        "313" -> WeatherCode.SLEET
+        "314" -> WeatherCode.RAIN
+        "315" -> WeatherCode.RAIN
+        "316" -> WeatherCode.RAIN
+        "317" -> WeatherCode.RAIN
+        "318" -> WeatherCode.RAIN
+        "350" -> WeatherCode.RAIN
+        "351" -> WeatherCode.RAIN
+        "399" -> WeatherCode.RAIN
+        "400" -> WeatherCode.SNOW
+        "401" -> WeatherCode.SNOW
+        "402" -> WeatherCode.SNOW
+        "403" -> WeatherCode.SNOW
+        "404" -> WeatherCode.SLEET
+        "405" -> WeatherCode.SLEET
+        "406" -> WeatherCode.SLEET
+        "407" -> WeatherCode.SNOW
+        "408" -> WeatherCode.SNOW
+        "409" -> WeatherCode.SNOW
+        "410" -> WeatherCode.SNOW
+        "456" -> WeatherCode.SLEET
+        "457" -> WeatherCode.SNOW
+        "499" -> WeatherCode.SNOW
+        "500" -> WeatherCode.FOG
+        "501" -> WeatherCode.FOG
+        "502" -> WeatherCode.HAZE
+        "503" -> WeatherCode.WIND
+        "504" -> WeatherCode.WIND
+        "507" -> WeatherCode.WIND
+        "508" -> WeatherCode.WIND
+        "509" -> WeatherCode.FOG
+        "510" -> WeatherCode.FOG
+        "511" -> WeatherCode.HAZE
+        "512" -> WeatherCode.HAZE
+        "513" -> WeatherCode.HAZE
+        "514" -> WeatherCode.FOG
+        "515" -> WeatherCode.FOG
+        "900" -> WeatherCode.CLEAR
+        "901" -> WeatherCode.CLOUDY
+        "999" -> WeatherCode.CLOUDY
+        else -> WeatherCode.CLOUDY
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/qweather/QWeatherGeoApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/qweather/QWeatherGeoApi.kt
@@ -1,0 +1,31 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.qweather
+
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.sources.qweather.json.QWeatherLocationResult
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface QWeatherGeoApi {
+    @GET("city/lookup")
+    fun cityLookup(
+        @Query("location") location: String,
+        @Query("key") key: String,
+        @Query("lang") lang: String = "en"
+    ): Observable<QWeatherLocationResult>
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/qweather/QWeatherService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/qweather/QWeatherService.kt
@@ -1,0 +1,208 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.qweather
+
+import android.annotation.SuppressLint
+import android.content.Context
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.weather.wrappers.SecondaryWeatherWrapper
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.BuildConfig
+import org.breezyweather.R
+import org.breezyweather.common.exceptions.InvalidLocationException
+import org.breezyweather.common.preference.EditTextPreference
+import org.breezyweather.common.preference.Preference
+import org.breezyweather.common.source.ConfigurableSource
+import org.breezyweather.common.source.HttpSource
+import org.breezyweather.common.source.LocationParametersSource
+import org.breezyweather.common.source.LocationSearchSource
+import org.breezyweather.common.source.ReverseGeocodingSource
+import org.breezyweather.common.source.SecondaryWeatherSource
+import org.breezyweather.common.source.SecondaryWeatherSourceFeature
+import org.breezyweather.settings.SourceConfigStore
+import org.breezyweather.sources.qweather.json.QWeatherAirResult
+import org.breezyweather.sources.qweather.json.QWeatherLocation
+import org.breezyweather.sources.qweather.json.QWeatherMinuteResult
+import org.breezyweather.sources.qweather.json.QWeatherWarningResult
+import retrofit2.Retrofit
+import javax.inject.Inject
+
+class QWeatherService @Inject constructor(
+    @ApplicationContext context: Context,
+    client: Retrofit.Builder
+) : HttpSource(), SecondaryWeatherSource, LocationSearchSource, ReverseGeocodingSource, LocationParametersSource, ConfigurableSource {
+    override val id = "qweather"
+    override val name = "QWeather"
+    override val privacyPolicyUrl = "https://www.qweather.com/en/terms/privacy"
+
+    override val airQualityAttribution = "QWeather"
+    override val pollenAttribution = null
+    override val minutelyAttribution = "QWeather"
+    override val alertAttribution = "QWeather"
+    override val normalsAttribution = null
+    override val locationSearchAttribution = "QWeather"
+
+    override val supportedFeaturesInSecondary = listOf(
+        SecondaryWeatherSourceFeature.FEATURE_AIR_QUALITY,
+        SecondaryWeatherSourceFeature.FEATURE_ALERT,
+        SecondaryWeatherSourceFeature.FEATURE_MINUTELY
+    )
+
+    private val mApi by lazy {
+        client
+            .baseUrl(QWEATHER_BASE_URL)
+            .build()
+            .create(QWeatherApi::class.java)
+    }
+    private val mGeoApi by lazy {
+        client
+            .baseUrl(QWEATHER_GEO_URL)
+            .build()
+            .create(QWeatherGeoApi::class.java)
+    }
+
+    // CONFIG
+    private val config = SourceConfigStore(context, id)
+    private var apikey: String
+        set(value) {
+            config.edit().putString("apikey", value).apply()
+        }
+        get() = config.getString("apikey", null) ?: ""
+
+    private fun getApiKeyOrDefault(): String {
+        return apikey.ifEmpty { BuildConfig.QWEATHER_KEY }
+    }
+
+    override val isConfigured
+        get() = getApiKeyOrDefault().isNotEmpty()
+
+    override val isRestricted
+        get() = apikey.isEmpty()
+
+    override fun getPreferences(context: Context): List<Preference> {
+        return listOf(
+            EditTextPreference(
+                titleId = R.string.settings_weather_source_qweather_api_key,
+                summary = { c, content ->
+                    content.ifEmpty {
+                        c.getString(R.string.settings_source_default_value)
+                    }
+                },
+                content = apikey,
+                onValueChanged = {
+                    apikey = it
+                }
+            )
+        )
+    }
+
+    @SuppressLint("DefaultLocale")
+    override fun requestSecondaryWeather(context: Context, location: Location, requestedFeatures: List<SecondaryWeatherSourceFeature>): Observable<SecondaryWeatherWrapper> {
+        var locationKey = location.parameters
+            .getOrElse(id) { null }?.getOrElse("locationKey") { null }
+
+        if (locationKey.isNullOrEmpty()) {
+            locationKey = "${location.longitude},${location.latitude}"
+        }
+
+        val airNow = if (requestedFeatures.contains(SecondaryWeatherSourceFeature.FEATURE_AIR_QUALITY)) {
+            mApi.getAirNow(locationKey, apikey)
+        } else {
+            Observable.create { emitter ->
+                emitter.onNext(QWeatherAirResult())
+            }
+        }
+        val warningNow = if (requestedFeatures.contains(SecondaryWeatherSourceFeature.FEATURE_ALERT)) {
+            mApi.getWarningNow(locationKey, apikey)
+        } else {
+            Observable.create { emitter ->
+                emitter.onNext(QWeatherWarningResult())
+            }
+        }
+        val minutely = if (requestedFeatures.contains(SecondaryWeatherSourceFeature.FEATURE_MINUTELY)) {
+            mApi.getMinutely("${location.longitude},${location.latitude}", apikey)
+        } else {
+            Observable.create { emitter ->
+                emitter.onNext(QWeatherMinuteResult())
+            }
+        }
+
+        return Observable.zip(airNow, warningNow, minutely) {
+                airResult: QWeatherAirResult,
+                warningResult: QWeatherWarningResult,
+                minutelyResult: QWeatherMinuteResult,
+            ->
+            convertSecondary(
+                airResult,
+                warningResult,
+                minutelyResult
+            )
+        }
+    }
+
+    override fun requestLocationSearch(context: Context, query: String): Observable<List<Location>> {
+        return mGeoApi.cityLookup(query, apikey)
+            .map { result ->
+                val locationList = mutableListOf<Location>()
+                result.location?.sortedBy(QWeatherLocation::rank)?.forEach {
+                    locationList.add(convertLocation(null, it))
+                }
+                locationList
+            }
+    }
+
+    override fun requestReverseGeocodingLocation(context: Context, location: Location): Observable<List<Location>> {
+        return mGeoApi.cityLookup("${location.longitude},${location.latitude}", apikey)
+            .map { result ->
+                val locationList = mutableListOf<Location>()
+                result.location?.forEach {
+                    locationList.add(convertLocation(location, it))
+                }
+                locationList
+            }
+    }
+
+    override fun needsLocationParametersRefresh(location: Location, coordinatesChanged: Boolean, features: List<SecondaryWeatherSourceFeature>): Boolean {
+        if (coordinatesChanged) return true
+
+        val currentLocationKey = location.parameters
+            .getOrElse(id) { null }?.getOrElse("locationKey") { null }
+
+        return currentLocationKey.isNullOrEmpty()
+    }
+
+    override fun requestLocationParameters(context: Context, location: Location): Observable<Map<String, String>> {
+        if (location.cityId != null) {
+            return Observable.just(mapOf("locationKey" to location.cityId!!))
+        }
+        return mGeoApi.cityLookup("${location.longitude},${location.latitude}", apikey).map {
+            if (!it.location?.getOrNull(0)?.id.isNullOrEmpty()) {
+                mapOf(
+                    "locationKey" to it.location?.get(0)?.id!!
+                )
+            } else {
+                throw InvalidLocationException()
+            }
+        }
+    }
+
+    companion object {
+        const val QWEATHER_BASE_URL = "https://devapi.qweather.com/v7/"
+        const val QWEATHER_GEO_URL = "https://geoapi.qweather.com/v2/"
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherAir.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherAir.kt
@@ -1,0 +1,38 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.qweather.json
+
+import kotlinx.serialization.Serializable
+import org.breezyweather.common.serializer.DateSerializer
+import java.util.Date
+
+@Serializable
+data class QWeatherAir(
+    @Serializable(DateSerializer::class) val pubTime: Date?,
+    val name: String?,
+    val id: String?,
+    val aqi: String?,
+    val level: String?,
+    val category: String?,
+    val primary: String?,
+    val pm10: String?,
+    val pm2p5: String?,
+    val no2: String?,
+    val so2: String?,
+    val co: String?,
+    val o3: String?
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherAirResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherAirResult.kt
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.qweather.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class QWeatherAirResult(
+    val code: String? = null,
+    val now: QWeatherAir? = null,
+    val station: List<QWeatherAir>? = null
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherLocation.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherLocation.kt
@@ -1,0 +1,35 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.qweather.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class QWeatherLocation(
+    val name: String?,
+    val id: String?,
+    val lat: String?,
+    val lon: String?,
+    val adm2: String?,
+    val adm1: String?,
+    val country: String?,
+    val tz: String?,
+    val utcOffset: String?,
+    val isDst: String?,
+    val type: String?,
+    val rank: String?
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherLocationResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherLocationResult.kt
@@ -1,0 +1,25 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.qweather.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class QWeatherLocationResult(
+    val code: String? = null,
+    val location: List<QWeatherLocation>? = null
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherMinute.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherMinute.kt
@@ -1,0 +1,28 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.qweather.json
+
+import kotlinx.serialization.Serializable
+import org.breezyweather.common.serializer.DateSerializer
+import java.util.Date
+
+@Serializable
+data class QWeatherMinute(
+    @Serializable(DateSerializer::class) val fxTime: Date,
+    val precip:String?,
+    val type:String?
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherMinuteResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherMinuteResult.kt
@@ -1,0 +1,29 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.qweather.json
+
+import kotlinx.serialization.Serializable
+import org.breezyweather.common.serializer.DateSerializer
+import java.util.Date
+
+@Serializable
+data class QWeatherMinuteResult(
+    val code: String? = null,
+    val summary: String? = null,
+    @Serializable(DateSerializer::class) val updateTime: Date? = null,
+    val minutely: List<QWeatherMinute>? = null
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherNow.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherNow.kt
@@ -1,0 +1,38 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.qweather.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class QWeatherNow(
+    val obsTime: String?,
+    val temp: String?,
+    val feelsLike: String?,
+    val icon: String?,
+    val text: String?,
+    val wind360: String?,
+    val windDir: String?,
+    val windScale: String?,
+    val windSpeed: String?,
+    val humidity: String?,
+    val precip: String?,
+    val pressure: String?,
+    val vis: String?,
+    val cloud: String?,
+    val dew: String?
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherNowResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherNowResult.kt
@@ -1,0 +1,25 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.qweather.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class QWeatherNowResult(
+    val code: String? = null,
+    val now: QWeatherNow? = null
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherWarning.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherWarning.kt
@@ -1,0 +1,41 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.qweather.json
+
+import kotlinx.serialization.Serializable
+import org.breezyweather.common.serializer.DateSerializer
+import java.util.Date
+
+@Serializable
+data class QWeatherWarning(
+    val id: String?,
+    val sender: String?,
+    @Serializable(DateSerializer::class) val pubTime: Date?,
+    val title: String?,
+    @Serializable(DateSerializer::class) val startTime: Date?,
+    @Serializable(DateSerializer::class) val endTime: Date?,
+    val status: String?,
+    val level: String?,
+    val severity: String?,
+    val severityColor: String?,
+    val type: String?,
+    val typeName: String?,
+    val urgency: String?,
+    val certainty: String?,
+    val text: String?,
+    val related: String?
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherWarningResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/qweather/json/QWeatherWarningResult.kt
@@ -1,0 +1,25 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.qweather.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class QWeatherWarningResult(
+    val code: String? = null,
+    val warning: List<QWeatherWarning>? = null
+)


### PR DESCRIPTION
I added a new weather API [`QWeather/和风天气`](https://dev.qweather.com/en/docs/start/), which is one of the most popular APIs in China. It is free to create a `free subscription` project and get a free API key, with a limit of 1000 requests per day. Considering its free daily forecast is only 7 days, much less than ChinaSource's 15 days, I only implemented it as a secondary source [`Comparison`](https://dev.qweather.com/en/docs/finance/subscription/#comparison)
