### PR TITLE
Fixed the problem that hourly pressure was not displayed when your city is above sea level

### DIFF
--- a/app/src/main/java/org/breezyweather/main/adapters/trend/hourly/HourlyPressureAdapter.kt
+++ b/app/src/main/java/org/breezyweather/main/adapters/trend/hourly/HourlyPressureAdapter.kt
@@ -150,8 +150,6 @@ class HourlyPressureAdapter(
                 i += 2
             }
         }
-        mHighestPressure = PressureUnit.NORMAL.toFloat()
-        mLowestPressure = PressureUnit.NORMAL.toFloat()
         weather.nextHourlyForecast
             .forEach { hourly ->
                 hourly.pressure?.let {
@@ -178,10 +176,7 @@ class HourlyPressureAdapter(
     override fun getItemCount() = location.weather!!.nextHourlyForecast.size
 
     override fun isValid(location: Location): Boolean {
-        return mHighestPressure != null &&
-            mLowestPressure != null &&
-            mHighestPressure != PressureUnit.NORMAL.toFloat() &&
-            mLowestPressure != PressureUnit.NORMAL.toFloat()
+        return location.weather?.nextHourlyForecast?.any { it.pressure != null } == true
     }
 
     override fun getDisplayName(context: Context) = context.getString(R.string.tag_pressure)


### PR DESCRIPTION
When a city's altitude is above sea level, the air pressure is always lower than `PressureUnit.NORMAL`. So `mHighestPressure` will always be `PressureUnit.NORMAL`, which causes the `isValid` method to constantly return false.

On the other hand, fixing the highest pressure or lowest pressure at `PressureUnit.NORMAL` will make the curve too straight when the city is on a plateau.