### PR TITLE
Extended MF to cover Overseas France, Andorra, and Monaco

### DIFF
--- a/app/src/main/java/org/breezyweather/common/source/LocationPreset.kt
+++ b/app/src/main/java/org/breezyweather/common/source/LocationPreset.kt
@@ -52,6 +52,7 @@ enum class LocationPreset(
     // Europe
     // AUSTRIA("openmeteo" /* GeoSphere too lightweight */, airQuality = "geosphereat", minutely = "geosphereat",
     //     alert = "geosphereat", normals = "geosphereat"),
+    ANDORRA("mf", airQuality = "openmeteo", pollen = "openmeteo"),
     DENMARK("dmi", airQuality = "openmeteo", pollen = "openmeteo", minutely = "metno", normals = "accu"),
     GERMANY("brightsky", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo", normals = "accu"),
     GERMANY_FREENET("brightsky", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo"),
@@ -61,6 +62,7 @@ enum class LocationPreset(
     IRELAND("metie", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo", normals = "accu"),
     ITALY("meteoam", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo", normals = "accu"),
     LUXEMBOURG("meteolux", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo", normals = "accu"),
+    MONACO("mf", airQuality = "openmeteo", pollen = "openmeteo", alert = "accu"),
     NORWAY("metno", pollen = "openmeteo", alert = "accu", normals = "accu"),
     PORTUGAL("ipma", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo", normals = "accu"),
     SWEDEN(
@@ -86,6 +88,9 @@ enum class LocationPreset(
     MONGOLIA("namem"),
     PHILIPPINES("pagasa", airQuality = "openmeteo", minutely = "openmeteo", alert = "accu", normals = "accu"),
     TURKIYE("mgm", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo"),
+
+    // France Overseas Territories
+    FRANCE_OVERSEAS("mf", airQuality = "openmeteo", minutely = "openmeteo"),
     ;
 
     companion object {
@@ -98,6 +103,7 @@ enum class LocationPreset(
                     "US", "PR", "VI", "MP", "GU", "FM", "PW", "AS" -> USA
 
                     // Europe
+                    "AD" -> ANDORRA
                     "DE" -> GERMANY
                     "DK" -> DENMARK
                     "FI" -> FINLAND
@@ -105,6 +111,7 @@ enum class LocationPreset(
                     "IE" -> IRELAND
                     "IT", "SM", "VA" -> ITALY
                     "LU" -> LUXEMBOURG
+                    "MC" -> MONACO
                     "NO" -> NORWAY
                     "PT" -> PORTUGAL
                     "SE" -> SWEDEN
@@ -121,6 +128,9 @@ enum class LocationPreset(
                     "MO" -> MACAO
                     "PH" -> PHILIPPINES
                     "TR" -> TURKIYE
+
+                    // France Overseas Territories
+                    "BL", "GF", "GP", "MF", "MQ", "NC", "PF", "PM", "RE", "WF", "YT" -> FRANCE_OVERSEAS
 
                     else -> DEFAULT
                 }

--- a/app/src/src_nonfreenet/org/breezyweather/sources/mf/MfOverseasApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/mf/MfOverseasApi.kt
@@ -1,0 +1,34 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.mf
+
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.sources.mf.json.MfOverseasWarningsResult
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.Query
+
+interface MfOverseasApi {
+    @GET("internet2018client/2.0/warning/full")
+    fun getWarnings(
+        @Header("User-Agent") userAgent: String,
+        @Query("domain", encoded = true) domain: String,
+        @Query("warning_type") warningType: String = "",
+        @Query("formatDate") formatDate: String = "iso",
+        @Query("token") token: String,
+    ): Observable<MfOverseasWarningsResult>
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/mf/json/MfOverseasWarningComments.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/mf/json/MfOverseasWarningComments.kt
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.mf.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MfOverseasWarningComments(
+    @SerialName("bloc_title") val blocTitle: String?,
+    @SerialName("text_bloc_item") val textBlocItems: List<MfOverseasWarningTextBlocItem>?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/mf/json/MfOverseasWarningTextBlocItem.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/mf/json/MfOverseasWarningTextBlocItem.kt
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.mf.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MfOverseasWarningTextBlocItem(
+    @SerialName("bloc_title") val blocTitle: String?,
+    @SerialName("text_items") val textItem: String?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/mf/json/MfOverseasWarningTimelaps.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/mf/json/MfOverseasWarningTimelaps.kt
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.mf.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MfOverseasWarningTimelaps(
+    @SerialName("phenomenon_id") val phenomenonId: Long,
+    @SerialName("timelaps_items") val timelapsItems: List<MfWarningTimelapsItem>?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/mf/json/MfOverseasWarningsResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/mf/json/MfOverseasWarningsResult.kt
@@ -1,0 +1,30 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.mf.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.breezyweather.common.serializer.DateSerializer
+import java.util.Date
+
+@Serializable
+data class MfOverseasWarningsResult(
+    @Serializable(DateSerializer::class) @SerialName("update_time") val updateTime: Date? = null,
+    @Serializable(DateSerializer::class) @SerialName("end_validity_time") val endValidityTime: Date? = null,
+    val timelaps: List<MfOverseasWarningTimelaps>? = null,
+    val text: MfOverseasWarningComments? = null,
+)


### PR DESCRIPTION
I extended MF source to cover warnings for Andorra as well as the following French overseas territories:
- French Guiana
- French Polynesia
- Guadeloupe
- Martinique
- Mayotte
- New Caledonia
- Réunion
- St. Barthélemy
- St. Martin
- St. Pierre & Miquelon
- Wallis & Futuna

Alerts will now work whether using MF reverse geocoding (which gives country code `FR`) or manually input locations (which are often under different country codes).

I have also added new presets for the above locations as well as Monaco.