### PR TITLE
Use new LocationAccessOffException in AndroidLocationService

### DIFF
--- a/app/src/main/java/org/breezyweather/common/exceptions/LocationAccessOffException.kt
+++ b/app/src/main/java/org/breezyweather/common/exceptions/LocationAccessOffException.kt
@@ -16,4 +16,4 @@
 
 package org.breezyweather.common.exceptions
 
-class LocationServiceDisabledException : Exception()
+class LocationAccessOffException : Exception()

--- a/app/src/main/java/org/breezyweather/sources/RefreshHelper.kt
+++ b/app/src/main/java/org/breezyweather/sources/RefreshHelper.kt
@@ -42,9 +42,9 @@ import org.breezyweather.common.exceptions.ApiLimitReachedException
 import org.breezyweather.common.exceptions.ApiUnauthorizedException
 import org.breezyweather.common.exceptions.InvalidLocationException
 import org.breezyweather.common.exceptions.InvalidOrIncompleteDataException
+import org.breezyweather.common.exceptions.LocationAccessOffException
 import org.breezyweather.common.exceptions.LocationException
 import org.breezyweather.common.exceptions.LocationSearchException
-import org.breezyweather.common.exceptions.LocationServiceDisabledException
 import org.breezyweather.common.exceptions.MissingPermissionLocationBackgroundException
 import org.breezyweather.common.exceptions.MissingPermissionLocationException
 import org.breezyweather.common.exceptions.NoNetworkException
@@ -872,7 +872,7 @@ class RefreshHelper @Inject constructor(
             is ApiUnauthorizedException -> RefreshErrorType.API_UNAUTHORIZED
             is InvalidLocationException -> RefreshErrorType.INVALID_LOCATION
             is LocationException -> RefreshErrorType.LOCATION_FAILED
-            is LocationServiceDisabledException -> RefreshErrorType.LOCATION_ACCESS_OFF
+            is LocationAccessOffException -> RefreshErrorType.LOCATION_ACCESS_OFF
             is MissingPermissionLocationException -> RefreshErrorType.ACCESS_LOCATION_PERMISSION_MISSING
             is MissingPermissionLocationBackgroundException ->
                 RefreshErrorType.ACCESS_BACKGROUND_LOCATION_PERMISSION_MISSING

--- a/app/src/main/java/org/breezyweather/sources/android/AndroidLocationService.kt
+++ b/app/src/main/java/org/breezyweather/sources/android/AndroidLocationService.kt
@@ -13,6 +13,7 @@ import androidx.core.location.LocationRequestCompat
 import io.reactivex.rxjava3.core.Observable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.rx3.rxObservable
+import org.breezyweather.common.exceptions.LocationAccessOffException
 import org.breezyweather.common.exceptions.LocationException
 import org.breezyweather.common.source.LocationPositionWrapper
 import org.breezyweather.common.source.LocationSource
@@ -50,7 +51,7 @@ class AndroidLocationService @Inject constructor() : LocationSource, LocationLis
 
         if (!LocationManagerCompat.isLocationEnabled(locationManager)) {
             LogHelper.log(msg = "Location service not enabled")
-            throw LocationException()
+            throw LocationAccessOffException()
         }
 
         return rxObservable {


### PR DESCRIPTION
In #1467 I missed that AndroidLocationService also contains a check if location access is enabled. This replaces the generic LocationException() with the more specific LocationAccessOffException().

I also updated the name of the exception to better match the wording Android uses.