### PR TITLE
added MeteoLux as a new source

### DIFF
--- a/app/src/main/java/org/breezyweather/common/source/LocationPreset.kt
+++ b/app/src/main/java/org/breezyweather/common/source/LocationPreset.kt
@@ -60,6 +60,7 @@ enum class LocationPreset(
     FRANCE_FREENET("openmeteo", pollen = "recosante"),
     IRELAND("metie", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo", normals = "accu"),
     ITALY("meteoam", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo", normals = "accu"),
+    LUXEMBOURG("meteolux", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo", normals = "accu"),
     NORWAY("metno", pollen = "openmeteo", alert = "accu", normals = "accu"),
     SWEDEN(
         "smhi",
@@ -98,6 +99,7 @@ enum class LocationPreset(
                     "FR" -> FRANCE
                     "IE" -> IRELAND
                     "IT", "SM", "VA" -> ITALY
+                    "LU" -> LUXEMBOURG
                     "NO" -> NORWAY
                     "SE" -> SWEDEN
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -700,4 +700,17 @@
     <string name="common_weather_text_mist">Feiner Nebel</string>
     <string name="common_weather_text_dry">Trocken</string>
     <string name="common_weather_text_hot">Heiß</string>
+    <string name="meteolux_warning_text_wind">Windwarnung</string>
+    <string name="meteolux_warning_text_rain">Regenwarnung</string>
+    <string name="meteolux_warning_text_snow">Schneewarnung</string>
+    <string name="meteolux_warning_text_black_ice">Glatteiswarnung</string>
+    <string name="meteolux_warning_text_thunderstorm">Gewitterwarnung</string>
+    <string name="meteolux_warning_text_heat">Hitzewarnung</string>
+    <string name="meteolux_warning_text_cold">Kältewarnung</string>
+    <string name="meteolux_warning_text_flood">Hochwasserwarnung*</string>
+    <string name="meteolux_warning_text_ozone">Ozongehalt in der Außenluft*</string>
+    <string name="meteolux_warning_text_pm">Feinstaub (PM) in der Außenluft*</string>
+    <string name="meteolux_warning_text_level_2">Potenzielle Gefahr</string>
+    <string name="meteolux_warning_text_level_3">Gefahr</string>
+    <string name="meteolux_warning_text_level_4">Große Gefahr</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -720,7 +720,7 @@
     <string name="about_matrix">Salon Matrix</string>
 
     <string name="null_data_text">N/A</string>
-    <string name="colon_separator" translatable="false">\u0020:\u0020</string>
+    <string name="colon_separator">\u0020:\u0020</string>
     <string name="notification_update_error">%d mise(s) à jour en échec</string>
     <string name="common_weather_text_snow_light">Neige légère</string>
     <string name="common_weather_text_snow_moderate">Neige modérée</string>
@@ -759,4 +759,17 @@
     <string name="meteoam_weather_text_tornado_watersprout">Trombe terrestre ou marine</string>
     <string name="common_weather_text_smoke">Fumée</string>
     <string name="metno_weather_text_andthunder">%s et tonnerre</string>
+    <string name="meteolux_warning_text_wind">Avis de vent</string>
+    <string name="meteolux_warning_text_rain">Avis de pluie</string>
+    <string name="meteolux_warning_text_snow">Avis de neige</string>
+    <string name="meteolux_warning_text_black_ice">Avis de verglas</string>
+    <string name="meteolux_warning_text_thunderstorm">Avis d’orages</string>
+    <string name="meteolux_warning_text_heat">Avis de chaleur</string>
+    <string name="meteolux_warning_text_cold">Avis de froid</string>
+    <string name="meteolux_warning_text_flood">Avis de crue*</string>
+    <string name="meteolux_warning_text_ozone">Ozone dans l’air*</string>
+    <string name="meteolux_warning_text_pm">Particules fines (PM) dans l’air*</string>
+    <string name="meteolux_warning_text_level_2">Danger potentiel</string>
+    <string name="meteolux_warning_text_level_3">Danger</string>
+    <string name="meteolux_warning_text_level_4">Danger important</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -974,6 +974,20 @@
     <string name="smg_warning_text_storm_surge_red" translatable="false">Red Storm Surge Warning</string>
     <string name="smg_warning_text_storm_surge_black" translatable="false">Black Storm Surge Warning</string>
     <string name="smg_warning_text_tsunami" translatable="false">Tsunami Warning Signal</string>
+    <!-- Warning texts for MeteoLux -->
+    <string name="meteolux_warning_text_wind" translatable="false">Wind warning</string>
+    <string name="meteolux_warning_text_rain" translatable="false">Rain warning</string>
+    <string name="meteolux_warning_text_snow" translatable="false">Snow warning</string>
+    <string name="meteolux_warning_text_black_ice" translatable="false">Black ice warning</string>
+    <string name="meteolux_warning_text_thunderstorm" translatable="false">Thunderstorm warning</string>
+    <string name="meteolux_warning_text_heat" translatable="false">Heat warning</string>
+    <string name="meteolux_warning_text_cold" translatable="false">Cold warning</string>
+    <string name="meteolux_warning_text_flood" translatable="false">Flood warning*</string>
+    <string name="meteolux_warning_text_ozone" translatable="false">Ozone in the air*</string>
+    <string name="meteolux_warning_text_pm" translatable="false">Particle pollution (PM) in the air*</string>
+    <string name="meteolux_warning_text_level_2" translatable="false">Potential danger</string>
+    <string name="meteolux_warning_text_level_3" translatable="false">Danger</string>
+    <string name="meteolux_warning_text_level_4" translatable="false">Significant danger</string>
     <!-- Do NOT translate everything below -->
     <!-- Widgets -->
     <string name="widget_custom_subtitle_keyword_cw" translatable="false">$cw$</string>

--- a/app/src/src_nonfreenet/org/breezyweather/sources/SourceManager.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/SourceManager.kt
@@ -53,6 +53,7 @@ import org.breezyweather.sources.imd.ImdService
 import org.breezyweather.sources.ims.ImsService
 import org.breezyweather.sources.ipsb.IpSbLocationService
 import org.breezyweather.sources.meteoam.MeteoAmService
+import org.breezyweather.sources.meteolux.MeteoLuxService
 import org.breezyweather.sources.metie.MetIeService
 import org.breezyweather.sources.metno.MetNoService
 import org.breezyweather.sources.metoffice.MetOfficeService
@@ -91,6 +92,7 @@ class SourceManager @Inject constructor(
     imsService: ImsService,
     ipSbService: IpSbLocationService,
     meteoAmService: MeteoAmService,
+    meteoLuxService: MeteoLuxService,
     metIeService: MetIeService,
     metNoService: MetNoService,
     metOfficeService: MetOfficeService,
@@ -149,6 +151,7 @@ class SourceManager @Inject constructor(
         imdService,
         imsService,
         meteoAmService,
+        meteoLuxService,
         metIeService,
         metOfficeService,
         mfService,

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/MeteoLuxApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/MeteoLuxApi.kt
@@ -1,0 +1,31 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteolux
+
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.sources.meteolux.json.MeteoLuxWeatherResult
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface MeteoLuxApi {
+    @GET("api/v1/metapp/weather")
+    fun getWeather(
+        @Query("langcode") language: String = "en",
+        @Query("lat") lat: Double,
+        @Query("long") lon: Double,
+    ): Observable<MeteoLuxWeatherResult>
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/MeteoLuxResultConverter.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/MeteoLuxResultConverter.kt
@@ -1,0 +1,438 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteolux
+
+import android.content.Context
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.weather.model.Alert
+import breezyweather.domain.weather.model.AlertSeverity
+import breezyweather.domain.weather.model.Astro
+import breezyweather.domain.weather.model.Current
+import breezyweather.domain.weather.model.Daily
+import breezyweather.domain.weather.model.HalfDay
+import breezyweather.domain.weather.model.Precipitation
+import breezyweather.domain.weather.model.Temperature
+import breezyweather.domain.weather.model.UV
+import breezyweather.domain.weather.model.WeatherCode
+import breezyweather.domain.weather.model.Wind
+import breezyweather.domain.weather.wrappers.HourlyWrapper
+import breezyweather.domain.weather.wrappers.SecondaryWeatherWrapper
+import breezyweather.domain.weather.wrappers.WeatherWrapper
+import com.google.maps.android.SphericalUtil
+import com.google.maps.android.model.LatLng
+import org.breezyweather.R
+import org.breezyweather.common.exceptions.InvalidLocationException
+import org.breezyweather.common.source.SecondaryWeatherSourceFeature
+import org.breezyweather.sources.meteolux.json.MeteoLuxWeatherResult
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+fun convert(
+    location: Location,
+    weatherResult: MeteoLuxWeatherResult,
+): Location {
+    if (weatherResult.city?.lat == null || weatherResult.city.long == null) {
+        throw InvalidLocationException()
+    }
+    // Make sure location is within 50km of a known location in Luxembourg
+    val distance = SphericalUtil.computeDistanceBetween(
+        LatLng(location.latitude, location.longitude),
+        LatLng(weatherResult.city.lat, weatherResult.city.long)
+    )
+    if (distance > 50000) {
+        throw InvalidLocationException()
+    }
+    return location.copy(
+        latitude = location.latitude,
+        longitude = location.longitude,
+        timeZone = "Europe/Luxembourg",
+        country = "Luxembourg",
+        countryCode = "LU",
+        admin1 = weatherResult.city.canton,
+        city = weatherResult.city.name ?: ""
+    )
+}
+
+fun convert(
+    context: Context,
+    weatherResult: MeteoLuxWeatherResult,
+    ignoreFeatures: List<SecondaryWeatherSourceFeature>,
+): WeatherWrapper {
+    return WeatherWrapper(
+        current = if (!ignoreFeatures.contains(SecondaryWeatherSourceFeature.FEATURE_CURRENT)) {
+            getCurrent(context, weatherResult)
+        } else {
+            null
+        },
+        dailyForecast = getDailyForecast(context, weatherResult),
+        hourlyForecast = getHourlyForecast(context, weatherResult),
+        alertList = if (!ignoreFeatures.contains(SecondaryWeatherSourceFeature.FEATURE_ALERT)) {
+            getAlertList(context, weatherResult)
+        } else {
+            null
+        }
+    )
+}
+
+fun convertSecondary(
+    context: Context,
+    weatherResult: MeteoLuxWeatherResult,
+    requestedFeatures: List<SecondaryWeatherSourceFeature>,
+): SecondaryWeatherWrapper {
+    return SecondaryWeatherWrapper(
+        current = if (requestedFeatures.contains(SecondaryWeatherSourceFeature.FEATURE_CURRENT)) {
+            getCurrent(context, weatherResult)
+        } else {
+            null
+        },
+        alertList = if (requestedFeatures.contains(SecondaryWeatherSourceFeature.FEATURE_ALERT)) {
+            getAlertList(context, weatherResult)
+        } else {
+            null
+        }
+    )
+}
+
+private fun getCurrent(
+    context: Context,
+    weatherResult: MeteoLuxWeatherResult,
+): Current? {
+    return weatherResult.forecast?.current?.let {
+        Current(
+            weatherText = getWeatherText(context, it.icon?.id),
+            weatherCode = getWeatherCode(it.icon?.id),
+            temperature = Temperature(
+                temperature = it.temperature?.temperature,
+                apparentTemperature = it.temperature?.felt
+            ),
+            wind = Wind(
+                degree = getWindDirection(it.wind?.direction),
+                speed = getRangeMax(it.wind?.speed)?.div(3.6), // convert km/h to m/s
+                gusts = getRangeMax(it.wind?.gusts)?.div(3.6) // convert km/h to m/s
+            )
+        )
+    }
+}
+
+private fun getDailyForecast(
+    context: Context,
+    weatherResult: MeteoLuxWeatherResult,
+): List<Daily> {
+    val dailyList = mutableListOf<Daily>()
+    val formatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ENGLISH)
+    formatter.timeZone = TimeZone.getTimeZone("Europe/Luxembourg")
+    val timeRegex = Regex("""^\d{2}:\d{2}$""")
+    weatherResult.forecast?.daily?.forEach {
+        dailyList.add(
+            Daily(
+                date = formatter.parse(it.date)!!,
+                day = HalfDay(
+                    weatherText = getWeatherText(context, it.icon?.id),
+                    weatherCode = getWeatherCode(it.icon?.id),
+                    temperature = Temperature(
+                        temperature = it.temperatureMax?.temperature,
+                        apparentTemperature = it.temperatureMax?.felt
+                    ),
+                    precipitation = Precipitation(
+                        rain = getRangeMax(it.rain),
+                        snow = getRangeMax(it.snow)?.times(10.0) // convert cm to mm
+                    ),
+                    wind = Wind(
+                        degree = getWindDirection(it.wind?.direction),
+                        speed = getRangeMax(it.wind?.speed)?.div(3.6), // convert km/h to m/s
+                        gusts = getRangeMax(it.wind?.gusts)?.div(3.6) // convert km/h to m/s
+                    )
+                ),
+                night = HalfDay(
+                    weatherText = getWeatherText(context, it.icon?.id),
+                    weatherCode = getWeatherCode(it.icon?.id),
+                    temperature = Temperature(
+                        temperature = it.temperatureMin?.temperature,
+                        apparentTemperature = it.temperatureMin?.felt
+                    ),
+                    wind = Wind(
+                        degree = getWindDirection(it.wind?.direction),
+                        speed = getRangeMax(it.wind?.speed)?.div(3.6), // convert km/h to m/s
+                        gusts = getRangeMax(it.wind?.gusts)?.div(3.6) // convert km/h to m/s
+                    )
+                ),
+                sun = if (weatherResult.ephemeris?.date != null && it.date.startsWith(weatherResult.ephemeris.date)) {
+                    Astro(
+                        riseDate = weatherResult.ephemeris.sunrise?.let { sunrise ->
+                            if (timeRegex.matches(sunrise)) {
+                                formatter.parse(it.date.substringBefore("T") + "T" + sunrise + ":00")
+                            } else {
+                                null
+                            }
+                        },
+                        setDate = weatherResult.ephemeris.sunset?.let { sunset ->
+                            if (timeRegex.matches(sunset)) {
+                                formatter.parse(it.date.substringBefore("T") + "T" + sunset + ":00")
+                            } else {
+                                null
+                            }
+                        }
+                    )
+                } else {
+                    null
+                },
+                moon = if (weatherResult.ephemeris?.date != null && it.date.startsWith(weatherResult.ephemeris.date)) {
+                    Astro(
+                        riseDate = weatherResult.ephemeris.moonrise?.let { moonrise ->
+                            if (timeRegex.matches(moonrise)) {
+                                formatter.parse(it.date.substringBefore("T") + "T" + moonrise + ":00")
+                            } else {
+                                null
+                            }
+                        },
+                        setDate = weatherResult.ephemeris.moonset?.let { moonset ->
+                            if (timeRegex.matches(moonset)) {
+                                formatter.parse(it.date.substringBefore("T") + "T" + moonset + ":00")
+                            } else {
+                                null
+                            }
+                        }
+                    )
+                } else {
+                    null
+                },
+                uV = UV(
+                    index = it.uvIndex
+                ),
+                sunshineDuration = it.sunshine
+            )
+        )
+    }
+    return dailyList
+}
+
+private fun getHourlyForecast(
+    context: Context,
+    weatherResult: MeteoLuxWeatherResult,
+): List<HourlyWrapper> {
+    val hourlyList = mutableListOf<HourlyWrapper>()
+    val formatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ENGLISH)
+    formatter.timeZone = TimeZone.getTimeZone("Europe/Luxembourg")
+    weatherResult.forecast?.hourly?.forEach {
+        hourlyList.add(
+            HourlyWrapper(
+                date = formatter.parse(it.date)!!,
+                weatherText = getWeatherText(context, it.icon?.id),
+                weatherCode = getWeatherCode(it.icon?.id),
+                temperature = Temperature(
+                    temperature = it.temperature?.temperature?.average(),
+                    apparentTemperature = it.temperature?.felt
+                ),
+                precipitation = Precipitation(
+                    rain = getRangeMax(it.rain),
+                    snow = getRangeMax(it.snow)?.times(10) // convert cm to mm
+                ),
+                wind = Wind(
+                    degree = getWindDirection(it.wind?.direction),
+                    speed = getRangeMax(it.wind?.speed)?.div(3.6), // convert km/h to m/s
+                    gusts = getRangeMax(it.wind?.gusts)?.div(3.6) // convert km/h to m/s
+                )
+            )
+        )
+    }
+    return hourlyList
+}
+
+private fun getAlertList(
+    context: Context,
+    weatherResult: MeteoLuxWeatherResult,
+): List<Alert> {
+    val alertList = mutableListOf<Alert>()
+    var severity: AlertSeverity
+
+    weatherResult.vigilances?.forEach {
+        severity = when (it.level) {
+            2 -> AlertSeverity.MODERATE
+            3 -> AlertSeverity.SEVERE
+            4 -> AlertSeverity.EXTREME
+            else -> AlertSeverity.UNKNOWN
+        }
+        if (it.region == "all" ||
+            (it.region ?: "").uppercase().startsWith((weatherResult.city?.region ?: "").uppercase())
+        ) {
+            alertList.add(
+                Alert(
+                    alertId = "${it.type} ${it.level} ${it.datetimeStart}",
+                    startDate = it.datetimeStart,
+                    endDate = it.datetimeEnd,
+                    headline = getAlertHeadline(
+                        context = context,
+                        type = it.type,
+                        level = it.level
+                    ),
+                    description = it.description,
+                    source = "MeteoLux",
+                    severity = severity,
+                    color = Alert.colorFromSeverity(severity)
+                )
+            )
+        }
+    }
+    return alertList
+}
+
+private fun getWeatherText(
+    context: Context,
+    icon: Int?,
+): String? {
+    // These icon codes are not the same as those from
+    // https://metapi.ana.lu/api/v1/metapp/text?lang=en
+    //
+    // TODO: Check the correct text for the following icon codes:
+    // 15: may be "freezing fog"
+    // 20: may be "heavy rain and drizzle"
+    // 50: may be "thunderstorm with rain and snow mixed"
+    // 51: may be "light thunder snowstorm"
+    // 52: may be "thunder snowstorm"
+    // 48: migrate string to common_weather_text?
+    // 53: migrate string to common_weather_text?
+    //
+    // The meaning of the following icon codes are unclear:
+    // 28, 29 -> sun/moon, cloud, and solid circles??
+    // 47 -> two lightning bolts with solid circles??
+    // 57 -> sun, cloud, thunder, no precipitation?
+    // 58 -> sun, cloud, thunder rain shower?
+    // 59 -> sun, cloud, thunder snow shower?
+    return when (icon) {
+        1, 7 -> context.getString(R.string.common_weather_text_clear_sky)
+        2, 8 -> context.getString(R.string.common_weather_text_mainly_clear)
+        3, 9 -> context.getString(R.string.common_weather_text_partly_cloudy)
+        4, 10 -> context.getString(R.string.common_weather_text_cloudy)
+        5 -> context.getString(R.string.common_weather_text_overcast)
+        12, 13 -> context.getString(R.string.common_weather_text_mist)
+        14, 15 -> context.getString(R.string.common_weather_text_fog)
+        17 -> context.getString(R.string.common_weather_text_drizzle_light)
+        18 -> context.getString(R.string.common_weather_text_drizzle)
+        19, 20 -> context.getString(R.string.common_weather_text_drizzle_heavy)
+        21 -> context.getString(R.string.common_weather_text_rain_light)
+        22 -> context.getString(R.string.common_weather_text_rain_moderate)
+        23 -> context.getString(R.string.common_weather_text_rain_heavy)
+        24 -> context.getString(R.string.common_weather_text_rain_snow_mixed)
+        25 -> context.getString(R.string.common_weather_text_snow_light)
+        26 -> context.getString(R.string.common_weather_text_snow)
+        27 -> context.getString(R.string.common_weather_text_rain_freezing)
+        30, 36 -> context.getString(R.string.common_weather_text_rain_showers_light)
+        31, 37 -> context.getString(R.string.common_weather_text_rain_showers_heavy)
+        32, 38 -> context.getString(R.string.common_weather_text_rain_snow_mixed_showers)
+        33, 39 -> context.getString(R.string.common_weather_text_snow_showers_light)
+        34, 40 -> context.getString(R.string.common_weather_text_snow_showers_heavy)
+        35, 41 -> context.getString(R.string.weather_kind_hail)
+        42, 57 -> context.getString(R.string.weather_kind_thunder)
+        43 -> context.getString(R.string.common_weather_text_rain_snow_mixed_light)
+        44, 45 -> context.getString(R.string.common_weather_text_rain_snow_mixed_showers_light)
+        48 -> context.getString(R.string.openmeteo_weather_text_thunderstorm_slight_or_moderate)
+        49, 51, 52, 58, 59 -> context.getString(R.string.weather_kind_thunderstorm)
+        53 -> context.getString(R.string.openmeteo_weather_text_thunderstorm_with_heavy_hail)
+        54 -> context.getString(R.string.weather_kind_wind)
+        55 -> context.getString(R.string.common_weather_text_hot)
+        56 -> context.getString(R.string.common_weather_text_cold)
+        else -> null
+    }
+}
+
+private fun getWeatherCode(
+    icon: Int?,
+): WeatherCode? {
+    return when (icon) {
+        1, 2, 7, 8 -> WeatherCode.CLEAR
+        3, 9 -> WeatherCode.PARTLY_CLOUDY
+        4, 5, 10 -> WeatherCode.CLOUDY
+        12, 13, 14, 15 -> WeatherCode.FOG
+        17, 18, 19, 20, 21, 22, 23, 30, 31, 36, 37 -> WeatherCode.RAIN
+        24, 27, 32, 38, 43, 44, 45 -> WeatherCode.SLEET
+        25, 26, 33, 34, 39, 40 -> WeatherCode.SNOW
+        35, 41 -> WeatherCode.HAIL
+        54 -> WeatherCode.WIND
+        42 -> WeatherCode.THUNDER
+        48, 49, 50, 51, 52, 53 -> WeatherCode.THUNDERSTORM
+        // 28, 29 -> sun/moon, cloud, and round drops??
+        // 47 -> two lightnings with solid round drops?
+        // 55 -> hot
+        // 56 -> cold
+        // 57 -> sun cloud thunder?
+        // 58 -> sun cloud thunder rain?
+        // 59 -> sun cloud thunder snow?
+        else -> null
+    }
+}
+
+private fun getWindDirection(
+    direction: String?,
+): Double? {
+    return when (direction) {
+        "N" -> 0.0
+        "NE" -> 45.0
+        "E" -> 90.0
+        "SE" -> 135.0
+        "S" -> 180.0
+        "SO" -> 225.0
+        "O" -> 270.0
+        "NO" -> 315.0
+        "VAR" -> -1.0
+        else -> null
+    }
+}
+
+private fun getRangeMax(
+    speed: String?,
+): Double? {
+    if (speed == null) {
+        return null
+    }
+    val speedRangeRegex = Regex("""(\d+)$""")
+    val matchResult = speedRangeRegex.find(speed)
+    return matchResult?.groups?.get(1)?.value?.toDoubleOrNull()
+}
+
+// Source: https://metapi.ana.lu/api/v1/metapp/text?lang=en
+private fun getAlertHeadline(
+    context: Context,
+    type: Int?,
+    level: Int?,
+): String? {
+    var headline = when (type) {
+        2 -> context.getString(R.string.meteolux_warning_text_wind)
+        3 -> context.getString(R.string.meteolux_warning_text_rain)
+        4 -> context.getString(R.string.meteolux_warning_text_snow)
+        5 -> context.getString(R.string.meteolux_warning_text_black_ice)
+        6 -> context.getString(R.string.meteolux_warning_text_thunderstorm)
+        9 -> context.getString(R.string.meteolux_warning_text_heat)
+        10 -> context.getString(R.string.meteolux_warning_text_cold)
+        11 -> context.getString(R.string.meteolux_warning_text_flood)
+        13 -> context.getString(R.string.meteolux_warning_text_ozone)
+        14 -> context.getString(R.string.meteolux_warning_text_pm)
+        else -> null
+    }
+
+    // warning types 11, 13, 14 are not issued by MeteoLux
+    // and therefore not assigned text to go with warning levels
+    if (listOf(2, 3, 4, 5, 6, 9, 10).contains(type)) {
+        headline += when (level) {
+            2 -> " - " + context.getString(R.string.meteolux_warning_text_level_2)
+            3 -> " - " + context.getString(R.string.meteolux_warning_text_level_3)
+            4 -> " - " + context.getString(R.string.meteolux_warning_text_level_4)
+            else -> ""
+        }
+    }
+    return headline
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/MeteoLuxService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/MeteoLuxService.kt
@@ -1,0 +1,177 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteolux
+
+import android.content.Context
+import android.graphics.Color
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.weather.wrappers.SecondaryWeatherWrapper
+import breezyweather.domain.weather.wrappers.WeatherWrapper
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.common.exceptions.SecondaryWeatherException
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
+import org.breezyweather.common.source.HttpSource
+import org.breezyweather.common.source.MainWeatherSource
+import org.breezyweather.common.source.ReverseGeocodingSource
+import org.breezyweather.common.source.SecondaryWeatherSource
+import org.breezyweather.common.source.SecondaryWeatherSourceFeature
+import retrofit2.Retrofit
+import javax.inject.Inject
+import javax.inject.Named
+
+class MeteoLuxService @Inject constructor(
+    @ApplicationContext context: Context,
+    @Named("JsonClient") client: Retrofit.Builder,
+) : HttpSource(), MainWeatherSource, SecondaryWeatherSource, ReverseGeocodingSource {
+
+    override val id = "meteolux"
+    override val name = "MeteoLux"
+    override val privacyPolicyUrl by lazy {
+        with(context.currentLocale.code) {
+            when {
+                startsWith("fr") -> "https://ana.gouvernement.lu/fr/support/politique-confidentialite-meteolux.html"
+                startsWith("de") -> "https://ana.gouvernement.lu/de/support/politique-confidentialite-meteolux.html"
+                else -> "https://ana.gouvernement.lu/en/support/politique-confidentialite-meteolux.html"
+            }
+        }
+    }
+
+    override val color = Color.rgb(7, 84, 91)
+    override val weatherAttribution = "MeteoLux"
+
+    private val mApi by lazy {
+        client
+            .baseUrl(METEOLUX_BASE_URL)
+            .build()
+            .create(MeteoLuxApi::class.java)
+    }
+
+    override val supportedFeaturesInMain = listOf(
+        SecondaryWeatherSourceFeature.FEATURE_CURRENT,
+        SecondaryWeatherSourceFeature.FEATURE_ALERT
+    )
+
+    override fun isFeatureSupportedInMainForLocation(
+        location: Location,
+        feature: SecondaryWeatherSourceFeature?,
+    ): Boolean {
+        return location.countryCode.equals("LU", ignoreCase = true)
+    }
+
+    override fun requestWeather(
+        context: Context,
+        location: Location,
+        ignoreFeatures: List<SecondaryWeatherSourceFeature>,
+    ): Observable<WeatherWrapper> {
+        return mApi.getWeather(
+            language = with(context.currentLocale.code) {
+                when {
+                    startsWith("de") -> "de"
+                    startsWith("fr") -> "fr"
+                    startsWith("lb") -> "lb"
+                    else -> "en"
+                }
+            },
+            lat = location.latitude,
+            lon = location.longitude
+        ).map {
+            convert(
+                context = context,
+                weatherResult = it,
+                ignoreFeatures = ignoreFeatures
+            )
+        }
+    }
+
+    // SECONDARY WEATHER SOURCE
+    override val supportedFeaturesInSecondary = listOf(
+        SecondaryWeatherSourceFeature.FEATURE_CURRENT,
+        SecondaryWeatherSourceFeature.FEATURE_ALERT
+    )
+    override fun isFeatureSupportedInSecondaryForLocation(
+        location: Location,
+        feature: SecondaryWeatherSourceFeature,
+    ): Boolean {
+        return isFeatureSupportedInMainForLocation(location, feature)
+    }
+    override val currentAttribution = weatherAttribution
+    override val airQualityAttribution = null
+    override val pollenAttribution = null
+    override val minutelyAttribution = null
+    override val alertAttribution = weatherAttribution
+    override val normalsAttribution = null
+
+    override fun requestSecondaryWeather(
+        context: Context,
+        location: Location,
+        requestedFeatures: List<SecondaryWeatherSourceFeature>,
+    ): Observable<SecondaryWeatherWrapper> {
+        if (!isFeatureSupportedInSecondaryForLocation(location, SecondaryWeatherSourceFeature.FEATURE_ALERT) ||
+            !isFeatureSupportedInSecondaryForLocation(location, SecondaryWeatherSourceFeature.FEATURE_CURRENT)
+        ) {
+            // TODO: return Observable.error(UnsupportedFeatureForLocationException())
+            return Observable.error(SecondaryWeatherException())
+        }
+
+        return mApi.getWeather(
+            language = with(context.currentLocale.code) {
+                when {
+                    startsWith("de") -> "de"
+                    startsWith("fr") -> "fr"
+                    startsWith("lb") -> "lb"
+                    else -> "en"
+                }
+            },
+            lat = location.latitude,
+            lon = location.longitude
+        ).map {
+            convertSecondary(
+                context = context,
+                weatherResult = it,
+                requestedFeatures = requestedFeatures
+            )
+        }
+    }
+
+    override fun requestReverseGeocodingLocation(
+        context: Context,
+        location: Location,
+    ): Observable<List<Location>> {
+        return mApi.getWeather(
+            language = with(context.currentLocale.code) {
+                when {
+                    startsWith("de") -> "de"
+                    startsWith("fr") -> "fr"
+                    startsWith("lb") -> "lb"
+                    else -> "en"
+                }
+            },
+            lat = location.latitude,
+            lon = location.longitude
+        ).map {
+            val locationList = mutableListOf<Location>()
+            locationList.add(convert(location, it))
+            locationList
+        }
+    }
+
+    companion object {
+        private const val METEOLUX_BASE_URL = "https://metapi.ana.lu/"
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherCity.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherCity.kt
@@ -1,0 +1,28 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteolux.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MeteoLuxWeatherCity(
+    val name: String?,
+    val region: String?,
+    val canton: String?,
+    val lat: Double?,
+    val long: Double?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherCurrent.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherCurrent.kt
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteolux.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MeteoLuxWeatherCurrent(
+    val icon: MeteoLuxWeatherIcon?,
+    val wind: MeteoLuxWeatherWind?,
+    val temperature: MeteoLuxWeatherTemperature?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherDaily.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherDaily.kt
@@ -1,0 +1,32 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteolux.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MeteoLuxWeatherDaily(
+    val date: String,
+    val icon: MeteoLuxWeatherIcon?,
+    val wind: MeteoLuxWeatherWind?,
+    val rain: String?,
+    val snow: String?,
+    val temperatureMin: MeteoLuxWeatherTemperature?,
+    val temperatureMax: MeteoLuxWeatherTemperature?,
+    val sunshine: Double?,
+    val uvIndex: Double?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherEphemeris.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherEphemeris.kt
@@ -1,0 +1,28 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteolux.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MeteoLuxWeatherEphemeris(
+    val date: String,
+    val sunrise: String?,
+    val sunset: String?,
+    val moonrise: String?,
+    val moonset: String?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherForecast.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherForecast.kt
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteolux.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MeteoLuxWeatherForecast(
+    val current: MeteoLuxWeatherCurrent?,
+    val hourly: List<MeteoLuxWeatherHourly>?,
+    val daily: List<MeteoLuxWeatherDaily>?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherHourly.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherHourly.kt
@@ -1,0 +1,29 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteolux.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MeteoLuxWeatherHourly(
+    val date: String,
+    val icon: MeteoLuxWeatherIcon?,
+    val wind: MeteoLuxWeatherWind?,
+    val rain: String?,
+    val snow: String?,
+    val temperature: MeteoLuxWeatherHourlyTemperature?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherHourlyTemperature.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherHourlyTemperature.kt
@@ -1,0 +1,25 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteolux.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MeteoLuxWeatherHourlyTemperature(
+    val temperature: List<Double>?,
+    val felt: Double?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherIcon.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherIcon.kt
@@ -1,0 +1,25 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteolux.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MeteoLuxWeatherIcon(
+    val id: Int?,
+    val name: String?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherResult.kt
@@ -1,0 +1,27 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteolux.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MeteoLuxWeatherResult(
+    val city: MeteoLuxWeatherCity? = null,
+    val forecast: MeteoLuxWeatherForecast? = null,
+    val vigilances: List<MeteoLuxWeatherVigilance>? = null,
+    val ephemeris: MeteoLuxWeatherEphemeris? = null,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherTemperature.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherTemperature.kt
@@ -1,0 +1,25 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteolux.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MeteoLuxWeatherTemperature(
+    val temperature: Double?,
+    val felt: Double?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherVigilance.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherVigilance.kt
@@ -1,0 +1,36 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteolux.json
+
+import kotlinx.serialization.Serializable
+import org.breezyweather.common.serializer.DateSerializer
+import java.util.Date
+
+@Serializable
+data class MeteoLuxWeatherVigilance(
+    val datetimeStart:
+    @Serializable(DateSerializer::class)
+    Date?,
+    val datetimeEnd:
+    @Serializable(DateSerializer::class)
+    Date?,
+    val level: Int?,
+    val type: Int?,
+    val group: Int?,
+    val region: String?,
+    val description: String?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherWind.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/json/MeteoLuxWeatherWind.kt
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.meteolux.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MeteoLuxWeatherWind(
+    val direction: String?,
+    val speed: String?,
+    val gusts: String?,
+)


### PR DESCRIPTION
I have added MeteoLux as a new official source for Luxembourg. I have implemented the following:

- Current
- Daily Forecasts
- Hourly Forecasts (6-hourly)
- Alerts in English, French, German, and Luxembourgish (if/when supported)

This source uses a LatLon-based endpoint.

I have deciphered most of its icon codes, but there are a few whose meanings I am not certain. There is no documentation for those, despite it being an official public API. The codes are not the same as those given in <https://metapi.ana.lu/api/v1/metapp/text?lang=en> either. Those are mentioned in the comments for `getWeatherText`.