### PR TITLE
Add refresh error type for disabled location service

### DIFF
--- a/app/src/main/java/org/breezyweather/common/exceptions/LocationServiceDisabledException.kt
+++ b/app/src/main/java/org/breezyweather/common/exceptions/LocationServiceDisabledException.kt
@@ -1,0 +1,19 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.common.exceptions
+
+class LocationServiceDisabledException : Exception()

--- a/app/src/main/java/org/breezyweather/common/extensions/ContextExtensions.kt
+++ b/app/src/main/java/org/breezyweather/common/extensions/ContextExtensions.kt
@@ -18,14 +18,16 @@ package org.breezyweather.common.extensions
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.pm.ShortcutManager
 import android.hardware.SensorManager
+import android.location.LocationManager
 import android.net.Uri
 import android.os.PowerManager
 import android.provider.Settings
 import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
-import androidx.core.content.PermissionChecker
+import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import org.breezyweather.settings.SettingsManager
 import java.io.File
@@ -45,9 +47,12 @@ import java.io.File
  */
 fun Context.hasPermission(
     permission: String,
-) = PermissionChecker.checkSelfPermission(this, permission) == PermissionChecker.PERMISSION_GRANTED
+) = ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
 
 val Context.inputMethodManager: InputMethodManager
+    get() = getSystemService()!!
+
+val Context.locationManager: LocationManager
     get() = getSystemService()!!
 
 val Context.powerManager: PowerManager

--- a/app/src/main/java/org/breezyweather/common/extensions/NotificationExtensions.kt
+++ b/app/src/main/java/org/breezyweather/common/extensions/NotificationExtensions.kt
@@ -20,12 +20,13 @@ import android.Manifest
 import android.app.Notification
 import android.app.NotificationManager
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationChannelGroupCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import androidx.core.content.PermissionChecker
+import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 
 /**
@@ -49,10 +50,10 @@ fun Context.notify(
 fun Context.notify(id: Int, notification: Notification) {
     if (
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-        PermissionChecker.checkSelfPermission(
+        ContextCompat.checkSelfPermission(
             this,
             Manifest.permission.POST_NOTIFICATIONS
-        ) != PermissionChecker.PERMISSION_GRANTED
+        ) != PackageManager.PERMISSION_GRANTED
     ) {
         return
     }
@@ -67,7 +68,7 @@ fun Context.cancelNotification(id: Int) {
 /**
  * Helper method to create a notification builder.
  *
- * @param id the channel id.
+ * @param channelId the channel id.
  * @param block the function that will execute inside the builder.
  * @return a notification to be displayed or updated.
  */

--- a/app/src/main/java/org/breezyweather/main/utils/RefreshErrorType.kt
+++ b/app/src/main/java/org/breezyweather/main/utils/RefreshErrorType.kt
@@ -19,6 +19,7 @@ package org.breezyweather.main.utils
 import android.app.Activity
 import androidx.annotation.StringRes
 import org.breezyweather.R
+import org.breezyweather.common.utils.helpers.IntentHelper
 import org.breezyweather.main.dialogs.ApiHelpDialog
 import org.breezyweather.main.dialogs.LocationHelpDialog
 import org.breezyweather.main.dialogs.SourceNoLongerAvailableHelpDialog
