### PR TITLE
Reformatted source names with countries

### DIFF
--- a/app/src/main/java/org/breezyweather/sources/brightsky/BrightSkyService.kt
+++ b/app/src/main/java/org/breezyweather/sources/brightsky/BrightSkyService.kt
@@ -43,6 +43,7 @@ import org.breezyweather.sources.brightsky.json.BrightSkyCurrentWeatherResult
 import retrofit2.Retrofit
 import java.util.Calendar
 import java.util.Date
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -52,7 +53,7 @@ class BrightSkyService @Inject constructor(
 ) : HttpSource(), MainWeatherSource, SecondaryWeatherSource, ConfigurableSource {
 
     override val id = "brightsky"
-    override val name = "Bright Sky (DWD)"
+    override val name = "Bright Sky (DWD) (${Locale(context.currentLocale.code, "DE").displayCountry})"
     override val continent = SourceContinent.EUROPE
     override val privacyPolicyUrl = "https://brightsky.dev/"
 

--- a/app/src/main/java/org/breezyweather/sources/recosante/RecosanteService.kt
+++ b/app/src/main/java/org/breezyweather/sources/recosante/RecosanteService.kt
@@ -26,6 +26,8 @@ import io.reactivex.rxjava3.core.Observable
 import org.breezyweather.R
 import org.breezyweather.common.exceptions.InvalidLocationException
 import org.breezyweather.common.exceptions.SecondaryWeatherException
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
 import org.breezyweather.common.preference.EditTextPreference
 import org.breezyweather.common.preference.Preference
 import org.breezyweather.common.source.ConfigurableSource
@@ -35,6 +37,7 @@ import org.breezyweather.common.source.PollenIndexSource
 import org.breezyweather.common.source.SecondaryWeatherSource
 import org.breezyweather.settings.SourceConfigStore
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -47,7 +50,7 @@ class RecosanteService @Inject constructor(
 ) : HttpSource(), SecondaryWeatherSource, PollenIndexSource, LocationParametersSource, ConfigurableSource {
 
     override val id = "recosante"
-    override val name = "Recosanté"
+    override val name = "Recosanté (${Locale(context.currentLocale.code, "FR").displayCountry})"
     override val continent = SourceContinent.EUROPE
     override val privacyPolicyUrl = "https://recosante.beta.gouv.fr/donnees-personnelles/"
 

--- a/app/src/src_nonfreenet/org/breezyweather/sources/aemet/AemetService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/aemet/AemetService.kt
@@ -32,6 +32,8 @@ import org.breezyweather.R
 import org.breezyweather.common.exceptions.ApiKeyMissingException
 import org.breezyweather.common.exceptions.InvalidLocationException
 import org.breezyweather.common.exceptions.InvalidOrIncompleteDataException
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
 import org.breezyweather.common.preference.EditTextPreference
 import org.breezyweather.common.preference.Preference
 import org.breezyweather.common.source.ConfigurableSource
@@ -45,6 +47,7 @@ import org.breezyweather.sources.aemet.json.AemetDailyResult
 import org.breezyweather.sources.aemet.json.AemetHourlyResult
 import org.breezyweather.sources.aemet.json.AemetNormalsResult
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.text.ifEmpty
@@ -55,7 +58,7 @@ class AemetService @Inject constructor(
 ) : HttpSource(), MainWeatherSource, SecondaryWeatherSource, LocationParametersSource, ConfigurableSource {
 
     override val id = "aemet"
-    override val name = "AEMET"
+    override val name = "AEMET (${Locale(context.currentLocale.code, "ES").displayCountry})"
     override val continent = SourceContinent.EUROPE
     override val privacyPolicyUrl = "https://www.aemet.es/es/nota_legal"
 

--- a/app/src/src_nonfreenet/org/breezyweather/sources/atmoaura/AtmoAuraService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/atmoaura/AtmoAuraService.kt
@@ -27,6 +27,8 @@ import org.breezyweather.BuildConfig
 import org.breezyweather.R
 import org.breezyweather.common.exceptions.ApiKeyMissingException
 import org.breezyweather.common.exceptions.SecondaryWeatherException
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
 import org.breezyweather.common.extensions.getFormattedDate
 import org.breezyweather.common.extensions.toCalendarWithTimeZone
 import org.breezyweather.common.preference.EditTextPreference
@@ -38,6 +40,7 @@ import org.breezyweather.settings.SourceConfigStore
 import retrofit2.Retrofit
 import java.util.Calendar
 import java.util.Date
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -50,7 +53,7 @@ class AtmoAuraService @Inject constructor(
 ) : HttpSource(), SecondaryWeatherSource, ConfigurableSource {
 
     override val id = "atmoaura"
-    override val name = "ATMO Auvergne-Rhône-Alpes"
+    override val name = "ATMO Auvergne-Rhône-Alpes (${Locale(context.currentLocale.code, "FR").displayCountry})"
     override val continent = SourceContinent.EUROPE
     override val privacyPolicyUrl = "https://www.atmo-auvergnerhonealpes.fr/article/politique-de-confidentialite"
 

--- a/app/src/src_nonfreenet/org/breezyweather/sources/baiduip/BaiduIPLocationService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/baiduip/BaiduIPLocationService.kt
@@ -38,6 +38,7 @@ import org.breezyweather.common.source.LocationPositionWrapper
 import org.breezyweather.common.source.LocationSource
 import org.breezyweather.settings.SourceConfigStore
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -50,8 +51,8 @@ class BaiduIPLocationService @Inject constructor(
     override val name by lazy {
         with(context.currentLocale.code) {
             when {
-                startsWith("zh") -> "百度IP定位"
-                else -> "Baidu IP location"
+                startsWith("zh") -> "百度IP定位 (${Locale(context.currentLocale.code, "CN").displayCountry})"
+                else -> "Baidu IP location (${Locale(context.currentLocale.code, "CN").displayCountry})"
             }
         }
     }

--- a/app/src/src_nonfreenet/org/breezyweather/sources/bmd/BmdService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/bmd/BmdService.kt
@@ -35,6 +35,7 @@ import org.breezyweather.common.source.MainWeatherSource
 import org.breezyweather.common.source.ReverseGeocodingSource
 import org.breezyweather.sources.bmd.json.BmdForecastResult
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -48,7 +49,7 @@ class BmdService @Inject constructor(
         if (context.currentLocale.code.startsWith("bn")) {
             "বাংলাদেশ আবহাওয়া অধিদপ্তর"
         } else {
-            "Bangladesh Meteorological Department"
+            "BMD (${Locale(context.currentLocale.code, "BD").displayCountry})"
         }
     }
     override val continent = SourceContinent.ASIA

--- a/app/src/src_nonfreenet/org/breezyweather/sources/bmkg/BmkgService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/bmkg/BmkgService.kt
@@ -29,6 +29,8 @@ import org.breezyweather.BuildConfig
 import org.breezyweather.R
 import org.breezyweather.common.exceptions.ApiKeyMissingException
 import org.breezyweather.common.exceptions.SecondaryWeatherException
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
 import org.breezyweather.common.preference.EditTextPreference
 import org.breezyweather.common.preference.Preference
 import org.breezyweather.common.source.ConfigurableSource
@@ -43,6 +45,7 @@ import org.breezyweather.sources.bmkg.json.BmkgIbfResult
 import org.breezyweather.sources.bmkg.json.BmkgPm25Result
 import org.breezyweather.sources.bmkg.json.BmkgWarningResult
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.text.ifEmpty
@@ -53,7 +56,7 @@ class BmkgService @Inject constructor(
 ) : HttpSource(), MainWeatherSource, SecondaryWeatherSource, ReverseGeocodingSource, ConfigurableSource {
 
     override val id = "bmkg"
-    override val name = "BMKG"
+    override val name = "BMKG (${Locale(context.currentLocale.code, "ID").displayCountry})"
     override val continent = SourceContinent.ASIA
     override val privacyPolicyUrl = ""
 

--- a/app/src/src_nonfreenet/org/breezyweather/sources/china/ChinaService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/china/ChinaService.kt
@@ -38,6 +38,7 @@ import org.breezyweather.common.source.SecondaryWeatherSource
 import org.breezyweather.sources.china.json.ChinaForecastResult
 import org.breezyweather.sources.china.json.ChinaMinutelyResult
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -52,14 +53,7 @@ class ChinaService @Inject constructor(
     LocationParametersSource {
 
     override val id = "china"
-    override val name by lazy {
-        with(context.currentLocale.code) {
-            when {
-                startsWith("zh") -> "中国"
-                else -> "China"
-            }
-        }
-    }
+    override val name = "${Locale(context.currentLocale.code, "CN").displayCountry}"
     override val continent = SourceContinent.ASIA
     override val privacyPolicyUrl by lazy {
         with(context.currentLocale.code) {

--- a/app/src/src_nonfreenet/org/breezyweather/sources/cwa/CwaService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/cwa/CwaService.kt
@@ -73,8 +73,8 @@ class CwaService @Inject constructor(
     override val name by lazy {
         with(context.currentLocale.code) {
             when {
-                startsWith("zh") -> "中央氣象署"
-                else -> "Central Weather Administration (CWA)"
+                startsWith("zh") -> "中央氣象署 (${Locale(context.currentLocale.code, "TW").displayCountry})"
+                else -> "CWA (${Locale(context.currentLocale.code, "TW").displayCountry})"
             }
         }
     }

--- a/app/src/src_nonfreenet/org/breezyweather/sources/dmi/DmiService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/dmi/DmiService.kt
@@ -23,9 +23,12 @@ import breezyweather.domain.source.SourceContinent
 import breezyweather.domain.source.SourceFeature
 import breezyweather.domain.weather.wrappers.SecondaryWeatherWrapper
 import breezyweather.domain.weather.wrappers.WeatherWrapper
+import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.rxjava3.core.Observable
 import org.breezyweather.common.exceptions.InvalidLocationException
 import org.breezyweather.common.exceptions.SecondaryWeatherException
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
 import org.breezyweather.common.source.HttpSource
 import org.breezyweather.common.source.LocationParametersSource
 import org.breezyweather.common.source.MainWeatherSource
@@ -34,15 +37,17 @@ import org.breezyweather.common.source.SecondaryWeatherSource
 import org.breezyweather.sources.dmi.json.DmiResult
 import org.breezyweather.sources.dmi.json.DmiWarningResult
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
 class DmiService @Inject constructor(
+    @ApplicationContext context: Context,
     @Named("JsonClient") client: Retrofit.Builder,
 ) : HttpSource(), MainWeatherSource, SecondaryWeatherSource, ReverseGeocodingSource, LocationParametersSource {
 
     override val id = "dmi"
-    override val name = "Danmarks Meteorologiske Institut (DMI)"
+    override val name = "DMI (${Locale(context.currentLocale.code, "DK").displayCountry})"
     override val continent = SourceContinent.EUROPE
     override val privacyPolicyUrl = "https://www.dmi.dk/om-hjemmesiden/privatliv/"
 

--- a/app/src/src_nonfreenet/org/breezyweather/sources/eccc/EcccService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/eccc/EcccService.kt
@@ -33,6 +33,7 @@ import org.breezyweather.common.source.MainWeatherSource
 import org.breezyweather.common.source.ReverseGeocodingSource
 import org.breezyweather.common.source.SecondaryWeatherSource
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -42,14 +43,9 @@ class EcccService @Inject constructor(
 ) : HttpSource(), MainWeatherSource, SecondaryWeatherSource, ReverseGeocodingSource {
 
     override val id = "eccc"
-    override val name by lazy {
-        with(context.currentLocale.code) {
-            when {
-                startsWith("fr") -> "Environnement et Changement Climatique Canada"
-                else -> "Environment and Climate Change Canada"
-            }
-        }
-    }
+    override val name = "ECCC (${Locale(context.currentLocale.code, "CA").displayCountry})"
+
+    // Environnement et Changement Climatique Canada
     override val continent = SourceContinent.NORTH_AMERICA
     override val privacyPolicyUrl by lazy {
         with(context.currentLocale.code) {
@@ -61,8 +57,18 @@ class EcccService @Inject constructor(
     }
 
     override val color = Color.rgb(255, 0, 0)
-    override val weatherAttribution =
-        "Environment and Climate Change Canada (Environment and Climate Change Canada Data Servers End-use Licence)"
+    override val weatherAttribution by lazy {
+        with(context.currentLocale.code) {
+            when {
+                startsWith("fr") ->
+                    "Environnement et Changement Climatique Canada (Licence d’utilisation finale" +
+                        " pour les serveurs de données d’Environnement et Changement climatique Canada)"
+                else ->
+                    "Environment and Climate Change Canada" +
+                        " (Environment and Climate Change Canada Data Servers End-use Licence)"
+            }
+        }
+    }
 
     private val mApi by lazy {
         client

--- a/app/src/src_nonfreenet/org/breezyweather/sources/geosphereat/GeoSphereAtService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/geosphereat/GeoSphereAtService.kt
@@ -25,6 +25,7 @@ import breezyweather.domain.weather.wrappers.SecondaryWeatherWrapper
 import breezyweather.domain.weather.wrappers.WeatherWrapper
 import com.google.maps.android.model.LatLng
 import com.google.maps.android.model.LatLngBounds
+import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.rxjava3.core.Observable
 import org.breezyweather.common.exceptions.SecondaryWeatherException
 import org.breezyweather.common.extensions.code
@@ -35,15 +36,24 @@ import org.breezyweather.common.source.SecondaryWeatherSource
 import org.breezyweather.sources.geosphereat.json.GeoSphereAtTimeseriesResult
 import org.breezyweather.sources.geosphereat.json.GeoSphereAtWarningsResult
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
 class GeoSphereAtService @Inject constructor(
+    @ApplicationContext context: Context,
     @Named("JsonClient") client: Retrofit.Builder,
 ) : HttpSource(), MainWeatherSource, SecondaryWeatherSource {
 
     override val id = "geosphereat"
-    override val name = "GeoSphere Austria"
+    val countryName = Locale(context.currentLocale.code, "AT").displayCountry
+    override val name = "GeoSphere Austria".let {
+        if (it.contains(countryName)) {
+            it
+        } else {
+            "$it ($countryName)"
+        }
+    }
     override val continent = SourceContinent.EUROPE
     override val privacyPolicyUrl = "https://www.geosphere.at/de/legal"
 

--- a/app/src/src_nonfreenet/org/breezyweather/sources/hko/HkoService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/hko/HkoService.kt
@@ -63,7 +63,7 @@ class HkoService @Inject constructor(
         if (context.currentLocale.code.startsWith("zh")) {
             "香港天文台"
         } else {
-            "Hong Kong Observatory"
+            "HKO (${Locale(context.currentLocale.code, "HK").displayCountry})"
         }
     }
     override val continent = SourceContinent.ASIA

--- a/app/src/src_nonfreenet/org/breezyweather/sources/imd/ImdService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/imd/ImdService.kt
@@ -22,9 +22,12 @@ import breezyweather.domain.location.model.Location
 import breezyweather.domain.source.SourceContinent
 import breezyweather.domain.source.SourceFeature
 import breezyweather.domain.weather.wrappers.WeatherWrapper
+import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.rxjava3.core.Observable
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
 import org.breezyweather.common.source.HttpSource
 import org.breezyweather.common.source.MainWeatherSource
 import org.breezyweather.sources.imd.json.ImdWeatherResult
@@ -37,11 +40,12 @@ import javax.inject.Named
 import kotlin.math.roundToInt
 
 class ImdService @Inject constructor(
+    @ApplicationContext context: Context,
     @Named("JsonClient") client: Retrofit.Builder,
 ) : HttpSource(), MainWeatherSource {
 
     override val id = "imd"
-    override val name = "India Meteorological Department"
+    override val name = "IMD (${Locale(context.currentLocale.code, "IN").displayCountry})"
     override val continent = SourceContinent.ASIA
     override val privacyPolicyUrl = ""
 

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ims/ImsService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ims/ImsService.kt
@@ -39,6 +39,7 @@ import org.breezyweather.common.source.ReverseGeocodingSource
 import org.breezyweather.common.source.SecondaryWeatherSource
 import org.breezyweather.common.utils.helpers.LogHelper
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -55,7 +56,7 @@ class ImsService @Inject constructor(
         with(context.currentLocale.code) {
             when {
                 startsWith("he") || startsWith("iw") -> "השירות המטאורולוגי הישראלי"
-                else -> "Israel Meteorological Service"
+                else -> "IMS (${Locale(context.currentLocale.code, "IL").displayCountry})"
             }
         }
     }
@@ -70,7 +71,14 @@ class ImsService @Inject constructor(
     }
 
     override val color = Color.rgb(52, 79, 110)
-    override val weatherAttribution = "Israel Meteorological Service"
+    override val weatherAttribution by lazy {
+        with(context.currentLocale.code) {
+            when {
+                startsWith("he") || startsWith("iw") -> "השירות המטאורולוגי הישראלי"
+                else -> "Israel Meteorological Service"
+            }
+        }
+    }
 
     private val mApi by lazy {
         client

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ipma/IpmaService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ipma/IpmaService.kt
@@ -39,6 +39,7 @@ import org.breezyweather.sources.ipma.json.IpmaDistrictResult
 import org.breezyweather.sources.ipma.json.IpmaForecastResult
 import org.breezyweather.sources.ipma.json.IpmaLocationResult
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.text.startsWith
@@ -49,7 +50,7 @@ class IpmaService @Inject constructor(
 ) : HttpSource(), MainWeatherSource, SecondaryWeatherSource, ReverseGeocodingSource, LocationParametersSource {
 
     override val id = "ipma"
-    override val name = "IPMA"
+    override val name = "IPMA (${Locale(context.currentLocale.code, "PT").displayCountry})"
     override val continent = SourceContinent.EUROPE
     override val privacyPolicyUrl by lazy {
         if (context.currentLocale.code.startsWith("pt")) {

--- a/app/src/src_nonfreenet/org/breezyweather/sources/jma/JmaService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/jma/JmaService.kt
@@ -62,7 +62,7 @@ class JmaService @Inject constructor(
         if (context.currentLocale.code.startsWith("ja")) {
             "気象庁"
         } else {
-            "Japan Meteorological Agency"
+            "JMA (${Locale(context.currentLocale.code, "JP").displayCountry})"
         }
     }
     override val continent = SourceContinent.ASIA

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/MeteoAmService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/MeteoAmService.kt
@@ -24,8 +24,11 @@ import breezyweather.domain.source.SourceContinent
 import breezyweather.domain.source.SourceFeature
 import breezyweather.domain.weather.wrappers.SecondaryWeatherWrapper
 import breezyweather.domain.weather.wrappers.WeatherWrapper
+import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.rxjava3.core.Observable
 import org.breezyweather.common.exceptions.SecondaryWeatherException
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
 import org.breezyweather.common.source.HttpSource
 import org.breezyweather.common.source.MainWeatherSource
 import org.breezyweather.common.source.ReverseGeocodingSource
@@ -34,15 +37,17 @@ import org.breezyweather.sources.meteoam.json.MeteoAmForecastResult
 import org.breezyweather.sources.meteoam.json.MeteoAmObservationResult
 import org.breezyweather.sources.meteoam.json.MeteoAmReverseLocationResult
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
 class MeteoAmService @Inject constructor(
+    @ApplicationContext context: Context,
     @Named("JsonClient") client: Retrofit.Builder,
 ) : HttpSource(), MainWeatherSource, SecondaryWeatherSource, ReverseGeocodingSource {
 
     override val id = "meteoam"
-    override val name = "Servizio Meteo AM"
+    override val name = "Servizio Meteo AM (${Locale(context.currentLocale.code, "IT").displayCountry})"
     override val continent = SourceContinent.EUROPE
     override val privacyPolicyUrl = "https://www.meteoam.it/it/privacy-policy"
 

--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/MeteoLuxService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteolux/MeteoLuxService.kt
@@ -33,6 +33,7 @@ import org.breezyweather.common.source.MainWeatherSource
 import org.breezyweather.common.source.ReverseGeocodingSource
 import org.breezyweather.common.source.SecondaryWeatherSource
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -42,7 +43,7 @@ class MeteoLuxService @Inject constructor(
 ) : HttpSource(), MainWeatherSource, SecondaryWeatherSource, ReverseGeocodingSource {
 
     override val id = "meteolux"
-    override val name = "MeteoLux"
+    override val name = "MeteoLux (${Locale(context.currentLocale.code, "LU").displayCountry})"
     override val continent = SourceContinent.EUROPE
     override val privacyPolicyUrl by lazy {
         with(context.currentLocale.code) {

--- a/app/src/src_nonfreenet/org/breezyweather/sources/metie/MetIeService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/metie/MetIeService.kt
@@ -23,8 +23,11 @@ import breezyweather.domain.source.SourceContinent
 import breezyweather.domain.source.SourceFeature
 import breezyweather.domain.weather.wrappers.SecondaryWeatherWrapper
 import breezyweather.domain.weather.wrappers.WeatherWrapper
+import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.rxjava3.core.Observable
 import org.breezyweather.common.exceptions.InvalidLocationException
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
 import org.breezyweather.common.source.HttpSource
 import org.breezyweather.common.source.LocationParametersSource
 import org.breezyweather.common.source.MainWeatherSource
@@ -33,6 +36,7 @@ import org.breezyweather.common.source.SecondaryWeatherSource
 import org.breezyweather.sources.metie.json.MetIeHourly
 import org.breezyweather.sources.metie.json.MetIeWarningResult
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -40,11 +44,19 @@ import javax.inject.Named
  * MET Éireann service
  */
 class MetIeService @Inject constructor(
+    @ApplicationContext context: Context,
     @Named("JsonClient") client: Retrofit.Builder,
 ) : HttpSource(), MainWeatherSource, SecondaryWeatherSource, ReverseGeocodingSource, LocationParametersSource {
 
     override val id = "metie"
-    override val name = "MET Éireann"
+    val countryName = Locale(context.currentLocale.code, "IE").displayCountry
+    override val name = "MET Éireann".let {
+        if (it.contains(countryName)) {
+            it
+        } else {
+            "$it ($countryName)"
+        }
+    }
     override val continent = SourceContinent.EUROPE
     override val privacyPolicyUrl = "https://www.met.ie/about-us/privacy"
 

--- a/app/src/src_nonfreenet/org/breezyweather/sources/metno/MetNoService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/metno/MetNoService.kt
@@ -40,6 +40,7 @@ import org.breezyweather.sources.metno.json.MetNoNowcastResult
 import org.breezyweather.sources.metno.json.MetNoSunResult
 import retrofit2.Retrofit
 import java.util.Date
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -49,11 +50,18 @@ class MetNoService @Inject constructor(
 ) : HttpSource(), MainWeatherSource, SecondaryWeatherSource {
 
     override val id = "metno"
+    val countryName = Locale(context.currentLocale.code, "NO").displayCountry
     override val name by lazy {
         with(context.currentLocale.code) {
             when {
                 startsWith("no") -> "Meteorologisk institutt"
-                else -> "MET Norway"
+                else -> "MET Norway".let {
+                    if (it.contains(countryName)) {
+                        it
+                    } else {
+                        "$it ($countryName)"
+                    }
+                }
             }
         }
     }

--- a/app/src/src_nonfreenet/org/breezyweather/sources/metoffice/MetOfficeService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/metoffice/MetOfficeService.kt
@@ -27,6 +27,8 @@ import io.reactivex.rxjava3.core.Observable
 import org.breezyweather.BuildConfig
 import org.breezyweather.R
 import org.breezyweather.common.exceptions.ApiKeyMissingException
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
 import org.breezyweather.common.preference.EditTextPreference
 import org.breezyweather.common.preference.Preference
 import org.breezyweather.common.source.ConfigurableSource
@@ -35,6 +37,7 @@ import org.breezyweather.common.source.MainWeatherSource
 import org.breezyweather.common.source.ReverseGeocodingSource
 import org.breezyweather.settings.SourceConfigStore
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -44,7 +47,7 @@ class MetOfficeService @Inject constructor(
 ) : HttpSource(), MainWeatherSource, ConfigurableSource, ReverseGeocodingSource {
 
     override val id = "metoffice"
-    override val name = "Met Office"
+    override val name = "Met Office (${Locale(context.currentLocale.code, "GB").displayCountry})"
     override val continent = SourceContinent.EUROPE
     override val privacyPolicyUrl = "https://www.metoffice.gov.uk/policies/privacy"
 

--- a/app/src/src_nonfreenet/org/breezyweather/sources/mf/MfService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/mf/MfService.kt
@@ -49,6 +49,7 @@ import org.breezyweather.sources.mf.json.MfWarningsResult
 import retrofit2.Retrofit
 import java.nio.charset.StandardCharsets
 import java.util.Date
+import java.util.Locale
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Named
@@ -62,7 +63,14 @@ class MfService @Inject constructor(
 ) : HttpSource(), MainWeatherSource, SecondaryWeatherSource, ReverseGeocodingSource, ConfigurableSource {
 
     override val id = "mf"
-    override val name = "Météo-France"
+    val countryName = Locale(context.currentLocale.code, "FR").displayCountry
+    override val name = "Météo-France".let {
+        if (it.contains(countryName)) {
+            it
+        } else {
+            "$it ($countryName)"
+        }
+    }
     override val continent = SourceContinent.EUROPE
     override val privacyPolicyUrl = "https://meteofrance.com/application-meteo-france-politique-de-confidentialite"
 

--- a/app/src/src_nonfreenet/org/breezyweather/sources/mgm/MgmService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/mgm/MgmService.kt
@@ -23,9 +23,12 @@ import breezyweather.domain.source.SourceContinent
 import breezyweather.domain.source.SourceFeature
 import breezyweather.domain.weather.wrappers.SecondaryWeatherWrapper
 import breezyweather.domain.weather.wrappers.WeatherWrapper
+import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.rxjava3.core.Observable
 import org.breezyweather.common.exceptions.InvalidLocationException
 import org.breezyweather.common.exceptions.SecondaryWeatherException
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
 import org.breezyweather.common.source.HttpSource
 import org.breezyweather.common.source.LocationParametersSource
 import org.breezyweather.common.source.MainWeatherSource
@@ -44,11 +47,12 @@ import javax.inject.Inject
 import javax.inject.Named
 
 class MgmService @Inject constructor(
+    @ApplicationContext context: Context,
     @Named("JsonClient") client: Retrofit.Builder,
 ) : HttpSource(), MainWeatherSource, SecondaryWeatherSource, ReverseGeocodingSource, LocationParametersSource {
 
     override val id = "mgm"
-    override val name = "Meteoroloji Genel Müdürlüğü (MGM)"
+    override val name = "MGM (${Locale(context.currentLocale.code, "TR").displayCountry})"
     override val continent = SourceContinent.ASIA
     override val privacyPolicyUrl = "https://www.mgm.gov.tr/site/gizlilik-politikasi.aspx"
 

--- a/app/src/src_nonfreenet/org/breezyweather/sources/namem/NamemService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/namem/NamemService.kt
@@ -42,6 +42,7 @@ import org.breezyweather.sources.namem.json.NamemDailyResult
 import org.breezyweather.sources.namem.json.NamemHourlyResult
 import org.breezyweather.sources.namem.json.NamemNormalsResult
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 import kotlin.text.startsWith
@@ -56,7 +57,7 @@ class NamemService @Inject constructor(
         if (context.currentLocale.code.startsWith("mn")) {
             "Цаг уур, орчны шинжилгээний газар"
         } else {
-            "NAMEM"
+            "NAMEM (${Locale(context.currentLocale.code, "MN").displayCountry})"
         }
     }
     override val continent = SourceContinent.ASIA

--- a/app/src/src_nonfreenet/org/breezyweather/sources/nws/NwsService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/nws/NwsService.kt
@@ -23,10 +23,13 @@ import breezyweather.domain.source.SourceContinent
 import breezyweather.domain.source.SourceFeature
 import breezyweather.domain.weather.wrappers.SecondaryWeatherWrapper
 import breezyweather.domain.weather.wrappers.WeatherWrapper
+import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.rxjava3.core.Observable
 import org.breezyweather.BuildConfig
 import org.breezyweather.common.exceptions.InvalidLocationException
 import org.breezyweather.common.exceptions.SecondaryWeatherException
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
 import org.breezyweather.common.source.HttpSource
 import org.breezyweather.common.source.LocationParametersSource
 import org.breezyweather.common.source.MainWeatherSource
@@ -34,15 +37,17 @@ import org.breezyweather.common.source.ReverseGeocodingSource
 import org.breezyweather.common.source.SecondaryWeatherSource
 import org.breezyweather.sources.nws.json.NwsAlertsResult
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
 class NwsService @Inject constructor(
+    @ApplicationContext context: Context,
     @Named("JsonClient") client: Retrofit.Builder,
 ) : HttpSource(), MainWeatherSource, SecondaryWeatherSource, ReverseGeocodingSource, LocationParametersSource {
 
     override val id = "nws"
-    override val name = "National Weather Service (NWS)"
+    override val name = "NWS (${Locale(context.currentLocale.code, "US").displayCountry})"
     override val continent = SourceContinent.NORTH_AMERICA
     override val privacyPolicyUrl = "https://www.weather.gov/privacy"
 

--- a/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/PagasaService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/pagasa/PagasaService.kt
@@ -23,23 +23,28 @@ import breezyweather.domain.location.model.Location
 import breezyweather.domain.source.SourceContinent
 import breezyweather.domain.source.SourceFeature
 import breezyweather.domain.weather.wrappers.WeatherWrapper
+import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.rxjava3.core.Observable
 import org.breezyweather.common.exceptions.InvalidLocationException
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
 import org.breezyweather.common.source.HttpSource
 import org.breezyweather.common.source.LocationParametersSource
 import org.breezyweather.common.source.MainWeatherSource
 import org.breezyweather.sources.pagasa.json.PagasaCurrentResult
 import org.breezyweather.sources.pagasa.json.PagasaHourlyResult
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
 class PagasaService @Inject constructor(
+    @ApplicationContext context: Context,
     @Named("JsonClient") client: Retrofit.Builder,
 ) : HttpSource(), MainWeatherSource, LocationParametersSource {
 
     override val id = "pagasa"
-    override val name = "PAGASA"
+    override val name = "PAGASA (${Locale(context.currentLocale.code, "PH").displayCountry})"
     override val continent = SourceContinent.ASIA
     override val privacyPolicyUrl = ""
     override val color = Color.rgb(75, 196, 211)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/smg/SmgService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/smg/SmgService.kt
@@ -61,9 +61,9 @@ class SmgService @Inject constructor(
     // for use in the source list. The English name can be used in attributions.
     override val name by lazy {
         if (context.currentLocale.code.startsWith("zh")) {
-            "地球物理氣象局"
+            "地球物理氣象局 (${Locale(context.currentLocale.code, "MO").displayCountry})"
         } else {
-            "Serviços Meteorológicos e Geofísicos (SMG)"
+            "SMG (${Locale(context.currentLocale.code, "MO").displayCountry})"
         }
     }
     override val continent = SourceContinent.ASIA

--- a/app/src/src_nonfreenet/org/breezyweather/sources/smhi/SmhiService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/smhi/SmhiService.kt
@@ -22,19 +22,24 @@ import breezyweather.domain.location.model.Location
 import breezyweather.domain.source.SourceContinent
 import breezyweather.domain.source.SourceFeature
 import breezyweather.domain.weather.wrappers.WeatherWrapper
+import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
 import org.breezyweather.common.source.HttpSource
 import org.breezyweather.common.source.MainWeatherSource
 import retrofit2.Retrofit
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
 
 class SmhiService @Inject constructor(
+    @ApplicationContext context: Context,
     @Named("JsonClient") client: Retrofit.Builder,
 ) : HttpSource(), MainWeatherSource {
 
     override val id = "smhi"
-    override val name = "SMHI"
+    override val name = "SMHI (${Locale(context.currentLocale.code, "SE").displayCountry})"
     override val continent = SourceContinent.EUROPE
     override val privacyPolicyUrl =
         "https://www.smhi.se/omsmhi/hantering-av-personuppgifter/hantering-av-personuppgifter-1.135429"


### PR DESCRIPTION
I reformatted source names into "Source (Country)". The Country part will change based on the user's language preference.

This fixes the second part of #1477.