### PR TITLE
added PAGASA as a new source

### DIFF
--- a/app/src/main/java/org/breezyweather/common/source/LocationPreset.kt
+++ b/app/src/main/java/org/breezyweather/common/source/LocationPreset.kt
@@ -79,6 +79,7 @@ enum class LocationPreset(
     INDIA("imd", airQuality = "openmeteo", minutely = "openmeteo", alert = "accu", normals = "accu"),
     ISRAEL("ims", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo"),
     MACAO("smg", minutely = "openmeteo"),
+    PHILIPPINES("pagasa", airQuality = "openmeteo", minutely = "openmeteo", alert = "accu", normals = "accu"),
     TURKIYE("mgm", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo"),
     ;
 
@@ -108,6 +109,7 @@ enum class LocationPreset(
                     "IL", "PS" -> ISRAEL
                     "IN" -> INDIA
                     "MO" -> MACAO
+                    "PH" -> PHILIPPINES
                     "TR" -> TURKIYE
 
                     else -> DEFAULT

--- a/app/src/src_nonfreenet/org/breezyweather/sources/SourceManager.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/SourceManager.kt
@@ -62,6 +62,7 @@ import org.breezyweather.sources.naturalearth.NaturalEarthService
 import org.breezyweather.sources.nws.NwsService
 import org.breezyweather.sources.openmeteo.OpenMeteoService
 import org.breezyweather.sources.openweather.OpenWeatherService
+import org.breezyweather.sources.pagasa.PagasaService
 import org.breezyweather.sources.pirateweather.PirateWeatherService
 import org.breezyweather.sources.recosante.RecosanteService
 import org.breezyweather.sources.smg.SmgService
@@ -100,6 +101,7 @@ class SourceManager @Inject constructor(
     nwsService: NwsService,
     openMeteoService: OpenMeteoService,
     openWeatherService: OpenWeatherService,
+    pagasaService: PagasaService,
     pirateWeatherService: PirateWeatherService,
     recosanteService: RecosanteService,
     smgService: SmgService,
@@ -154,6 +156,7 @@ class SourceManager @Inject constructor(
         mfService,
         mgmService,
         nwsService,
+        pagasaService,
         smgService,
         smhiService
     )

--- a/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/PagasaApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/PagasaApi.kt
@@ -1,0 +1,43 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.pagasa
+
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.sources.pagasa.json.PagasaCurrentResult
+import org.breezyweather.sources.pagasa.json.PagasaHourlyResult
+import org.breezyweather.sources.pagasa.json.PagasaLocationResult
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface PagasaApi {
+    // Not a reliable source of current weather despite the URL
+    @Headers("Origin: https://www.pagasa.dost.gov.ph")
+    @POST("api/CurrentWeather")
+    fun getLocations(): Observable<Map<String, PagasaLocationResult>>
+
+    @Headers("Origin: https://www.pagasa.dost.gov.ph")
+    @POST("api/NearestAWS")
+    fun getCurrent(): Observable<Map<String, List<PagasaCurrentResult>>>
+
+    @GET("api/meteogram/{site}/{day}")
+    fun getHourly(
+        @Path("site") site: String,
+        @Path("day") day: Int,
+    ): Observable<PagasaHourlyResult>
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/PagasaResultConverter.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/PagasaResultConverter.kt
@@ -1,0 +1,278 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.pagasa
+
+import android.content.Context
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.weather.model.Current
+import breezyweather.domain.weather.model.Daily
+import breezyweather.domain.weather.model.Precipitation
+import breezyweather.domain.weather.model.Temperature
+import breezyweather.domain.weather.model.WeatherCode
+import breezyweather.domain.weather.model.Wind
+import breezyweather.domain.weather.wrappers.HourlyWrapper
+import breezyweather.domain.weather.wrappers.WeatherWrapper
+import com.google.maps.android.SphericalUtil
+import com.google.maps.android.model.LatLng
+import org.breezyweather.R
+import org.breezyweather.common.exceptions.InvalidLocationException
+import org.breezyweather.common.extensions.getFormattedDate
+import org.breezyweather.sources.pagasa.json.PagasaCurrentResult
+import org.breezyweather.sources.pagasa.json.PagasaHourlyResult
+import org.breezyweather.sources.pagasa.json.PagasaLocationResult
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import kotlin.time.Duration.Companion.hours
+
+fun convert(
+    location: Location,
+    locations: Map<String, PagasaLocationResult>,
+): Map<String, String> {
+    var nearestDistance = Double.POSITIVE_INFINITY
+    var nearestStation: String = ""
+    var nearestKey: String = ""
+    var distance = Double.POSITIVE_INFINITY
+    locations.keys.forEach { key ->
+        locations[key]!!.let {
+            distance = SphericalUtil.computeDistanceBetween(
+                LatLng(it.latitude.toDouble(), it.longitude.toDouble()),
+                LatLng(location.latitude, location.longitude)
+            )
+            if (distance < nearestDistance) {
+                nearestDistance = distance
+                nearestStation = it.siteId
+                nearestKey = key
+            }
+        }
+    }
+
+    // Forecast locations are sparse across the archipelago of the Philippines.
+    // Therefore, only reject distances more than 200 km,
+    // otherwise several major cities will trigger invalid location exception.
+    if (nearestDistance > 200000) {
+        throw InvalidLocationException()
+    }
+    return mapOf(
+        "station" to nearestStation,
+        "key" to nearestKey
+    )
+}
+
+fun convert(
+    context: Context,
+    location: Location,
+    currentResult: List<PagasaCurrentResult>?,
+    hourlyResult: List<PagasaHourlyResult>?,
+): WeatherWrapper {
+    val hourlyForecast = getHourlyForecast(context, hourlyResult)
+    return WeatherWrapper(
+        current = getCurrent(location, currentResult),
+        dailyForecast = getDailyForecast(location, hourlyForecast),
+        hourlyForecast = hourlyForecast
+    )
+}
+
+private fun getCurrent(
+    location: Location,
+    currentResult: List<PagasaCurrentResult>?,
+): Current? {
+    val formatter = SimpleDateFormat("MMMM d, yyyy, h:mm a", Locale.ENGLISH)
+    formatter.timeZone = TimeZone.getTimeZone("Asia/Manila")
+    val now = Date().time
+    var nearestDistance = Double.POSITIVE_INFINITY
+    var nearestStation = Int.MAX_VALUE
+    var distance = Double.POSITIVE_INFINITY
+    var update: Long
+    currentResult?.forEachIndexed { i, station ->
+        update = formatter.parse(station.datetime)!!.time
+        if ((now - update) <= 2.hours.inWholeMilliseconds) {
+            distance = SphericalUtil.computeDistanceBetween(
+                LatLng(station.latitude.toDouble(), station.longitude.toDouble()),
+                LatLng(location.latitude, location.longitude)
+            )
+            if (distance < nearestDistance) {
+                nearestDistance = distance
+                nearestStation = i
+            }
+        }
+    }
+    return currentResult?.getOrNull(nearestStation)?.let {
+        Current(
+            temperature = Temperature(
+                temperature = it.temperature?.substringBefore(" ")?.toDoubleOrNull()
+            ),
+            wind = Wind(
+                degree = getWindDirection(it.windDirection),
+                speed = it.windSpeed?.substringBefore(" ")?.toDoubleOrNull()?.div(3.6)
+            ),
+            relativeHumidity = it.humidity?.substringBefore(" ")?.toDoubleOrNull(),
+            pressure = it.pressure?.toDoubleOrNull()
+        )
+    }
+}
+
+private fun getDailyForecast(
+    location: Location,
+    hourlyForecast: List<HourlyWrapper>,
+): List<Daily> {
+    // Need to provide an empty daily list so that
+    // CommonConverter.kt will compute the daily forecast items.
+    val dates = hourlyForecast.groupBy { it.date.getFormattedDate("yyyy-MM-dd", location) }.keys
+    val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH)
+    formatter.timeZone = TimeZone.getTimeZone(location.timeZone)
+    val dailyList = mutableListOf<Daily>()
+    dates.forEachIndexed { i, day ->
+        if (i < dates.size - 1) { // skip the last day
+            dailyList.add(
+                Daily(
+                    date = formatter.parse(day)!!
+                )
+            )
+        }
+    }
+    return dailyList
+}
+
+private fun getHourlyForecast(
+    context: Context,
+    hourlyResult: List<PagasaHourlyResult>?,
+): List<HourlyWrapper> {
+    val hourlyList = mutableListOf<HourlyWrapper>()
+    val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ENGLISH)
+    // Hourly forecasts are likely reported in UTC rather than Asia/Manila,
+    // judging from the temperature and humidity trends.
+    formatter.timeZone = TimeZone.getTimeZone("Etc/UTC")
+    var lastTime: String? = null
+    hourlyResult?.forEach { day ->
+        day.forecast?.tabular?.time?.forEach {
+            // Check for duplication: for day 0, every hour in the output is duplicated
+            if ((it.attributes?.from != null) && (it.attributes.from != lastTime)) {
+                lastTime = it.attributes.from
+                hourlyList.add(
+                    HourlyWrapper(
+                        date = formatter.parse(it.attributes.from)!!,
+                        weatherText = getHourlyWeatherText(context, it.symbol?.attributes?.symbol),
+                        weatherCode = getHourlyWeatherCode(it.symbol?.attributes?.symbol),
+                        temperature = Temperature(
+                            temperature = it.temperature?.attributes?.value?.toDoubleOrNull()
+                        ),
+                        precipitation = Precipitation(
+                            total = it.precipitation?.attributes?.value?.toDoubleOrNull()
+                        ),
+                        wind = Wind(
+                            degree = it.windDirection?.attributes?.deg?.toDoubleOrNull(),
+                            speed = it.windSpeed?.attributes?.mps?.toDoubleOrNull()
+                        ),
+                        relativeHumidity = it.relativeHumidity?.attributes?.value?.toDoubleOrNull()
+                    )
+                )
+            }
+        }
+    }
+    return hourlyList
+}
+
+private fun getWindDirection(
+    direction: String?,
+): Double? {
+    return when (direction) {
+        "N" -> 0.0
+        "NNE" -> 22.5
+        "NE" -> 45.0
+        "ENE" -> 67.5
+        "E" -> 90.0
+        "ESE" -> 112.5
+        "SE" -> 135.0
+        "SSE" -> 157.5
+        "S" -> 180.0
+        "SSW" -> 202.5
+        "SW" -> 225.0
+        "WSW" -> 247.5
+        "W" -> 270.0
+        "WNW" -> 292.5
+        "NW" -> 315.0
+        "NNW" -> 337.5
+        else -> null
+    }
+}
+
+private fun getHourlyWeatherText(
+    context: Context,
+    symbol: String?,
+): String? {
+    return symbol?.let {
+        with(symbol) {
+            when {
+                startsWith("01") -> context.getString(R.string.common_weather_text_clear_sky)
+                startsWith("02") -> context.getString(R.string.common_weather_text_mainly_clear)
+                startsWith("03") -> context.getString(R.string.common_weather_text_partly_cloudy)
+                startsWith("04") -> context.getString(R.string.common_weather_text_cloudy)
+                startsWith("05") -> context.getString(R.string.common_weather_text_rain_showers)
+                startsWith("06") -> "Thunder showers" // thundershower
+                startsWith("07") -> context.getString(R.string.common_weather_text_rain_snow_mixed_showers)
+                startsWith("08") -> context.getString(R.string.common_weather_text_snow_showers)
+                startsWith("09") -> context.getString(R.string.common_weather_text_rain)
+                startsWith("10") -> context.getString(R.string.common_weather_text_rain_heavy)
+                startsWith("11") -> context.getString(R.string.weather_kind_thunderstorm) // heavy thunderstorm
+                startsWith("12") -> context.getString(R.string.common_weather_text_rain_snow_mixed)
+                startsWith("13") -> context.getString(R.string.common_weather_text_snow)
+                startsWith("14") -> "Thunder snowstorm" // thunder snow
+                startsWith("15") -> context.getString(R.string.common_weather_text_fog)
+                startsWith("16") -> "Thunder sleet shower" // thunder sleet shower
+                startsWith("17") -> "Thunder snow shower" // thunder snow shower
+                startsWith("18") -> context.getString(R.string.weather_kind_thunderstorm) // thunderstorm
+                startsWith("19") -> "Thunder rain and snow mixed" // thunder sleet
+                else -> null
+            }
+        }
+    }
+}
+
+// Source: https://pubfiles.pagasa.dost.gov.ph/pagasaweb/images/meteogram-symbols-30px.png
+// There are too many snow and sleet icons for a tropical country like the Philippines
+private fun getHourlyWeatherCode(
+    symbol: String?,
+): WeatherCode? {
+    return symbol?.let {
+        with(symbol) {
+            when {
+                startsWith("01") -> WeatherCode.CLEAR
+                startsWith("02") -> WeatherCode.CLEAR
+                startsWith("03") -> WeatherCode.PARTLY_CLOUDY
+                startsWith("04") -> WeatherCode.CLOUDY
+                startsWith("05") -> WeatherCode.RAIN
+                startsWith("06") -> WeatherCode.THUNDERSTORM // thundershower
+                startsWith("07") -> WeatherCode.SLEET
+                startsWith("08") -> WeatherCode.SNOW
+                startsWith("09") -> WeatherCode.RAIN
+                startsWith("10") -> WeatherCode.RAIN
+                startsWith("11") -> WeatherCode.THUNDERSTORM // heavy thunderstorm
+                startsWith("12") -> WeatherCode.SLEET
+                startsWith("13") -> WeatherCode.SNOW
+                startsWith("14") -> WeatherCode.THUNDERSTORM // thunder snow
+                startsWith("15") -> WeatherCode.FOG
+                startsWith("16") -> WeatherCode.THUNDERSTORM // thunder sleet shower
+                startsWith("17") -> WeatherCode.THUNDERSTORM // thunder snow shower
+                startsWith("18") -> WeatherCode.THUNDERSTORM // thunderstorm
+                startsWith("19") -> WeatherCode.THUNDERSTORM // thunder sleet
+                else -> null
+            }
+        }
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/PagasaService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/PagasaService.kt
@@ -1,0 +1,127 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.pagasa
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Color
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.weather.wrappers.WeatherWrapper
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.common.exceptions.InvalidLocationException
+import org.breezyweather.common.source.HttpSource
+import org.breezyweather.common.source.LocationParametersSource
+import org.breezyweather.common.source.MainWeatherSource
+import org.breezyweather.common.source.SecondaryWeatherSourceFeature
+import org.breezyweather.sources.pagasa.json.PagasaCurrentResult
+import org.breezyweather.sources.pagasa.json.PagasaHourlyResult
+import retrofit2.Retrofit
+import javax.inject.Inject
+import javax.inject.Named
+
+class PagasaService @Inject constructor(
+    @ApplicationContext context: Context,
+    @Named("JsonClient") client: Retrofit.Builder,
+) : HttpSource(), MainWeatherSource, LocationParametersSource {
+
+    override val id = "pagasa"
+    override val name = "PAGASA"
+    override val privacyPolicyUrl = ""
+    override val color = Color.rgb(75, 196, 211)
+    override val weatherAttribution = "Philippine Atmospheric, Geophysical and Astronomical Services Administration"
+
+    private val mApi by lazy {
+        client
+            .baseUrl(PAGASA_BASE_URL)
+            .build()
+            .create(PagasaApi::class.java)
+    }
+
+    override val supportedFeaturesInMain = listOf<SecondaryWeatherSourceFeature>()
+
+    override fun isFeatureSupportedInMainForLocation(
+        location: Location,
+        feature: SecondaryWeatherSourceFeature?,
+    ): Boolean {
+        return location.countryCode.equals("PH", ignoreCase = true)
+    }
+
+    override fun requestWeather(
+        context: Context,
+        location: Location,
+        ignoreFeatures: List<SecondaryWeatherSourceFeature>,
+    ): Observable<WeatherWrapper> {
+        val station = location.parameters.getOrElse(id) { null }?.getOrElse("station") { null }
+        val key = location.parameters.getOrElse(id) { null }?.getOrElse("key") { null }
+        if (station.isNullOrEmpty() || key.isNullOrEmpty()) {
+            return Observable.error(InvalidLocationException())
+        }
+
+        val current = mApi.getCurrent()
+        val hourly = List(5) { day ->
+            mApi.getHourly(
+                site = station,
+                day = day
+            )
+        }
+
+        return Observable.zip(current, hourly[0], hourly[1], hourly[2], hourly[3], hourly[4]) {
+                currentResult: Map<String, List<PagasaCurrentResult>>,
+                hourlyResult0: PagasaHourlyResult,
+                hourlyResult1: PagasaHourlyResult,
+                hourlyResult2: PagasaHourlyResult,
+                hourlyResult3: PagasaHourlyResult,
+                hourlyResult4: PagasaHourlyResult,
+            ->
+            convert(
+                context = context,
+                location = location,
+                currentResult = currentResult.getOrElse(key) { null },
+                hourlyResult = listOf(hourlyResult0, hourlyResult1, hourlyResult2, hourlyResult3, hourlyResult4)
+            )
+        }
+    }
+
+    // Location parameters
+    override fun needsLocationParametersRefresh(
+        location: Location,
+        coordinatesChanged: Boolean,
+        features: List<SecondaryWeatherSourceFeature>,
+    ): Boolean {
+        if (coordinatesChanged) return true
+
+        val station = location.parameters.getOrElse(id) { null }?.getOrElse("station") { null }
+        val key = location.parameters.getOrElse(id) { null }?.getOrElse("key") { null }
+
+        return station.isNullOrEmpty() || key.isNullOrEmpty()
+    }
+
+    @SuppressLint("NewApi")
+    override fun requestLocationParameters(
+        context: Context,
+        location: Location,
+    ): Observable<Map<String, String>> {
+        return mApi.getLocations().map {
+            convert(location, it)
+        }
+    }
+
+    companion object {
+        private const val PAGASA_BASE_URL = "https://www.pagasa.dost.gov.ph/"
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/json/PagasaCurrentResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/json/PagasaCurrentResult.kt
@@ -1,0 +1,32 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.pagasa.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PagasaCurrentResult(
+    val datetime: String,
+    val temperature: String?,
+    val humidity: String?,
+    val pressure: String?,
+    @SerialName("wind_speed") val windSpeed: String?,
+    @SerialName("wind_direction") val windDirection: String?,
+    val latitude: String,
+    val longitude: String,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/json/PagasaHourlyAttributes.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/json/PagasaHourlyAttributes.kt
@@ -1,0 +1,29 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.pagasa.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PagasaHourlyAttributes(
+    val from: String?,
+    @SerialName("var") val symbol: String?,
+    val value: String?,
+    val deg: String?,
+    val mps: String?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/json/PagasaHourlyElement.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/json/PagasaHourlyElement.kt
@@ -1,0 +1,25 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.pagasa.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PagasaHourlyElement(
+    @SerialName("@attributes") val attributes: PagasaHourlyAttributes?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/json/PagasaHourlyForecast.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/json/PagasaHourlyForecast.kt
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.pagasa.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PagasaHourlyForecast(
+    val tabular: PagasaHourlyTabular?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/json/PagasaHourlyResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/json/PagasaHourlyResult.kt
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.pagasa.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PagasaHourlyResult(
+    val forecast: PagasaHourlyForecast? = null,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/json/PagasaHourlyTabular.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/json/PagasaHourlyTabular.kt
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.pagasa.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PagasaHourlyTabular(
+    val time: List<PagasaHourlyTime>?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/json/PagasaHourlyTime.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/json/PagasaHourlyTime.kt
@@ -1,0 +1,31 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.pagasa.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PagasaHourlyTime(
+    @SerialName("@attributes") val attributes: PagasaHourlyAttributes?,
+    val symbol: PagasaHourlyElement?,
+    val precipitation: PagasaHourlyElement?,
+    val windDirection: PagasaHourlyElement?,
+    val windSpeed: PagasaHourlyElement?,
+    val temperature: PagasaHourlyElement?,
+    val relativeHumidity: PagasaHourlyElement?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/json/PagasaLocationResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/json/PagasaLocationResult.kt
@@ -1,0 +1,27 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.pagasa.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PagasaLocationResult(
+    @SerialName("site_id") val siteId: String,
+    val latitude: String,
+    val longitude: String,
+)


### PR DESCRIPTION
I have added Philippine Atmospheric, Geophysical and Astronomical Services Administration (PAGASA) as a new official source for the Philippines. I have implemented the following:

- Current observation
- Hourly forecasts

This source provides a location list for location parameters. However, the forecast locations are sparse across the Philippine archipelago (it has 7,641 islands), therefore I didn't use the list for reverse geocoding.