### PR TITLE
Fixed the issue where the hourly tag view disappears after refreshing…

### DIFF
--- a/app/src/main/java/org/breezyweather/main/adapters/main/holder/HourlyViewHolder.kt
+++ b/app/src/main/java/org/breezyweather/main/adapters/main/holder/HourlyViewHolder.kt
@@ -105,6 +105,7 @@ class HourlyViewHolder(
         if (tagList.size < 2) {
             tagView.visibility = View.GONE
         } else {
+            tagView.visibility = View.VISIBLE
             val decorCount = tagView.itemDecorationCount
             for (i in 0 until decorCount) {
                 tagView.removeItemDecorationAt(0)


### PR DESCRIPTION
Once the hourly tab view is set to gone, it will never show again unless the application is restarted.
This problem can be reproduced by refreshing the weather data at intervals longer than the length of the hourly forecast.