### PR TITLE
Fix position and readability of page indicator for page count > 7

### DIFF
--- a/app/src/main/java/org/breezyweather/common/ui/widgets/InkPageIndicator.kt
+++ b/app/src/main/java/org/breezyweather/common/ui/widgets/InkPageIndicator.kt
@@ -259,6 +259,10 @@ class InkPageIndicator @JvmOverloads constructor(
         setCurrentPageImmediate()
     }
 
+    private fun calculateTextSize(): Float {
+        return (mDotDiameter + mGap / 2) * 1.2F
+    }
+
     private fun setCurrentPageImmediate() {
         mCurrentPage = mSwitchView?.position ?: 0
         if (mDotCenterX.isNotEmpty() && (mMoveAnimation == null || !mMoveAnimation!!.isStarted)) {
@@ -303,7 +307,8 @@ class InkPageIndicator @JvmOverloads constructor(
     }
 
     private val desiredHeight: Int
-        get() = paddingTop + mDotDiameter + paddingBottom
+        get() = paddingBottom +
+                if (mPageCount > 7) { calculateTextSize().toInt() } else mDotDiameter
     private val requiredWidth: Int
         get() = mPageCount * mDotDiameter + (mPageCount - 1) * mGap
     private val desiredWidth: Int
@@ -321,15 +326,14 @@ class InkPageIndicator @JvmOverloads constructor(
         if (mSwitchView == null || mPageCount == 0) return
         if (mPageCount > 7) {
             val cx = measuredWidth / 2
-            val cy = measuredHeight / 2
             mTextPaint.textAlign = Paint.Align.CENTER
-            mTextPaint.textSize = (mDotDiameter + mGap / 2).toFloat()
+            mTextPaint.textSize = calculateTextSize()
             val fontMetrics = mTextPaint.fontMetrics
-            val baseLineY = (cy - fontMetrics.top - fontMetrics.bottom).toInt()
+            val baseLineY = paddingTop - fontMetrics.top - fontMetrics.bottom
             canvas.drawText(
                 (mCurrentPage + 1).toString() + "/" + mPageCount,
                 cx.toFloat(),
-                baseLineY.toFloat(),
+                baseLineY,
                 mTextPaint
             )
             return
@@ -657,9 +661,9 @@ class InkPageIndicator @JvmOverloads constructor(
 
     private fun setJoiningFraction(leftDot: Int, fraction: Float) {
         if (leftDot < mJoiningFractions.size) {
-            if (leftDot == 1) {
-                //LogHelper.log(msg = "PageIndicator", "dot 1 fraction:\t" + fraction);
-            }
+            /*if (leftDot == 1) {
+                LogHelper.log("PageIndicator", "dot 1 fraction:\t$fraction")
+            }*/
             mJoiningFractions[leftDot] = fraction
             ViewCompat.postInvalidateOnAnimation(this)
         }


### PR DESCRIPTION
This fixes the alignment of the page indicator in the home fragment when more than 7 locations exist. Previously, the indicator was cut off when using 3-button navigation. It also slightly increases the font size of the page indicator to improve the readability.

Tested on devices with Android 9, 14 and on a tablet (emulator with Android 14).

<details>

<summary>screenshots</summary>

| issue | fixed |
| --- | --- |
| ![landscape_issue](https://github.com/user-attachments/assets/6bd509ea-9084-42e3-8bd3-80a558382fac) | ![landscape_fixed](https://github.com/user-attachments/assets/6a98e3f5-c2f5-4077-a2fb-136c0f8a9f32) |
| ![portrait_issue](https://github.com/user-attachments/assets/25a94882-e654-4c3c-98fe-989566201726) | ![portrait_fixed](https://github.com/user-attachments/assets/75172976-d959-49d8-949f-6984c0011444) |

</details>
