### PR TITLE
Improve setSystemBarStyle and fix color of status bar on Android 15

### DIFF
--- a/app/src/main/java/org/breezyweather/common/basic/GeoActivity.kt
+++ b/app/src/main/java/org/breezyweather/common/basic/GeoActivity.kt
@@ -41,7 +41,7 @@ abstract class GeoActivity : AppCompatActivity() {
                 statusShaderP = false,
                 lightStatusP = !this.isDarkMode,
                 navigationShaderP = true,
-                lightNavigationP = false
+                lightNavigationP = !this.isDarkMode
             )
         }
 

--- a/app/src/main/java/org/breezyweather/common/extensions/DisplayExtensions.kt
+++ b/app/src/main/java/org/breezyweather/common/extensions/DisplayExtensions.kt
@@ -37,7 +37,6 @@ import android.view.animation.OvershootInterpolator
 import androidx.annotation.Px
 import androidx.annotation.Size
 import androidx.annotation.StyleRes
-import androidx.core.graphics.ColorUtils
 import androidx.core.view.WindowInsetsControllerCompat
 import com.google.android.material.resources.TextAppearance
 import kotlin.math.min
@@ -122,38 +121,41 @@ fun Window.setSystemBarStyle(
     var lightNavigation = lightNavigationP
     var navigationShader = navigationShaderP
 
-    // status bar
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-        lightStatus = false
-        statusShader = true
-    }
-    WindowInsetsControllerCompat(this, this.decorView)
-        .isAppearanceLightStatusBars = lightStatus
-
-    if (statusShader) {
-        this.statusBarColor = ColorUtils.setAlphaComponent(
-            if (lightStatus) Color.WHITE else Color.BLACK,
-            ((if (lightStatus) 0.5 else 0.2) * 255).toInt()
-        )
-    } else {
-        this.statusBarColor = Color.TRANSPARENT
-    }
-
-    // navigation bar
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-        lightNavigation = false
-        navigationShader = true
-    }
-    WindowInsetsControllerCompat(this, this.decorView)
-        .isAppearanceLightNavigationBars = lightNavigation
+        // Use default dark and light platform colors from EdgeToEdge
+        val colorSystemBarDark = Color.argb(0x80, 0x1b, 0x1b, 0x1b)
+        val colorSystemBarLight = Color.argb(0xe6, 0xFF, 0xFF, 0xFF)
 
-    if (navigationShader) {
-        this.navigationBarColor = ColorUtils.setAlphaComponent(
-            if (lightNavigation) Color.WHITE else Color.BLACK,
-            ((if (lightNavigation) 0.5 else 0.2) * 255).toInt()
-        )
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            // Always apply a dark shader as a light or transparent status bar is not supported
+            lightStatus = false
+            statusShader = true
+        }
+        this.statusBarColor = if (statusShader) {
+            if (lightStatus) colorSystemBarLight else colorSystemBarDark
+        } else {
+            Color.TRANSPARENT
+        }
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            // Always apply a dark shader as a light or transparent navigation bar is not supported
+            lightNavigation = false
+            navigationShader = true
+        }
+        this.navigationBarColor = if (navigationShader) {
+            if (lightNavigation) colorSystemBarLight else colorSystemBarDark
+        } else {
+            Color.TRANSPARENT
+        }
     } else {
-        this.navigationBarColor = Color.TRANSPARENT
+        this.isStatusBarContrastEnforced = statusShader
+        this.isNavigationBarContrastEnforced = navigationShaderP
+    }
+
+    // Contrary to the documentation FALSE applies a light foreground color and TRUE a dark foreground color
+    WindowInsetsControllerCompat(this, this.decorView).run {
+        isAppearanceLightStatusBars = lightStatus
+        isAppearanceLightNavigationBars = lightNavigation
     }
 }
 

--- a/app/src/main/java/org/breezyweather/common/ui/activities/AlertActivity.kt
+++ b/app/src/main/java/org/breezyweather/common/ui/activities/AlertActivity.kt
@@ -175,7 +175,7 @@ class AlertActivity : GeoActivity() {
                     window = this.window,
                     statusShader = false,
                     lightStatus = isLightTheme,
-                    navigationShader = false,
+                    navigationShader = true,
                     lightNavigation = isLightTheme
                 )
 

--- a/app/src/main/java/org/breezyweather/common/ui/activities/PollenActivity.kt
+++ b/app/src/main/java/org/breezyweather/common/ui/activities/PollenActivity.kt
@@ -132,7 +132,7 @@ class PollenActivity : GeoActivity() {
                     window = this.window,
                     statusShader = false,
                     lightStatus = isLightTheme,
-                    navigationShader = false,
+                    navigationShader = true,
                     lightNavigation = isLightTheme
                 )
 

--- a/app/src/main/java/org/breezyweather/main/fragments/ManagementFragment.kt
+++ b/app/src/main/java/org/breezyweather/main/fragments/ManagementFragment.kt
@@ -111,7 +111,7 @@ class PushedManagementFragment : ManagementFragment() {
                 requireActivity().window,
                 statusShader = false,
                 lightStatus = !requireActivity().isDarkMode,
-                navigationShader = false,
+                navigationShader = true,
                 lightNavigation = !requireActivity().isDarkMode
             )
     }


### PR DESCRIPTION
### Changes
- replace color attributes with contrast enforced attributes (>= Android Q)
- use default dark and light platform colors for system bars (< Android Q)

Successfully tested on the following devices: Google Pixel 6a (Android 15) and LG G6 (Android 9).

Contributes to #837.

<details>

<summary>screenshots</summary>

| 5.2.8 | SDK 35 fix|
| --- | --- |
| ![Screenshot_20241122-204136](https://github.com/user-attachments/assets/cb57985a-e8c3-48d2-89f0-90b0dea6fd10) | ![Screenshot_20241122-204439](https://github.com/user-attachments/assets/1269be5c-9a0a-4fc7-81bc-c4b0261e9bdd) |

</details>