### PR TITLE
Fix #1474 - Handle multiple refresh errors

### DIFF
--- a/app/src/main/java/org/breezyweather/common/extensions/ModifierExtensions.kt
+++ b/app/src/main/java/org/breezyweather/common/extensions/ModifierExtensions.kt
@@ -1,0 +1,33 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.common.extensions
+
+import androidx.compose.ui.Modifier
+
+/**
+ * Source: ProAndroidDev
+ * https://proandroiddev.com/jetpack-compose-tricks-conditionally-applying-modifiers-for-dynamic-uis-e3fe5a119f45
+ */
+inline fun Modifier.conditional(
+    condition: Boolean,
+    ifTrue: Modifier.() -> Modifier,
+    ifFalse: Modifier.() -> Modifier = { this },
+): Modifier = if (condition) {
+    then(ifTrue(Modifier))
+} else {
+    then(ifFalse(Modifier))
+}

--- a/app/src/main/java/org/breezyweather/main/MainActivityViewModel.kt
+++ b/app/src/main/java/org/breezyweather/main/MainActivityViewModel.kt
@@ -84,7 +84,7 @@ class MainActivityViewModel @Inject constructor(
     val indicator = _indicator.asStateFlow()
 
     val locationPermissionsRequest: MutableStateFlow<PermissionsRequest?> = MutableStateFlow(null)
-    val snackbarError = BusLiveData<RefreshError?>(Handler(Looper.getMainLooper()))
+    val snackbarError = BusLiveData<List<RefreshError>>(Handler(Looper.getMainLooper()))
 
     // inner data.
 
@@ -116,7 +116,7 @@ class MainActivityViewModel @Inject constructor(
             )
 
             locationPermissionsRequest.value = null
-            snackbarError.setValue(null)
+            snackbarError.setValue(emptyList())
 
             _initCompleted.value = true
         }
@@ -224,8 +224,7 @@ class MainActivityViewModel @Inject constructor(
         location: Location,
         errors: List<RefreshError> = emptyList(),
     ) {
-        // Arbitrarily post only the first error, as we can only show one snackbar at a time
-        snackbarError.postValue(errors.getOrNull(0))
+        snackbarError.postValue(errors)
 
         updateInnerData(location)
 

--- a/app/src/main/res/layout-w640dp/activity_main.xml
+++ b/app/src/main/res/layout-w640dp/activity_main.xml
@@ -40,6 +40,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/refresh_error_dialog"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
     </org.breezyweather.common.ui.widgets.DrawerLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -24,4 +24,9 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/refresh_error_dialog"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -346,6 +346,7 @@
     <string name="action_share">Share</string>
     <string name="action_download">Download</string>
     <string name="action_show_errors">Tap to see details</string>
+    <string name="action_show">Show</string>
     <!-- Button shown in the weather selection dialog -->
     <string name="action_help_me_choose">Help me choose</string>
     <!-- Dialogs -->
@@ -357,11 +358,15 @@
     <string name="dialog_permissions_location_content">To use this feature, you need to grant the app permission to access your current location. It will only be shared with the selected weather sources. If you changed your mind, you can cancel the process and add a fixed location manually.</string>
     <string name="dialog_permissions_location_background_title">Access location in background</string>
     <string name="dialog_permissions_location_background_content">To allow weather refresh in the background to be made for the most recent current location known by Android, you need to set location permission to “Allow all the time”. If you don’t, weather will be refreshed based on the latest retrieved coordinates in the foreground, which can be outdated.</string>
+    <string name="dialog_refresh_error_details_title">Refresh errors</string>
+    <string name="dialog_refresh_error_details_content">Tap on error messages with a question mark to get further help.</string>
     <string name="dialog_time_picker_select_time">Select time</string>
     <string name="dialog_time_picker_input_time">Input time</string>
     <string name="dialog_time_picker_toggle_touch_input_voice">Switch to Touch Input</string>
     <string name="dialog_time_picker_toggle_text_input_voice">Switch to Text Input</string>
     <!-- Miscellaneous messages -->
+    <!-- Please keep it as short as possible as only a limited number of characters can be displayed. -->
+    <string name="message_multiple_refresh_errors">Refresh completed with errors</string>
     <string name="message_invalid_incomplete_data">Invalid or incomplete data received from server</string>
     <string name="message_network_unavailable">Network unavailable</string>
     <string name="message_server_timeout">Request timed out</string>


### PR DESCRIPTION
If more than a single error occurred during a weather data refresh, a generic snackbar is shown with an action to show error details in a dialog. Otherwise, the current behavior is kept and a snackbar with the error is directly shown.

Successfully tested on the following devices: Google Pixel 6a (Android 15).

Closes #1474.

<details>

<summary>screenshots</summary>

| snackbar | dialog |
| --- | --- |
| ![snackbar](https://github.com/user-attachments/assets/ee4f99f6-3423-41e8-ad3a-e11561d3a899) | ![dialog](https://github.com/user-attachments/assets/9dd14058-59eb-4b32-b18b-16171d6aa74c) |

</details>
