### PR TITLE
Always perform an update after requesting location permissions

### DIFF
--- a/app/src/main/java/org/breezyweather/main/MainActivityViewModel.kt
+++ b/app/src/main/java/org/breezyweather/main/MainActivityViewModel.kt
@@ -75,6 +75,9 @@ class MainActivityViewModel @Inject constructor(
     private val _dialogChooseWeatherSourcesOpen = MutableStateFlow(false)
     val dialogChooseWeatherSourcesOpen = _dialogChooseWeatherSourcesOpen.asStateFlow()
 
+    private val _dialogRefreshErrorDetails = MutableStateFlow(false)
+    val dialogRefreshErrorDetails = _dialogRefreshErrorDetails.asStateFlow()
+
     private val _selectedLocation: MutableStateFlow<Location?> = MutableStateFlow(null)
     val selectedLocation = _selectedLocation.asStateFlow()
 
@@ -147,6 +150,10 @@ class MainActivityViewModel @Inject constructor(
     fun closeChooseWeatherSourcesDialog() {
         _dialogChooseWeatherSourcesOpen.value = false
         _selectedLocation.value = null
+    }
+
+    fun setRefreshErrorDetailsDialogVisible(visible: Boolean) {
+        _dialogRefreshErrorDetails.value = visible
     }
 
     private fun updateInnerData(newValid: List<Location>) {
@@ -248,6 +255,11 @@ class MainActivityViewModel @Inject constructor(
             // update if init completed.
             // otherwise, mark a loading state and wait the init progress complete.
             if (initCompleted.value) {
+                if (dialogRefreshErrorDetails.value) {
+                    // When refreshing, some of the errors shown in the dialog might be outdated. We should close it,
+                    // so users can directly see new errors if any occur.
+                    setRefreshErrorDetailsDialogVisible(false)
+                }
                 updateWithUpdatingChecking(
                     triggeredByUser = false,
                     checkPermissions = true


### PR DESCRIPTION
When a location permission was denied and missing, the location/weather update was silently cancelled without showing any messages to the user. Since there are dedicated refresh errors for missing location permissions in place, this PR adjusts the current approach for processing requests for location permissions.

An update is now always performed after requesting location permissions to ensure that proper error messages are displayed in case the update fails due to missing permissions.

As there is a [checkToUpdate](https://github.com/breezy-weather/breezy-weather/blob/679fac79eb3f56dee318ddabf98688245c2a1957/app/src/main/java/org/breezyweather/main/MainActivity.kt#L280) the current location in `onStart` of the `MainActivity`, the refresh error details dialog is closed before performing an update to make sure that no outdated information is shown to users.

Successfully tested on the following devices: Google Pixel 6a (Android 15) and LG G6 (Android 9).