### PR TITLE
Miscellaneous geo-related fixes

### DIFF
--- a/app/src/main/java/org/breezyweather/common/source/LocationPreset.kt
+++ b/app/src/main/java/org/breezyweather/common/source/LocationPreset.kt
@@ -52,15 +52,25 @@ enum class LocationPreset(
     // Europe
     // AUSTRIA("openmeteo" /* GeoSphere too lightweight */, airQuality = "geosphereat", minutely = "geosphereat",
     //     alert = "geosphereat", normals = "geosphereat"),
+    ANDORRA("fr", airQuality = "openmeteo", pollen = "openmeteo"),
     DENMARK("dmi", airQuality = "openmeteo", pollen = "openmeteo", minutely = "metno", normals = "accu"),
     GERMANY("brightsky", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo", normals = "accu"),
     GERMANY_FREENET("brightsky", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo"),
     FINLAND("metno", airQuality = "openmeteo", pollen = "openmeteo", alert = "accu", normals = "accu"),
     FRANCE("mf", airQuality = "openmeteo", pollen = "recosante"),
+    FRANCE_OVERSEAS("mf", airQuality = "openmeteo", minutely = "openmeteo"),
     FRANCE_FREENET("openmeteo", pollen = "recosante"),
     IRELAND("metie", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo", normals = "accu"),
-    ITALY("meteoam", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo", normals = "accu"),
+    ITALY(
+        "meteoam",
+        airQuality = "openmeteo",
+        pollen = "openmeteo",
+        minutely = "openmeteo",
+        alert = "accu",
+        normals = "accu"
+    ),
     LUXEMBOURG("meteolux", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo", normals = "accu"),
+    MONACO("mf", airQuality = "openmeteo", pollen = "openmeteo", alert = "accu"),
     NORWAY("metno", pollen = "openmeteo", alert = "accu", normals = "accu"),
     PORTUGAL("ipma", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo", normals = "accu"),
     SPAIN("aemet", airQuality = "openmeteo", pollen = "openmeteo", alert = "accu", minutely = "openmeteo"),
@@ -78,13 +88,13 @@ enum class LocationPreset(
     // Don’t add cwa for TAIWAN as it is a rate-limited source
     BANGLADESH("bmd", airQuality = "openmeteo", minutely = "openmeteo", alert = "accu", normals = "accu"),
     CHINA("china"),
-    HONG_KONG("hko"),
-    INDONESIA("bmkg", pollen = "openmeteo", minutely = "openmeteo", normals = "accu"),
+    HONG_KONG("hko", airQuality = "openmeteo", minutely = "openmeteo"),
+    INDONESIA("bmkg", minutely = "openmeteo", normals = "accu"),
     INDIA("imd", airQuality = "openmeteo", minutely = "openmeteo", alert = "accu", normals = "accu"),
     ISRAEL("ims", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo"),
     JAPAN("jma", airQuality = "openmeteo", minutely = "openmeteo"),
     MACAO("smg", minutely = "openmeteo"),
-    MONGOLIA("namem"),
+    MONGOLIA("namem", minutely = "openmeteo", alert = "accu"),
     PHILIPPINES("pagasa", airQuality = "openmeteo", minutely = "openmeteo", alert = "accu", normals = "accu"),
     TURKIYE("mgm", airQuality = "openmeteo", pollen = "openmeteo", minutely = "openmeteo"),
     ;
@@ -96,18 +106,21 @@ enum class LocationPreset(
                 when (countryCode.uppercase(Locale.ENGLISH)) {
                     // North America
                     "CA" -> CANADA
-                    "US", "PR", "VI", "MP", "GU", "FM", "PW", "AS" -> USA
+                    "US", "PR", "VI", "MP", "GU" -> USA
 
                     // Europe
+                    "AD" -> ANDORRA
                     "DE" -> GERMANY
-                    "DK" -> DENMARK
+                    "DK", "FO", "GL" -> DENMARK
                     "ES" -> SPAIN
                     "FI" -> FINLAND
                     "FR" -> FRANCE
+                    "BL", "GF", "GP", "MF", "MQ", "NC", "PF", "PM", "RE", "WF", "YT" -> FRANCE_OVERSEAS
                     "IE" -> IRELAND
                     "IT", "SM", "VA" -> ITALY
                     "LU" -> LUXEMBOURG
-                    "NO" -> NORWAY
+                    "MC" -> MONACO
+                    "NO", "SJ" -> NORWAY
                     "PT" -> PORTUGAL
                     "SE" -> SWEDEN
 

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -689,4 +689,5 @@
     <string name="settings_unavailable_no_animations">Nepasiekiama, pirmiausia įgalinkite animacijas Android nustatymuose</string>
     <string name="settings_notifications_app_updates_check">Pranešimai apie programėlės atnaujinimus</string>
     <string name="meteoam_weather_text_tornado_watersprout">Tornadas arba vandens viesulas</string>
+    <string name="common_weather_text_squall">Škvalas</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -759,4 +759,5 @@
     <string name="jma_warning_text_frost_advisory">Aviso de atenção para geada</string>
     <string name="jma_warning_text_ice_accretion_advisory">Aviso de atenção para aderência de gelo</string>
     <string name="jma_warning_text_snow_accretion_advisory">Aviso de atenção para aderência de neve</string>
+    <string name="common_weather_text_squall">Borrasca</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -735,4 +735,5 @@
     <string name="jma_warning_text_frost_advisory">Aviso de atenção para geada</string>
     <string name="jma_warning_text_ice_accretion_advisory">Aviso de atenção para aderência de gelo</string>
     <string name="jma_warning_text_snow_accretion_advisory">Aviso de atenção para aderência de neve</string>
+    <string name="common_weather_text_squall">Borrasca</string>
 </resources>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -778,4 +778,5 @@
     <string name="jma_warning_text_snow_accretion_advisory">積雪注意報</string>
     <string name="location_message_location_access_off">位置存取尚未啟用</string>
     <string name="weather_message_failed_feature">無法更新來源：%s</string>
+    <string name="common_weather_text_squall">颮</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -787,4 +787,5 @@
     <string name="jma_warning_text_snow_accretion_advisory">積雪注意報</string>
     <string name="location_message_location_access_off">位置存取尚未啟用</string>
     <string name="weather_message_failed_feature">無法更新來源：%s</string>
+    <string name="common_weather_text_squall">颮</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -822,6 +822,7 @@
     <string name="common_weather_text_dust">Dust</string>
     <string name="common_weather_text_dust_storm">Dust storm</string>
     <string name="common_weather_text_frost">Frost</string>
+    <string name="common_weather_text_squall">Squall</string>
     <!-- Weather kind -->
     <string name="weather_kind_clear" translatable="false">@string/common_weather_text_clear_sky</string>
     <string name="weather_kind_partly_cloudy" translatable="false">@string/common_weather_text_partly_cloudy</string>

--- a/app/src/src_nonfreenet/org/breezyweather/sources/dmi/DmiService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/dmi/DmiService.kt
@@ -71,7 +71,7 @@ class DmiService @Inject constructor(
 
         val failedFeatures = mutableListOf<SourceFeature>()
         val alerts = if (!ignoreFeatures.contains(SourceFeature.FEATURE_ALERT) &&
-            location.countryCode.equals("DK", ignoreCase = true)
+            arrayOf("DK", "FO", "GL").any { it.equals(location.countryCode, ignoreCase = true) }
         ) {
             val id = location.parameters.getOrElse(id) { null }?.getOrElse("id") { null }
             if (!id.isNullOrEmpty()) {
@@ -103,7 +103,7 @@ class DmiService @Inject constructor(
         location: Location,
         feature: SourceFeature,
     ): Boolean {
-        return location.countryCode.equals("DK", ignoreCase = true)
+        return arrayOf("DK", "FO", "GL").any { it.equals(location.countryCode, ignoreCase = true) }
     }
     override val currentAttribution = null
     override val airQualityAttribution = null
@@ -153,13 +153,10 @@ class DmiService @Inject constructor(
         coordinatesChanged: Boolean,
         features: List<SourceFeature>,
     ): Boolean {
-        // If we are in Denmark, we need location parameters (update it if coordinates changes,
-        // OR if we didn't have it yet)
-        return location.countryCode.equals("DK", ignoreCase = true) &&
-            (
-                coordinatesChanged ||
-                    location.parameters.getOrElse(id) { null }?.getOrElse("id") { null }.isNullOrEmpty()
-                )
+        // If we are in Denmark, Faroe Islands, or Greenland, we need location parameters
+        // (update it if coordinates changes, OR if we didn't have it yet)
+        return arrayOf("DK", "FO", "GL").any { it.equals(location.countryCode, ignoreCase = true) } &&
+            (coordinatesChanged || location.parameters.getOrElse(id) { null }?.getOrElse("id") { null }.isNullOrEmpty())
     }
 
     override fun requestLocationParameters(

--- a/app/src/src_nonfreenet/org/breezyweather/sources/metno/MetNoService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/metno/MetNoService.kt
@@ -159,11 +159,13 @@ class MetNoService @Inject constructor(
                 Observable.just(MetNoAirQualityResult())
             }
 
-        // Alerts only for Norway
+        // Alerts only for Norway and Svalbard & Jan Mayen
         val alerts =
             if (!ignoreFeatures.contains(SourceFeature.FEATURE_ALERT) &&
                 !location.countryCode.isNullOrEmpty() &&
-                location.countryCode.equals("NO", ignoreCase = true)
+                arrayOf("NO", "SJ").any {
+                    it.equals(location.countryCode, ignoreCase = true)
+                }
             ) {
                 mApi.getAlerts(
                     USER_AGENT,
@@ -229,7 +231,9 @@ class MetNoService @Inject constructor(
             (
                 feature == SourceFeature.FEATURE_ALERT &&
                     !location.countryCode.isNullOrEmpty() &&
-                    location.countryCode.equals("NO", ignoreCase = true)
+                    arrayOf("NO", "SJ").any {
+                        it.equals(location.countryCode, ignoreCase = true)
+                    }
                 )
     }
     override val currentAttribution = weatherAttribution
@@ -278,11 +282,13 @@ class MetNoService @Inject constructor(
             Observable.just(MetNoAirQualityResult())
         }
 
-        // Alerts only for Norway
+        // Alerts only for Norway and Svalbard & Jan Mayen
         val alerts =
             if (requestedFeatures.contains(SourceFeature.FEATURE_ALERT) &&
                 !location.countryCode.isNullOrEmpty() &&
-                location.countryCode.equals("NO", ignoreCase = true)
+                arrayOf("NO", "SJ").any {
+                    it.equals(location.countryCode, ignoreCase = true)
+                }
             ) {
                 mApi.getAlerts(
                     USER_AGENT,

--- a/app/src/src_nonfreenet/org/breezyweather/sources/metoffice/MetOfficeService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/metoffice/MetOfficeService.kt
@@ -92,8 +92,7 @@ class MetOfficeService @Inject constructor(
                 it.features.getOrNull(0)?.let { feature ->
                     add(
                         location.copy(
-                            district = feature.properties.location?.name,
-                            countryCode = "GB"
+                            district = feature.properties.location?.name
                         )
                     )
                 }

--- a/app/src/src_nonfreenet/org/breezyweather/sources/nws/NwsService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/nws/NwsService.kt
@@ -63,11 +63,13 @@ class NwsService @Inject constructor(
         "PR", // Puerto Rico
         "VI", // St Thomas Islands
         "MP", // Mariana Islands
-        "GU", // Guam
-        "FM", // Palikir
-        "PW", // Melekeok
-        "AS", // Pago Pago
-        "UM", "XB", "XH", "XQ", "XU", "XM", "QM", "XV", "XL", "QW" // Minor Outlying Islands
+        "GU" // Guam
+        // The following codes no longer work as of 2024-11-21
+        // "FM", // Palikir - no longer works as of 2024-11-21
+        // "PW", // Melekeok - no longer works as of 2024-11-21
+        // "AS", // Pago Pago - no longer works as of 2024-11-21
+        // "UM", "XB", "XH", "XQ", "XU", "XM", "QM", "XV", "XL", "QW" // Minor Outlying Islands
+        // Minor Outlying Islands are largely uninhabited, except for temporary U.S. military staff
     )
 
     override fun isFeatureSupportedInMainForLocation(

--- a/app/src/src_nonfreenet/org/breezyweather/sources/smg/SmgResultConverter.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/smg/SmgResultConverter.kt
@@ -485,7 +485,7 @@ private fun getWeatherText(
         "08" -> context.getString(R.string.common_weather_text_mist) // Mist
         "09" -> context.getString(R.string.common_weather_text_smoke) // Smoke
         "10" -> context.getString(R.string.common_weather_text_drizzle) // Drizzle
-        "11" -> context.getString(R.string.weather_kind_thunderstorm) // Squall
+        "11" -> context.getString(R.string.common_weather_text_squall) // Squall
         "12" -> context.getString(R.string.common_weather_text_rain) // Rain
         "13" -> context.getString(R.string.common_weather_text_rain_heavy)
         "14", "15" -> context.getString(R.string.common_weather_text_snow) // Snow
@@ -520,10 +520,10 @@ private fun getWeatherCode(
         "06", "08" -> WeatherCode.FOG
         "05", "07", "09" -> WeatherCode.HAZE
         "10", "12", "13", "16", "17", "28", "c8", "29", "c9" -> WeatherCode.RAIN
-        "11", "18", "24" -> WeatherCode.THUNDERSTORM
+        "18", "24" -> WeatherCode.THUNDERSTORM
         "14", "15" -> WeatherCode.SNOW
         "25" -> WeatherCode.THUNDER
-        "19", "20", "22", "23", "27", "30" -> WeatherCode.WIND
+        "11", "19", "20", "22", "23", "27", "30" -> WeatherCode.WIND
         else -> null
     }
 }


### PR DESCRIPTION
### Presets
- Added presets for various overseas territories:
  - Denmark: Faroe Islands, Greenland
  - France: French Guiana, French Polynesia, Guadeloupe, Martinique, Mayotte, New Caledonia, Réunion, St. Barthélemy, St. Martin, St. Pierre & Miquelon, Wallis & Futuna
  - Norway: Svalbard & Jan Mayen
- Added presets for Andorra, Monaco
- Amended presets for Hong Kong, Indonesia, Italy, Mongolia
- Removed presets for several locations as the NWS API no longer works for them: American Samoa, Federated States of Micronesia, Palau

### Sources
- Extended check of DMI to cover Faroe Islands, Greenland for alerts
- Extended check of MET Norway to cover Svalbard & Jan Mayen for alerts
- Removed assumption of `GB` country code during reverse geocoding in Met Office, as the source can be used worldwide
- Removed support for American Samoa, Federated States of Micronesia, Palau, and U.S. Minor Outlying Islands from NWS

### Resource text
- Added resource text for "Squall" in English, Traditional Chinese (TW, HK), Portuguese (PT, BR), and Lithuanian