### PR TITLE
Use SplashScreen API and add night version of splash screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -169,6 +169,7 @@ dependencies {
     implementation(libs.core.ktx)
     implementation(libs.appcompat)
     implementation(libs.material)
+    implementation(libs.core.splashscreen)
 
     implementation(libs.cardview)
     implementation(libs.swiperefreshlayout)

--- a/app/src/debug/res/values-night-v31/colors.xml
+++ b/app/src/debug/res/values-night-v31/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- theme -->
+    <color name="colorSplashScreen">#400000</color>
+
+</resources>

--- a/app/src/debug/res/values/colors.xml
+++ b/app/src/debug/res/values/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- theme -->
+    <color name="colorSplashScreen">#800000</color>
+
+</resources>

--- a/app/src/main/java/org/breezyweather/main/MainActivity.kt
+++ b/app/src/main/java/org/breezyweather/main/MainActivity.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.res.stringResource
 import androidx.core.view.updatePadding
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
@@ -176,6 +177,8 @@ class MainActivity : GeoActivity(),
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
+
         val isLaunch = savedInstanceState == null
 
         super.onCreate(savedInstanceState)

--- a/app/src/main/res/drawable/launch_background.xml
+++ b/app/src/main/res/drawable/launch_background.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@color/ic_launcher_background" />
-    <item
-        android:drawable="@drawable/ic_launcher_foreground"
-        android:gravity="center" />
-</layer-list>

--- a/app/src/main/res/values-night-v31/colors.xml
+++ b/app/src/main/res/values-night-v31/colors.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <!-- theme -->
+    <color name="colorSplashScreen">#0a0e16</color>
+
     <!-- widget S. -->
 
     <color name="colorWidgetM3Root">@android:color/system_accent2_800</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -67,6 +67,8 @@
 
     <color name="colorNotificationSecondary">@color/secondary_text_default_material_light</color>
 
+    <color name="colorSplashScreen">#5F96D0</color>
+
     <!-- widget. -->
 
     <color name="colorWidgetRoot">@color/md_theme_surface</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -41,7 +41,7 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
 
-        <item name="colorControlHighlight">@color/colorRipple</item>
+        <item name="colorControlHighlight">@color/colorRipple_regular</item>
         <item name="colorTitleText">@color/colorTextTitle</item>
         <item name="colorBodyText">@color/colorTextContent</item>
         <item name="colorCaptionText">@color/colorTextSubtitle</item>
@@ -50,9 +50,10 @@
         <item name="actionBarSize">@dimen/action_bar_height</item>
     </style>
 
-    <style name="BreezyWeatherTheme.Main" parent="BreezyWeatherTheme">
-        <item name="android:windowBackground">@drawable/launch_background</item>
-        <item name="colorControlHighlight">@color/colorRipple_regular</item>
+    <style name="BreezyWeatherTheme.Main" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/colorSplashScreen</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <item name="postSplashScreenTheme">@style/BreezyWeatherTheme</item>
     </style>
 
     <style name="BreezyWeatherTheme.Search" parent="BreezyWeatherTheme">

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ compose = "1.7.3"
 compose-lint-checks = "1.4.1"
 compose-material3 = "1.3.0"
 core-ktx = "1.13.1"
+core-splashscreen = "1.0.1"
 dagger = "2.52"
 #datastore = "1.1.1"
 expandabletextcompose = "2.0.1"
@@ -63,6 +64,7 @@ compose-material3 = { group = "androidx.compose.material3", name = "material3", 
 compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "compose" }
 compose-ui-util = { group = "androidx.compose.ui", name = "ui-util", version.ref = "compose" }
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
+core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "core-splashscreen" }
 dagger-hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "dagger" }
 dagger-hilt-core = { group = "com.google.dagger", name = "hilt-android", version.ref = "dagger" }
 dagger-hilt-gradle = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "dagger" }


### PR DESCRIPTION
This closes #137.

The splash screen is now implemented via the [SplashScreen API](https://developer.android.com/reference/kotlin/androidx/core/splashscreen/SplashScreen) to provide a [consistent experience](https://developer.android.com/develop/ui/views/launch/splash-screen/migrate#migrate) across Android versions.

The version of the splash screen is chosen as follows:

| Android version | splash screen |
| --- | --- |
| >= 12 | light theme -> light version<br>night theme -> night version |
| < 12 | light version |

Tested on devices with Android 9 and 14.

<details>

<summary>screenshots</summary>

| theme | debug | release |
| --- | --- | --- |
| light | ![debug light](https://github.com/user-attachments/assets/ee1713fe-39f7-4825-a300-0bd5d7a17c62) | ![release light](https://github.com/user-attachments/assets/52308b24-ca0f-4a5a-a8e3-48680b55a4d7) |
| night | ![debug dark](https://github.com/user-attachments/assets/3dc74269-2501-4729-a6ca-29bfc32cac08) | ![release dark](https://github.com/user-attachments/assets/c4df367b-6eb6-4a1b-b882-0bc6a161710d) |

</details>

----

During the transition between the splash screen and the home fragment the window background (a light/dark screen) is visible for a split second before the actual layout is displayed. It is mostly noticeable in the debug version or on devices with a lower performance. 

This is also the case in the current release version 5.2.8 and probably caused by the way `updatePreviewSubviews` is called in [initView](https://github.com/breezy-weather/breezy-weather/blob/6c72013a1d913d9fee24b26c00ab8f4d6afcafea/app/src/main/java/org/breezyweather/main/fragments/HomeFragment.kt#L310-L317). As this is not related to the splash screen, I'll investigate this separately and create a new PR to fix it.

<details>

<summary>screen recording</summary>

App start with cleared cache (v5.2.8)

https://github.com/user-attachments/assets/07628db4-aa16-49be-bfac-2d8030d5fd59

</details>
