### PR TITLE
Fix dialogs being offset in MainActivity in landscape mode

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -41,6 +41,12 @@
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
 
+        <!-- Reset flag to default to fix a bug in the SplashScreen API which keeps an incorrect
+         value for the postSplashScreenTheme causing layouts to be unintentionally offset into the
+         display cutout area in landscape mode.
+         Related issue: https://issuetracker.google.com/issues/214408199 -->
+        <item name="android:windowLayoutInDisplayCutoutMode" tools:ignore="NewApi">default</item>
+
         <item name="colorControlHighlight">@color/colorRipple_regular</item>
         <item name="colorTitleText">@color/colorTextTitle</item>
         <item name="colorBodyText">@color/colorTextContent</item>


### PR DESCRIPTION
This fixes an issue where dialogs in the MainActivity were not centered correctly in landscape mode due to an [issue](https://issuetracker.google.com/issues/214408199) in the SplashScreen API.

While the issue was fixed in [v1.2.0-alpha1](https://developer.android.com/jetpack/androidx/releases/core?hl=en#core-splashscreen-1.2.0-alpha01) for [API 30 and higher](https://android.googlesource.com/platform/frameworks/support/+/135f0021da98da2c3538eecd70399bf17d974847), it is not fixed for lower APIs supporting display cutouts. This PR fixes it for all API levels.

Successfully tested on the following devices: Google Pixel 6a (Android 15), Samsung Galaxy S24 (Android 14), an emulated device with display cutout (Android 9) and an emulated device without display cutout (Android 7.1.1).

<details>

<summary>screenshots</summary>

| issue | fix |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/b14bac40-96e7-48ba-9d0f-2dda4a252a76" width=95%> | <img src="https://github.com/user-attachments/assets/aa6d7826-1b6c-423b-acf2-5cdc59755990" width=95%> |

</details>
