### PR TITLE
Replace deprecated getParcelable methods

### DIFF
--- a/app/src/main/java/org/breezyweather/main/MainActivity.kt
+++ b/app/src/main/java/org/breezyweather/main/MainActivity.kt
@@ -50,6 +50,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.core.content.IntentCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
@@ -146,7 +147,11 @@ class MainActivity : GeoActivity(), HomeFragment.Callback, ManagementFragment.Ca
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
             if (it.resultCode == Activity.RESULT_OK && it.data != null) {
                 BreezyWeather.instance.setTopActivity(this)
-                val location: Location? = it.data!!.getParcelableExtra(SearchActivity.KEY_LOCATION)
+                val location = IntentCompat.getParcelableExtra(
+                    it.data!!,
+                    SearchActivity.KEY_LOCATION,
+                    Location::class.java
+                )
                 if (location != null) {
                     viewModel.addLocation(location, null)
                     SnackbarHelper.showSnackbar(getString(R.string.location_message_added))

--- a/app/src/main/java/org/breezyweather/remoteviews/common/WidgetSizeUtils.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/common/WidgetSizeUtils.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import android.os.Bundle
 import android.util.SizeF
 import android.widget.RemoteViews
+import androidx.core.os.BundleCompat
 import kotlin.math.roundToInt
 
 object WidgetSizeUtils {
@@ -16,7 +17,11 @@ object WidgetSizeUtils {
     ): RemoteViews {
         val appWidgetOptions = appWidgetManager.getAppWidgetOptions(widgetId)
         val parcelableArrayList: ArrayList<*>? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            appWidgetOptions.getParcelableArrayList<SizeF>(AppWidgetManager.OPTION_APPWIDGET_SIZES)
+            BundleCompat.getParcelableArrayList(
+                appWidgetOptions,
+                AppWidgetManager.OPTION_APPWIDGET_SIZES,
+                SizeF::class.java
+            )
         } else {
             null
         }


### PR DESCRIPTION
Successfully tested on the following devices: Google Pixel 6a (Android 15) and LG G6 (Android 9).