@@ -107,6 +108,10 @@ enum class RefreshErrorType(
     ACCESS_BACKGROUND_LOCATION_PERMISSION_MISSING(
         shortMessage = R.string.location_message_permission_background_missing
         // showDialogAction = { } // TODO
+    ),
+    LOCATION_SERVICE_DISABLED(
+        shortMessage = R.string.location_message_location_service_disabled,
+        showDialogAction = { IntentHelper.startLocationSettingsActivity(it) }
     ),
     REVERSE_GEOCODING_FAILED(
         shortMessage = R.string.location_message_reverse_geocoding_failed

--- a/app/src/main/java/org/breezyweather/remoteviews/config/AbstractWidgetConfigActivity.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/config/AbstractWidgetConfigActivity.kt
@@ -23,7 +23,6 @@ import android.app.WallpaperManager
 import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.graphics.Rect
 import android.os.Build
 import android.os.Bundle
@@ -62,6 +61,7 @@ import org.breezyweather.common.basic.models.options.appearance.CalendarHelper
 import org.breezyweather.common.extensions.currentLocale
 import org.breezyweather.common.extensions.doOnApplyWindowInsets
 import org.breezyweather.common.extensions.getTabletListAdaptiveWidth
+import org.breezyweather.common.extensions.hasPermission
 import org.breezyweather.common.extensions.launchUI
 import org.breezyweather.common.snackbar.Snackbar
 import org.breezyweather.common.snackbar.SnackbarManager
@@ -672,7 +672,7 @@ abstract class AbstractWidgetConfigActivity : GeoActivity() {
      */
     @RequiresApi(api = Build.VERSION_CODES.M)
     private fun checkPermissions(requestCode: Int): Boolean {
-        if (checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+        if (!hasPermission(Manifest.permission.READ_EXTERNAL_STORAGE)) {
             requestPermissions(arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE), requestCode)
             return false
         }

--- a/app/src/main/java/org/breezyweather/sources/RefreshHelper.kt
+++ b/app/src/main/java/org/breezyweather/sources/RefreshHelper.kt
@@ -23,6 +23,7 @@ import android.content.pm.PackageManager
 import android.content.pm.ShortcutInfo
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.core.location.LocationManagerCompat
 import breezyweather.data.location.LocationRepository
 import breezyweather.data.weather.WeatherRepository
 import breezyweather.domain.location.model.Location
@@ -42,6 +43,7 @@ import org.breezyweather.common.exceptions.InvalidLocationException
 import org.breezyweather.common.exceptions.InvalidOrIncompleteDataException
 import org.breezyweather.common.exceptions.LocationException
 import org.breezyweather.common.exceptions.LocationSearchException
+import org.breezyweather.common.exceptions.LocationServiceDisabledException
 import org.breezyweather.common.exceptions.MissingPermissionLocationBackgroundException
 import org.breezyweather.common.exceptions.MissingPermissionLocationException
 import org.breezyweather.common.exceptions.NoNetworkException
@@ -54,6 +56,7 @@ import org.breezyweather.common.extensions.getFormattedDate
 import org.breezyweather.common.extensions.getStringByLocale
 import org.breezyweather.common.extensions.hasPermission
 import org.breezyweather.common.extensions.isOnline
+import org.breezyweather.common.extensions.locationManager
 import org.breezyweather.common.extensions.shortcutManager
 import org.breezyweather.common.extensions.toCalendarWithTimeZone
 import org.breezyweather.common.extensions.toDateNoHour
@@ -213,6 +216,9 @@ class RefreshHelper @Inject constructor(
                     errors.add(RefreshError(RefreshErrorType.ACCESS_BACKGROUND_LOCATION_PERMISSION_MISSING))
                 }
             }
+        }
+        if (!LocationManagerCompat.isLocationEnabled(context.locationManager)) {
+            errors.add(RefreshError(RefreshErrorType.LOCATION_SERVICE_DISABLED))
         }
         if (errors.isNotEmpty()) {
             return LocationResult(location, errors)
@@ -763,6 +769,7 @@ class RefreshHelper @Inject constructor(
             is ApiUnauthorizedException -> RefreshErrorType.API_UNAUTHORIZED
             is InvalidLocationException -> RefreshErrorType.INVALID_LOCATION
             is LocationException -> RefreshErrorType.LOCATION_FAILED
+            is LocationServiceDisabledException -> RefreshErrorType.LOCATION_SERVICE_DISABLED
             is MissingPermissionLocationException -> RefreshErrorType.ACCESS_LOCATION_PERMISSION_MISSING
             is MissingPermissionLocationBackgroundException ->
                 RefreshErrorType.ACCESS_BACKGROUND_LOCATION_PERMISSION_MISSING

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,6 +290,7 @@
     <string name="location_message_failed_to_locate">Failed to find current location</string>
     <string name="location_message_permission_missing">Access location permission missing</string>
     <string name="location_message_permission_background_missing">Access location in background permission missing</string>
+    <string name="location_message_location_service_disabled">Location service is disabled</string>
     <string name="location_message_reverse_geocoding_failed">Weather source failed to find a matching location</string>
     <string name="location_dialog_failed_to_locate_title">Cannot get location correctly?</string>
     <string name="location_dialog_failed_to_locate_action_check_permission">Check location permissions</string>


### PR DESCRIPTION
### Changes

- extend RefreshHelper with a check if location service is disabled
- use ContextCompat.checkSelfPermission instead of PermissionChecker

Successfully tested on the following devices: Google Pixel 6a (Android 15) and LG G6 (Android 9).

Closes #1447.

### Remark

I noticed that when refreshing the current location after the location permission was denied, the refresh is immediately cancelled in [onRequestPermissionsResult](https://github.com/breezy-weather/breezy-weather/blob/dad2f11f9a274ee3c42decebc5df741852e6d5f6/app/src/main/java/org/breezyweather/main/MainActivity.kt#L570-L577). As a result, users don't receive any feedback message (refresh error snackbar) why the refresh doesn't work. I plan to have a separate look at this.