### PR TITLE
Patch CWA wind speed forecast and add human-written summary

### DIFF
--- a/app/src/src_nonfreenet/org/breezyweather/sources/cwa/CwaApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/cwa/CwaApi.kt
@@ -19,6 +19,7 @@ package org.breezyweather.sources.cwa
 import io.reactivex.rxjava3.core.Observable
 import okhttp3.RequestBody
 import org.breezyweather.sources.cwa.json.CwaAlertResult
+import org.breezyweather.sources.cwa.json.CwaAssistantResult
 import org.breezyweather.sources.cwa.json.CwaAstroResult
 import org.breezyweather.sources.cwa.json.CwaLocationResult
 import org.breezyweather.sources.cwa.json.CwaNormalsResult
@@ -68,4 +69,12 @@ interface CwaApi {
         @Query("weatherElement") weatherElement: String,
         @Query("Month") month: String
     ): Observable<CwaNormalsResult>
+
+    @GET("fileapi/v1/opendataapi/{endpoint}")
+    fun getAssistant(
+        @Path("endpoint") endpoint: String,
+        @Query("Authorization") apiKey: String,
+        @Query("downloadType") downloadType: String,
+        @Query("format") format: String
+    ): Observable<CwaAssistantResult>
 }

--- a/app/src/src_nonfreenet/org/breezyweather/sources/cwa/CwaGeoLookup.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/cwa/CwaGeoLookup.kt
@@ -174,3 +174,33 @@ val CWA_TOWNSHIP_WARNING_AREAS = mapOf<String, String>(
     "67000250" to "M", // 臺南市南化區 Nanhua District, Tainan City
     "68000130" to "M"  // 桃園市復興區 Fuxing District, Taoyuan City
 )
+
+// API endpoints for "Weather Assistant", a collection of human-written text-based
+// forecast summary for the general public. "Assistants" are organized by counties.
+// List of endpoints can be seen on this page:
+// https://opendata.cwa.gov.tw/dataset/all?page=1
+// Search for 天氣小幫手
+val CWA_ASSISTANT_ENDPOINTS = mapOf<String, String>(
+    "臺北市" to "F-C0032-009", // Taipei City
+    "新北市" to "F-C0032-010", // New Taipei City
+    "基隆市" to "F-C0032-011", // Keelung City
+    "花蓮縣" to "F-C0032-012", // Hualien County
+    "宜蘭縣" to "F-C0032-013", // Yilan County
+    "金門縣" to "F-C0032-014", // Kinmen County
+    "澎湖縣" to "F-C0032-015", // Penghu County
+    "臺南市" to "F-C0032-016", // Tainan City
+    "高雄市" to "F-C0032-017", // Kaohsiung City
+    "嘉義縣" to "F-C0032-018", // Chiayi County
+    "嘉義市" to "F-C0032-019", // Chiayi City
+    "苗栗縣" to "F-C0032-020", // Miaoli County
+    "臺中市" to "F-C0032-021", // Taichung City
+    "桃園市" to "F-C0032-022", // Taoyuan City
+    "新竹縣" to "F-C0032-023", // Hsinchu County
+    "新竹市" to "F-C0032-024", // Hsinchu City
+    "屏東縣" to "F-C0032-025", // Pingtung County
+    "南投縣" to "F-C0032-026", // Nantou County
+    "臺東縣" to "F-C0032-027", // Taitung County
+    "彰化縣" to "F-C0032-028", // Changhua County
+    "雲林縣" to "F-C0032-029", // Yunlin County
+    "連江縣" to "F-C0032-030"  // Lienchiang County
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/cwa/json/CwaAssistantDataSet.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/cwa/json/CwaAssistantDataSet.kt
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.cwa.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CwaAssistantDataSet(
+    val parameterSet: CwaAssistantParameterSet? = null
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/cwa/json/CwaAssistantOpenData.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/cwa/json/CwaAssistantOpenData.kt
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.cwa.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CwaAssistantOpenData(
+    val dataset: CwaAssistantDataSet? = null
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/cwa/json/CwaAssistantParameter.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/cwa/json/CwaAssistantParameter.kt
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.cwa.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CwaAssistantParameter(
+    val parameterValue: String?
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/cwa/json/CwaAssistantParameterSet.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/cwa/json/CwaAssistantParameterSet.kt
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.cwa.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CwaAssistantParameterSet(
+    val parameter: List<CwaAssistantParameter>?
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/cwa/json/CwaAssistantResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/cwa/json/CwaAssistantResult.kt
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.cwa.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CwaAssistantResult(
+    val cwaopendata: CwaAssistantOpenData? = null
+)


### PR DESCRIPTION
Two changes to the CWA source:

1. Added endpoint for "Weather Assistant" – human-written forecast summaries prepared every 12 hours on a per-county basis. The text is added to `dailyForecast`.
2. Patched wind speed forecast. CWA APIs return `>= 11` for very windy forecast periods. I have emailed them about this issue. They replied that because they can't predict wind speed for extreme high winds with precision, they would not return any other value for very windy times. In this case, it's better to at least have 11m/s on the wind charts than complete blanks.