### PR TITLE
added Ilmateenistus and EKUK as new sources

### DIFF
--- a/app/src/main/java/org/breezyweather/common/source/LocationPreset.kt
+++ b/app/src/main/java/org/breezyweather/common/source/LocationPreset.kt
@@ -127,6 +127,15 @@ enum class LocationPreset(
         alert = "brightsky",
         normals = null
     ),
+    ESTONIA(
+        forecast = "ilmateenistus",
+        current = null,
+        airQuality = "ekuk",
+        pollen = "ekuk",
+        minutely = "openmeteo",
+        alert = "accu",
+        normals = "accu"
+    ),
     FINLAND(
         forecast = "metno",
         current = "metno",
@@ -528,6 +537,7 @@ enum class LocationPreset(
                     "AD" -> ANDORRA
                     "DE" -> GERMANY
                     "DK", "FO", "GL" -> DENMARK
+                    "EE" -> ESTONIA
                     "FI" -> FINLAND
                     "FR" -> FRANCE
                     "BL", "GF", "GP", "MF", "MQ", "NC", "PF", "PM", "RE", "WF", "YT" -> FRANCE_OVERSEAS

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -689,4 +689,14 @@
     <string name="common_weather_text_smoke">Suits</string>
     <string name="current_weather">Praegune ilm</string>
     <string name="weather_current_data_by">Praegune ilm andmete allikas: %s</string>
+    <string name="common_weather_text_blowing_snow">Üldtuisk</string>
+    <string name="common_weather_text_drifting_snow">Pinnatuisk</string>
+    <string name="common_weather_text_glaze">Jäide</string>
+    <string name="pollen_alternaria">Alternaria</string>
+    <string name="pollen_ulmus">Jalakas</string>
+    <string name="pollen_juniperus">Kadakas</string>
+    <string name="pollen_picea">Kuusk</string>
+    <string name="pollen_pinus">Mänd</string>
+    <string name="pollen_acer">Vaher</string>
+    <string name="pollen_atriplex">Malts</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -725,4 +725,14 @@
     <string name="settings_weather_source_current_position_disclaimer">После первого обновления для вашего местоположения могут стать доступны дополнительные источники погоды.</string>
     <string name="weather_forecast_data_by">Прогноз предоставлен %s</string>
     <string name="settings_weather_source_not_configured">%s (не настроено)</string>
+    <string name="common_weather_text_blowing_snow">Общая метель</string>
+    <string name="common_weather_text_drifting_snow">Позёмка</string>
+    <string name="common_weather_text_glaze">Гололёд</string>
+    <string name="pollen_alternaria">Альтернариa</string>
+    <string name="pollen_ulmus">Вяз</string>
+    <string name="pollen_juniperus">Можжевельник</string>
+    <string name="pollen_picea">Ель</string>
+    <string name="pollen_pinus">Сосна</string>
+    <string name="pollen_acer">Клен</string>
+    <string name="pollen_atriplex">Лебеда</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,12 +151,18 @@
     <!-- Pollen -->
     <string name="pollen_tree">Tree</string>
     <string name="pollen_mold">Mold</string>
+    <!-- Latin name: Acer. Use latin (not English!) if no matching translation -->
+    <string name="pollen_acer">Maple</string>
     <!-- Latin name: Alnus. Use latin (not English!) if no matching translation -->
     <string name="pollen_alnus">Alder</string>
+    <!-- Latin name: Alternaria. Use latin (not English!) if no matching translation -->
+    <string name="pollen_alternaria">Alternaria</string>
     <!-- Latin name: Ambrosia. Use latin (not English!) if no matching translation -->
     <string name="pollen_ambrosia">Ragweed</string>
     <!-- Latin name: Artemisia. Use latin (not English!) if no matching translation -->
     <string name="pollen_artemisia">Mugwort</string>
+    <!-- Latin name: Atriplex. Use latin (not English!) if no matching translation -->
+    <string name="pollen_atriplex">Saltbush</string>
     <!-- Latin name: Betula. Use latin (not English!) if no matching translation -->
     <string name="pollen_betula">Birch</string>
     <!-- Latin name: Carpinus. Use latin (not English!) if no matching translation -->
@@ -169,8 +175,14 @@
     <string name="pollen_cupressaceae_taxaceae">Cypress</string>
     <!-- Latin name: Fraxinus. Use latin (not English!) if no matching translation -->
     <string name="pollen_fraxinus">Ash</string>
+    <!-- Latin name: Juniperus. Use latin (not English!) if no matching translation -->
+    <string name="pollen_juniperus">Juniper</string>
     <!-- Latin name: Olea. Use latin (not English!) if no matching translation -->
     <string name="pollen_olea">Olive tree</string>
+    <!-- Latin name: Picea. Use latin (not English!) if no matching translation -->
+    <string name="pollen_picea">Spruce</string>
+    <!-- Latin name: Pinus. Use latin (not English!) if no matching translation -->
+    <string name="pollen_pinus">Pine</string>
     <!-- Latin name: Plantaginaceae. Use latin (not English!) if no matching translation -->
     <string name="pollen_plantaginaceae">Plantain</string>
     <!-- Latin name: Platanus. Use latin (not English!) if no matching translation -->
@@ -187,6 +199,8 @@
     <string name="pollen_salix">Willow</string>
     <!-- Latin name: Tilia. Use latin (not English!) if no matching translation -->
     <string name="pollen_tilia">Linden</string>
+    <!-- Latin name: Ulmus. Use latin (not English!) if no matching translation -->
+    <string name="pollen_ulmus">Elm</string>
     <!-- Latin name: Urticaceae. Use latin (not English!) if no matching translation -->
     <string name="pollen_urticaceae">Nettle/Pellitory</string>
     <!-- Pollen level means “Potential risk of allergy” -->
@@ -859,6 +873,9 @@
     <string name="common_weather_text_frost">Frost</string>
     <string name="common_weather_text_squall">Squall</string>
     <string name="common_weather_text_tornado">Tornado</string>
+    <string name="common_weather_text_blowing_snow">Blowing snow</string>
+    <string name="common_weather_text_drifting_snow">Drifting snow</string>
+    <string name="common_weather_text_glaze">Glaze</string>
     <!-- Weather kind -->
     <string name="weather_kind_clear" translatable="false">@string/common_weather_text_clear_sky</string>
     <string name="weather_kind_partly_cloudy" translatable="false">@string/common_weather_text_partly_cloudy</string>
@@ -1061,7 +1078,6 @@
     <string name="jma_warning_text_ice_accretion_advisory" translatable="false">Ice accretion advisory</string>
     <string name="jma_warning_text_snow_accretion_advisory" translatable="false">Snow accretion advisory</string>
     <!-- Weather texts for NWS -->
-    <string name="nws_weather_text_blowing_snow" translatable="false">Blowing snow</string>
     <string name="nws_weather_text_freezing_spray" translatable="false">Freezing spray</string>
     <string name="nws_weather_text_ice_crystals" translatable="false">Ice crystals</string>
     <string name="nws_weather_text_ice_fog" translatable="false">Ice fog</string>

--- a/app/src/src_nonfreenet/org/breezyweather/sources/SourceManager.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/SourceManager.kt
@@ -65,12 +65,14 @@ import org.breezyweather.sources.climweb.SsmsService
 import org.breezyweather.sources.cwa.CwaService
 import org.breezyweather.sources.dmi.DmiService
 import org.breezyweather.sources.eccc.EcccService
+import org.breezyweather.sources.ekuk.EkukService
 import org.breezyweather.sources.epdhk.EpdHkService
 import org.breezyweather.sources.gadgetbridge.GadgetbridgeService
 import org.breezyweather.sources.geonames.GeoNamesService
 import org.breezyweather.sources.geosphereat.GeoSphereAtService
 import org.breezyweather.sources.here.HereService
 import org.breezyweather.sources.hko.HkoService
+import org.breezyweather.sources.ilmateenistus.IlmateenistusService
 import org.breezyweather.sources.imd.ImdService
 import org.breezyweather.sources.ims.ImsService
 import org.breezyweather.sources.ipma.IpmaService
@@ -121,6 +123,7 @@ class SourceManager @Inject constructor(
     dmiService: DmiService,
     dwrGmService: DwrGmService,
     ecccService: EcccService,
+    ekukService: EkukService,
     epdHkService: EpdHkService,
     ethioMetService: EthioMetService,
     gadgetbridgeService: GadgetbridgeService,
@@ -130,6 +133,7 @@ class SourceManager @Inject constructor(
     hereService: HereService,
     hkoService: HkoService,
     igebuService: IgebuService,
+    ilmateenistusService: IlmateenistusService,
     imdService: ImdService,
     imsService: ImsService,
     inmgbService: InmgbService,
@@ -215,12 +219,14 @@ class SourceManager @Inject constructor(
         dmnNeService,
         dwrGmService,
         ecccService,
+        ekukService,
         epdHkService,
         ethioMetService,
         geoSphereAtService,
         gMetService,
         hkoService,
         igebuService,
+        ilmateenistusService,
         imdService,
         imsService,
         inmgbService,

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ekuk/EkukApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ekuk/EkukApi.kt
@@ -1,0 +1,35 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ekuk
+
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.sources.ekuk.json.EkukObservationsResult
+import org.breezyweather.sources.ekuk.json.EkukStationsResult
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface EkukApi {
+    @GET("api/station/en")
+    fun getStations(): Observable<EkukStationsResult>
+
+    @GET("api/monitoring/en")
+    fun getObservations(
+        @Query("stations") station: String,
+        @Query("indicators") indicators: String = "",
+        @Query("range") range: String,
+    ): Observable<List<EkukObservationsResult>>
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ekuk/EkukResultConverter.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ekuk/EkukResultConverter.kt
@@ -1,0 +1,131 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ekuk
+
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.weather.model.AirQuality
+import breezyweather.domain.weather.model.Pollen
+import com.google.maps.android.model.LatLng
+import org.breezyweather.sources.ekuk.json.EkukObservationsResult
+import org.breezyweather.sources.ekuk.json.EkukStationsResult
+import kotlin.math.roundToInt
+
+internal fun convert(
+    location: Location,
+    stationsResult: EkukStationsResult,
+): Map<String, String> {
+    val airQualityStations = mutableMapOf<String, LatLng>()
+    val pollenStations = mutableMapOf<String, LatLng>()
+    stationsResult.features?.filter { it.properties.type != "POLLEN" && it.properties.type != "RADIATION" }?.forEach {
+        airQualityStations[it.id.toString()] = LatLng(it.geometry.coordinates[1], it.geometry.coordinates[0])
+    }
+    stationsResult.features?.filter { it.properties.type == "POLLEN" }?.forEach {
+        pollenStations[it.id.toString()] = LatLng(it.geometry.coordinates[1], it.geometry.coordinates[0])
+    }
+
+    // limit a valid station within 50km of selected location; return empty string otherwise
+    return mapOf(
+        "airQualityStation" to
+            (LatLng(location.latitude, location.longitude).getNearestLocation(airQualityStations, 50000.0) ?: ""),
+        "pollenStation" to
+            (LatLng(location.latitude, location.longitude).getNearestLocation(pollenStations, 50000.0) ?: "")
+    )
+}
+
+internal fun getAirQuality(
+    airQualityResult: List<EkukObservationsResult>,
+): AirQuality {
+    val pollutantConcentrations = mutableMapOf<String, Double?>()
+    EKUK_POLLUTANT_IDS.keys.forEach { pollutant ->
+        pollutantConcentrations[pollutant] = airQualityResult
+            .filter { it.indicator == EKUK_POLLUTANT_IDS[pollutant] }
+            .sortedByDescending { it.measured }
+            .firstOrNull()?.value?.toDoubleOrNull()
+    }
+    return AirQuality(
+        pM25 = pollutantConcentrations.getOrElse("PM25") { null },
+        pM10 = pollutantConcentrations.getOrElse("PM10") { null },
+        sO2 = pollutantConcentrations.getOrElse("SO2") { null },
+        nO2 = pollutantConcentrations.getOrElse("NO2") { null },
+        o3 = pollutantConcentrations.getOrElse("O3") { null },
+        cO = pollutantConcentrations.getOrElse("CO") { null }
+    )
+}
+
+internal fun getPollen(
+    pollenResult: List<EkukObservationsResult>,
+): Pollen {
+    val pollenConcentrations = mutableMapOf<String, Double?>()
+    EKUK_POLLEN_IDS.keys.forEach { pollen ->
+        pollenConcentrations[pollen] = pollenResult
+            .filter { it.indicator == EKUK_POLLEN_IDS[pollen] }
+            .sortedByDescending { it.measured }
+            .firstOrNull()?.value?.toDoubleOrNull()
+    }
+    // TODO: Alternaria, Elm, Juniper, Spruce, Pine, Maple, Saltbush
+    return Pollen(
+        alder = pollenConcentrations.getOrElse("ALDER") { null }?.roundToInt(),
+        ash = pollenConcentrations.getOrElse("ASH") { null }?.roundToInt(),
+        birch = pollenConcentrations.getOrElse("BIRCH") { null }?.roundToInt(),
+        grass = pollenConcentrations.getOrElse("GRASSES") { null }?.roundToInt(),
+        hazel = pollenConcentrations.getOrElse("HAZEL") { null }?.roundToInt(),
+        mold = pollenConcentrations.getOrElse("CLADOSPORIUM") { null }?.roundToInt(),
+        mugwort = pollenConcentrations.getOrElse("WORMWOOD") { null }?.roundToInt(),
+        oak = pollenConcentrations.getOrElse("OAK") { null }?.roundToInt(),
+        poplar = pollenConcentrations.getOrElse("POPLAR") { null }?.roundToInt(),
+        ragweed = pollenConcentrations.getOrElse("AMBROSIA") { null }?.roundToInt(),
+        sorrel = pollenConcentrations.getOrElse("DOCK") { null }?.roundToInt(),
+        tree = pollenConcentrations.getOrElse("UNIDENTIFIED") { null }?.roundToInt(),
+        urticaceae = pollenConcentrations.getOrElse("NETTLE") { null }?.roundToInt(),
+        willow = pollenConcentrations.getOrElse("WILLOW") { null }?.roundToInt()
+    )
+}
+
+// Source: https://www.ohuseire.ee/api/indicator/en?type=INDICATOR
+private val EKUK_POLLUTANT_IDS = mapOf(
+    "PM25" to 23,
+    "PM10" to 21,
+    "SO2" to 1,
+    "NO2" to 3,
+    "O3" to 6,
+    "CO" to 4
+)
+
+// Source: https://www.ohuseire.ee/api/indicator/en?type=POLLEN
+private val EKUK_POLLEN_IDS = mapOf(
+    "ALDER" to 51,
+    "ALTERNARIA" to 44,
+    "AMBROSIA" to 63,
+    "ASH" to 58,
+    "BIRCH" to 48,
+    "CLADOSPORIUM" to 45,
+    "DOCK" to 54,
+    "ELM" to 46,
+    "GRASSES" to 49,
+    "HAZEL" to 59,
+    "JUNIPER" to 47,
+    "MAPLE" to 61,
+    "NETTLE" to 53,
+    "OAK" to 60,
+    "PINE" to 52,
+    "POPLAR" to 56,
+    "SALTBUSH" to 62,
+    "SPRUCE" to 50,
+    "UNIDENTIFIED" to 43,
+    "WILLOW" to 55,
+    "WORMWOOD" to 57
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ekuk/EkukService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ekuk/EkukService.kt
@@ -1,0 +1,183 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ekuk
+
+import android.content.Context
+import android.graphics.Color
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.source.SourceContinent
+import breezyweather.domain.source.SourceFeature
+import breezyweather.domain.weather.wrappers.AirQualityWrapper
+import breezyweather.domain.weather.wrappers.PollenWrapper
+import breezyweather.domain.weather.wrappers.WeatherWrapper
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
+import org.breezyweather.common.source.HttpSource
+import org.breezyweather.common.source.LocationParametersSource
+import org.breezyweather.common.source.WeatherSource
+import org.breezyweather.sources.ekuk.json.EkukObservationsResult
+import retrofit2.Retrofit
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+import java.util.TimeZone
+import javax.inject.Inject
+import javax.inject.Named
+
+class EkukService @Inject constructor(
+    @ApplicationContext context: Context,
+    @Named("JsonClient") client: Retrofit.Builder,
+) : HttpSource(), WeatherSource, LocationParametersSource {
+    override val id = "ekuk"
+    override val name = "EKUK (${Locale(context.currentLocale.code, "EE").displayCountry})"
+    override val continent = SourceContinent.EUROPE
+    override val privacyPolicyUrl = ""
+    override val color = Color.rgb(51, 153, 51)
+    private val weatherAttribution by lazy {
+        with(context.currentLocale.code) {
+            when {
+                startsWith("et") -> "Eesti Keskkonnauuringute Keskus"
+                startsWith("ru") -> "Эстонский центр экологических исследований"
+                startsWith("uk") -> "Естонський центр екологічних досліджень"
+                else -> "Estonian Environmental Research Center"
+            }
+        }
+    }
+
+    private val mApi by lazy {
+        client.baseUrl(EKUK_BASE_URL)
+            .build()
+            .create(EkukApi::class.java)
+    }
+
+    override val supportedFeatures = mapOf(
+        SourceFeature.AIR_QUALITY to weatherAttribution,
+        SourceFeature.POLLEN to weatherAttribution
+    )
+
+    override fun isFeatureSupportedForLocation(
+        location: Location,
+        feature: SourceFeature,
+    ): Boolean {
+        return location.countryCode.equals("EE", ignoreCase = true)
+    }
+
+    override fun requestWeather(
+        context: Context,
+        location: Location,
+        requestedFeatures: List<SourceFeature>,
+    ): Observable<WeatherWrapper> {
+        val formatter = SimpleDateFormat("dd.MM.yyyy", Locale.ENGLISH)
+        formatter.timeZone = TimeZone.getTimeZone("Europe/Tallinn")
+        val now = Calendar.getInstance()
+        val today = formatter.format(now.time)
+        now.add(Calendar.DATE, -1)
+        val yesterday = formatter.format(now.time)
+
+        val failedFeatures = mutableListOf<SourceFeature>()
+
+        val airQuality = if (SourceFeature.AIR_QUALITY in requestedFeatures) {
+            val airQualityStation = location.parameters.getOrElse(id) { null }?.getOrElse("airQualityStation") { null }
+            if (!airQualityStation.isNullOrEmpty()) {
+                mApi.getObservations(
+                    station = airQualityStation,
+                    indicators = EKUK_AIR_QUALITY_INDICATORS,
+                    range = "$yesterday,$today"
+                ).onErrorResumeNext {
+                    failedFeatures.add(SourceFeature.AIR_QUALITY)
+                    Observable.just(emptyList())
+                }
+            } else {
+                // Do not fail: airQualityStation is empty if the nearest one is > 50km away
+                Observable.just(emptyList())
+            }
+        } else {
+            Observable.just(emptyList())
+        }
+
+        val pollen = if (SourceFeature.POLLEN in requestedFeatures) {
+            val pollenStation = location.parameters.getOrElse(id) { null }?.getOrElse("pollenStation") { null }
+            if (!pollenStation.isNullOrEmpty()) {
+                mApi.getObservations(
+                    station = pollenStation,
+                    indicators = EKUK_POLLEN_INDICATORS,
+                    range = "$yesterday,$today"
+                ).onErrorResumeNext {
+                    failedFeatures.add(SourceFeature.POLLEN)
+                    Observable.just(emptyList())
+                }
+            } else {
+                // Do not fail: pollenStation is empty if the nearest one is > 50km away
+                Observable.just(emptyList())
+            }
+        } else {
+            Observable.just(emptyList())
+        }
+
+        return Observable.zip(airQuality, pollen) {
+                airQualityResult: List<EkukObservationsResult>,
+                pollenResult: List<EkukObservationsResult>,
+            ->
+            WeatherWrapper(
+                airQuality = if (SourceFeature.AIR_QUALITY in requestedFeatures) {
+                    AirQualityWrapper(current = getAirQuality(airQualityResult))
+                } else {
+                    null
+                },
+                pollen = if (SourceFeature.POLLEN in requestedFeatures) {
+                    PollenWrapper(current = getPollen(pollenResult))
+                } else {
+                    null
+                },
+                failedFeatures = failedFeatures
+            )
+        }
+    }
+
+    override fun needsLocationParametersRefresh(
+        location: Location,
+        coordinatesChanged: Boolean,
+        features: List<SourceFeature>,
+    ): Boolean {
+        if (coordinatesChanged) return true
+        val airQualityStation = location.parameters.getOrElse(id) { null }?.getOrElse("airQualityStation") { null }
+        val pollenStation = location.parameters.getOrElse(id) { null }?.getOrElse("pollenStation") { null }
+
+        // Do not check for empty, because a valid station should be within 50km of selected location
+        return (SourceFeature.AIR_QUALITY in features && airQualityStation == null) ||
+            (SourceFeature.POLLEN in features && pollenStation == null)
+    }
+
+    override fun requestLocationParameters(
+        context: Context,
+        location: Location,
+    ): Observable<Map<String, String>> {
+        return mApi.getStations().map {
+            convert(location, it)
+        }
+    }
+
+    override val testingLocations: List<Location> = emptyList()
+
+    companion object {
+        private const val EKUK_BASE_URL = "https://www.ohuseire.ee/"
+        private const val EKUK_AIR_QUALITY_INDICATORS = "1,3,4,6,21,23"
+        private const val EKUK_POLLEN_INDICATORS = "43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63"
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ekuk/json/EkukObservationsResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ekuk/json/EkukObservationsResult.kt
@@ -1,0 +1,10 @@
+package org.breezyweather.sources.ekuk.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EkukObservationsResult(
+    val measured: String?,
+    val value: String?,
+    val indicator: Int?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ekuk/json/EkukStation.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ekuk/json/EkukStation.kt
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ekuk.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EkukStation(
+    val id: Long,
+    val geometry: EkukStationGeometry,
+    val properties: EkukStationProperties,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ekuk/json/EkukStationGeometry.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ekuk/json/EkukStationGeometry.kt
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ekuk.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EkukStationGeometry(
+    val coordinates: List<Double>,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ekuk/json/EkukStationProperties.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ekuk/json/EkukStationProperties.kt
@@ -1,0 +1,25 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ekuk.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EkukStationProperties(
+    val type: String?,
+    val indicators: List<Double>?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ekuk/json/EkukStationsResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ekuk/json/EkukStationsResult.kt
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ekuk.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EkukStationsResult(
+    val features: List<EkukStation>? = null,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/IlmateenistusApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/IlmateenistusApi.kt
@@ -1,0 +1,29 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ilmateenistus
+
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.sources.ilmateenistus.json.IlmateenistusForecastResult
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface IlmateenistusApi {
+    @GET("wp-content/themes/ilm2020/meteogram.php")
+    fun getHourly(
+        @Query("coordinates") coordinates: String,
+    ): Observable<IlmateenistusForecastResult>
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/IlmateenistusResultConverter.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/IlmateenistusResultConverter.kt
@@ -1,0 +1,181 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ilmateenistus
+
+import android.content.Context
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.weather.model.Precipitation
+import breezyweather.domain.weather.model.Temperature
+import breezyweather.domain.weather.model.WeatherCode
+import breezyweather.domain.weather.model.Wind
+import breezyweather.domain.weather.wrappers.DailyWrapper
+import breezyweather.domain.weather.wrappers.HourlyWrapper
+import org.breezyweather.R
+import org.breezyweather.common.exceptions.InvalidLocationException
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
+import org.breezyweather.sources.ilmateenistus.json.IlmateenistusForecastResult
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+internal fun convert(
+    context: Context,
+    location: Location,
+    forecastResult: IlmateenistusForecastResult,
+): List<Location> {
+    val locationList = mutableListOf<Location>()
+    if (forecastResult.location.isNullOrEmpty()) {
+        throw InvalidLocationException()
+    }
+    val locationParts = forecastResult.location.split(',')
+    locationList.add(
+        location.copy(
+            latitude = location.latitude,
+            longitude = location.longitude,
+            timeZone = "Europe/Tallinn",
+            country = Locale(context.currentLocale.code, "EE").displayCountry,
+            countryCode = "EE",
+            admin1 = locationParts.getOrNull(0)?.trim(),
+            city = locationParts.getOrNull(1)?.trim() ?: "",
+            district = locationParts.getOrNull(2)?.trim()
+        )
+    )
+    return locationList
+}
+
+internal fun getDailyForecast(
+    hourlyList: List<HourlyWrapper>,
+): List<DailyWrapper> {
+    // CommonConverter.kt does not compute daily for this source
+    // without providing at least a empty list filled with dates.
+    val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH)
+    formatter.timeZone = TimeZone.getTimeZone("Europe/Tallinn")
+    val hourlyListDates = hourlyList.groupBy { formatter.format(it.date) }.keys
+    val dailyList = mutableListOf<DailyWrapper>()
+    hourlyListDates.forEach {
+        dailyList.add(
+            DailyWrapper(
+                date = formatter.parse(it)!!
+            )
+        )
+    }
+    return dailyList
+}
+
+internal fun getHourlyForecast(
+    context: Context,
+    forecastResult: IlmateenistusForecastResult,
+): List<HourlyWrapper> {
+    val hourlyList = mutableListOf<HourlyWrapper>()
+    val formatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.ENGLISH)
+    formatter.timeZone = TimeZone.getTimeZone("Europe/Tallinn")
+    forecastResult.forecast?.tabular?.time?.forEach {
+        if (it.attributes.from != null) {
+            hourlyList.add(
+                HourlyWrapper(
+                    date = formatter.parse(it.attributes.from)!!,
+                    weatherText = getWeatherText(context, it.phenomen?.attributes?.className),
+                    weatherCode = getWeatherCode(it.phenomen?.attributes?.className),
+                    temperature = Temperature(
+                        temperature = it.temperature?.attributes?.value?.toDoubleOrNull()
+                    ),
+                    precipitation = Precipitation(
+                        total = it.precipitation?.attributes?.value?.toDoubleOrNull()
+                    ),
+                    wind = Wind(
+                        degree = it.windDirection?.attributes?.deg?.toDoubleOrNull(),
+                        speed = it.windSpeed?.attributes?.mps?.toDoubleOrNull()
+                    ),
+                    pressure = it.pressure?.attributes?.value?.toDoubleOrNull()
+                )
+            )
+        }
+    }
+    return hourlyList
+}
+
+private fun getWeatherText(
+    context: Context,
+    phenomenon: String?,
+): String? {
+    return when (phenomenon) {
+        "clear" -> context.getString(R.string.common_weather_text_clear_sky)
+        "few_clouds" -> context.getString(R.string.common_weather_text_mainly_clear)
+        "cloudy" -> context.getString(R.string.common_weather_text_partly_cloudy)
+        "cloudy_with_clear_spells" -> context.getString(R.string.common_weather_text_partly_cloudy)
+        "overcast" -> context.getString(R.string.common_weather_text_cloudy)
+        "light_snow_shower" -> context.getString(R.string.common_weather_text_snow_showers_light)
+        "moderate_snow_shower" -> context.getString(R.string.common_weather_text_snow_showers)
+        "heavy_snow_shower" -> context.getString(R.string.openmeteo_weather_text_snow_showers_heavy)
+        "light_shower" -> context.getString(R.string.common_weather_text_rain_showers_light)
+        "moderate_shower" -> context.getString(R.string.common_weather_text_rain_showers_moderate)
+        "heavy_shower" -> context.getString(R.string.common_weather_text_rain_showers_heavy)
+        "light_rain" -> context.getString(R.string.common_weather_text_rain_light)
+        "moderate_rain" -> context.getString(R.string.common_weather_text_rain_moderate)
+        "heavy_rain" -> context.getString(R.string.common_weather_text_rain_heavy)
+        "risk_of_glaze" -> context.getString(R.string.common_weather_text_glaze)
+        "light_sleet" -> context.getString(R.string.common_weather_text_rain_snow_mixed_light)
+        "moderate_sleet" -> context.getString(R.string.common_weather_text_rain_snow_mixed)
+        "light_snowfall" -> context.getString(R.string.common_weather_text_snow_light)
+        "moderate_snowfall" -> context.getString(R.string.common_weather_text_snow_moderate)
+        "heavy_snowfall" -> context.getString(R.string.common_weather_text_snow_heavy)
+        "snowstorm" -> context.getString(R.string.common_weather_text_blowing_snow)
+        "drifting_snow" -> context.getString(R.string.common_weather_text_drifting_snow)
+        "hail" -> context.getString(R.string.weather_kind_hail)
+        "mist" -> context.getString(R.string.common_weather_text_mist)
+        "fog" -> context.getString(R.string.common_weather_text_fog)
+        "thunder" -> context.getString(R.string.weather_kind_thunder)
+        "thunderstorm" -> context.getString(R.string.weather_kind_thunderstorm)
+        else -> null
+    }
+}
+
+private fun getWeatherCode(
+    phenomenon: String?,
+): WeatherCode? {
+    return when (phenomenon) {
+        "clear" -> WeatherCode.CLEAR
+        "few_clouds" -> WeatherCode.CLEAR
+        "cloudy" -> WeatherCode.PARTLY_CLOUDY
+        "cloudy_with_clear_spells" -> WeatherCode.PARTLY_CLOUDY
+        "overcast" -> WeatherCode.CLOUDY
+        "light_snow_shower" -> WeatherCode.SNOW
+        "moderate_snow_shower" -> WeatherCode.SNOW
+        "heavy_snow_shower" -> WeatherCode.SNOW
+        "light_shower" -> WeatherCode.RAIN
+        "moderate_shower" -> WeatherCode.RAIN
+        "heavy_shower" -> WeatherCode.RAIN
+        "light_rain" -> WeatherCode.RAIN
+        "moderate_rain" -> WeatherCode.RAIN
+        "heavy_rain" -> WeatherCode.RAIN
+        "risk_of_glaze" -> WeatherCode.SLEET
+        "light_sleet" -> WeatherCode.SLEET
+        "moderate_sleet" -> WeatherCode.SLEET
+        "light_snowfall" -> WeatherCode.SNOW
+        "moderate_snowfall" -> WeatherCode.SNOW
+        "heavy_snowfall" -> WeatherCode.SNOW
+        "snowstorm" -> WeatherCode.SNOW
+        "drifting_snow" -> WeatherCode.SNOW
+        "hail" -> WeatherCode.HAIL
+        "mist" -> WeatherCode.FOG
+        "fog" -> WeatherCode.FOG
+        "thunder" -> WeatherCode.THUNDER
+        "thunderstorm" -> WeatherCode.THUNDERSTORM
+        else -> null
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/IlmateenistusService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/IlmateenistusService.kt
@@ -1,0 +1,115 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ilmateenistus
+
+import android.content.Context
+import android.graphics.Color
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.source.SourceContinent
+import breezyweather.domain.source.SourceFeature
+import breezyweather.domain.weather.wrappers.WeatherWrapper
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
+import org.breezyweather.common.source.HttpSource
+import org.breezyweather.common.source.ReverseGeocodingSource
+import org.breezyweather.common.source.WeatherSource
+import retrofit2.Retrofit
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Named
+
+class IlmateenistusService @Inject constructor(
+    @ApplicationContext context: Context,
+    @Named("JsonClient") client: Retrofit.Builder,
+) : HttpSource(), WeatherSource, ReverseGeocodingSource {
+    override val id = "ilmateenistus"
+    override val name = "Ilmateenistus (${Locale(context.currentLocale.code, "EE").displayCountry})"
+    override val continent = SourceContinent.EUROPE
+    override val privacyPolicyUrl by lazy {
+        with(context.currentLocale.code) {
+            when {
+                startsWith("et") -> "https://www.ilmateenistus.ee/meist/kasutustingimused/"
+                startsWith("ru") -> "https://www.ilmateenistus.ee/meist/kasutustingimused/?lang=ru"
+                else -> "https://www.ilmateenistus.ee/meist/kasutustingimused/?lang=en"
+            }
+        }
+    }
+    override val color = Color.rgb(0, 0, 150)
+
+    private val mApi by lazy {
+        client.baseUrl(ILMATEENISTUS_BASE_URL)
+            .build()
+            .create(IlmateenistusApi::class.java)
+    }
+
+    private val weatherAttribution by lazy {
+        with(context.currentLocale.code) {
+            when {
+                startsWith("et") -> "Keskkonnaagentuur"
+                startsWith("ru") -> "Агентство окружающей среды"
+                else -> "Estonian Environment Agency"
+            }
+        }
+    }
+    override val supportedFeatures = mapOf(
+        SourceFeature.FORECAST to weatherAttribution
+    )
+
+    override fun isFeatureSupportedForLocation(
+        location: Location,
+        feature: SourceFeature,
+    ): Boolean {
+        return location.countryCode.equals("EE", ignoreCase = true)
+    }
+
+    override fun requestWeather(
+        context: Context,
+        location: Location,
+        requestedFeatures: List<SourceFeature>,
+    ): Observable<WeatherWrapper> {
+        val coordinates = "${location.latitude};${location.longitude}"
+        return mApi.getHourly(
+            coordinates = coordinates
+        ).map {
+            val hourlyForecast = getHourlyForecast(context, it)
+            WeatherWrapper(
+                dailyForecast = getDailyForecast(hourlyForecast),
+                hourlyForecast = hourlyForecast
+            )
+        }
+    }
+
+    override fun requestReverseGeocodingLocation(
+        context: Context,
+        location: Location,
+    ): Observable<List<Location>> {
+        val coordinates = "${location.latitude};${location.longitude}"
+        return mApi.getHourly(
+            coordinates = coordinates
+        ).map {
+            convert(context, location, it)
+        }
+    }
+
+    override val testingLocations: List<Location> = emptyList()
+
+    companion object {
+        private const val ILMATEENISTUS_BASE_URL = "https://www.ilmateenistus.ee/"
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/json/IlmateenistusForecast.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/json/IlmateenistusForecast.kt
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ilmateenistus.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class IlmateenistusForecast(
+    val tabular: IlmateenistusForecastTabular?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/json/IlmateenistusForecastAttributes.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/json/IlmateenistusForecastAttributes.kt
@@ -1,0 +1,28 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ilmateenistus.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class IlmateenistusForecastAttributes(
+    val from: String?,
+    val className: String?,
+    val value: String?,
+    val deg: String?,
+    val mps: String?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/json/IlmateenistusForecastItem.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/json/IlmateenistusForecastItem.kt
@@ -1,0 +1,25 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ilmateenistus.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class IlmateenistusForecastItem(
+    @SerialName("@attributes") val attributes: IlmateenistusForecastAttributes,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/json/IlmateenistusForecastResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/json/IlmateenistusForecastResult.kt
@@ -1,0 +1,25 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ilmateenistus.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class IlmateenistusForecastResult(
+    val location: String? = null,
+    val forecast: IlmateenistusForecast? = null,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/json/IlmateenistusForecastTabular.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/json/IlmateenistusForecastTabular.kt
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ilmateenistus.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class IlmateenistusForecastTabular(
+    val time: List<IlmateenistusForecastTime>?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/json/IlmateenistusForecastTime.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ilmateenistus/json/IlmateenistusForecastTime.kt
@@ -1,0 +1,31 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ilmateenistus.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class IlmateenistusForecastTime(
+    @SerialName("@attributes") val attributes: IlmateenistusForecastAttributes,
+    val phenomen: IlmateenistusForecastItem?,
+    val precipitation: IlmateenistusForecastItem?,
+    val windDirection: IlmateenistusForecastItem?,
+    val windSpeed: IlmateenistusForecastItem?,
+    val temperature: IlmateenistusForecastItem?,
+    val pressure: IlmateenistusForecastItem?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/nws/NwsResultConverter.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/nws/NwsResultConverter.kt
@@ -539,7 +539,7 @@ private fun getWeatherText(
     weatherText = when (weather?.weather) {
         "blowing_dust" -> context.getString(R.string.common_weather_text_dust_storm)
         "blowing_sand" -> context.getString(R.string.common_weather_text_sand_storm)
-        "blowing_snow" -> context.getString(R.string.nws_weather_text_blowing_snow)
+        "blowing_snow" -> context.getString(R.string.common_weather_text_blowing_snow)
         "drizzle" -> context.getString(R.string.common_weather_text_drizzle)
         "fog" -> context.getString(R.string.common_weather_text_fog)
         "freezing_drizzle" -> context.getString(R.string.common_weather_text_drizzle_freezing)

--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -2,12 +2,12 @@
 
 This page documents the coverage status of weather sources around the world in Breezy Weather. Before you submit a request for a new source, please check this document to see if it has been considered for coverage in the past.
 
-In general, a main weather source can be considered for inclusion in the official release of Breezy Weather if it meets the following requirements:
+In general, a weather source can be considered for inclusion in the official release of Breezy Weather if it meets the following requirements:
 
-- **Geolocation availability:** A source should be able to provide forecast directly from geographical coordinates (latitude and longitude) directly, or return forecast locations from given coordinates. Breezy Weather is a mobile app, and is primary used for querying weather forecasts on the go. It is not enough to for a source to provide forecast from location names alone.
+- **Geolocation availability:** A source should be able to provide data directly from geographical coordinates (latitude and longitude) directly, or return forecast locations from given coordinates. Breezy Weather is a mobile app, and is primary used for querying weather forecasts on the go. It is not enough to for a source to provide forecast from location names alone.
 - **Data format:** A source should provide its forecast data in JSON or XML format.
-- **Forecast availability:** _(for Main sources)_ A source should provide hourly forecast. The minimum frequency should be 6-hourly. Sources providing current observation, air pollution, pollen, alerts, or temperature normals WITHOUT hourly forecast can be implemented as a “Secondary Source.”
-- **Privacy requirement:** If an API key is needed to access the forecast data, it should not ask for personally identifiable information such as credit card or telephone number.
+- **Forecast availability:** _(for Forecast sources)_ A source should provide hourly forecast. The minimum frequency should be 6-hourly. Sources providing current observation, air pollution, pollen, alerts, or temperature normals WITHOUT hourly forecast can be implemented as a “Secondary Source.”
+- **Privacy requirement:** If an API key is needed to access the data, it should not ask for personally identifiable information such as credit card or telephone number.
 - **Concentration requirement:**  _(for Air Quality and Pollen sources)_ A source must provide air pollutant concentration data in µg/m³, mg/m³, ppb, or ppm. Pollen concentration must be in pollen count /m³. If the data source only provides a calculated index, it cannot be included in Breezy Weather, since every country has its own AQI standard which is often different from others.
 
 ## Summary
@@ -155,7 +155,7 @@ In general, a main weather source can be considered for inclusion in the officia
 | 🇨🇾 Cyprus                   | [Cyprus](https://www.moa.gov.cy/)                     |                                                                                       |              |
 | 🇨🇿 Czechia                  | [CHMI](https://www.chmi.cz/)                          |                                                                                       |              |
 | 🇩🇰 Denmark                  | [DMI](https://www.dmi.dk)                             | ✅ included from v5.0.0                                                                |              |
-| 🇪🇪 Estonia                  | [EEA](https://www.ilmateenistus.ee/)                  |                                                                                       |              |
+| 🇪🇪 Estonia                  | [Ilmateenistus](https://www.ilmateenistus.ee/)        | ✅ included from v5.4.0                                                                | 2024-12-24   |
 | 🇫🇴 Faroe Is.                | [DMI](https://www.dmi.dk)                             | ✅ included from v5.0.0                                                                |              |
 | 🇫🇮 Finland                  | [FMI](https://en.ilmatieteenlaitos.fi/)               | [data in XML](https://github.com/breezy-weather/breezy-weather/issues/1211)           | 2024-07-22   |
 | 🇫🇷 France                   | [Météo-France](https://meteofrance.com/)              | ✅ included                                                                            |              |
@@ -300,6 +300,8 @@ In general, a main weather source can be considered for inclusion in the officia
 ## Other sources
 | Source             | Status                                                                                     | Last Checked |
 |--------------------|--------------------------------------------------------------------------------------------|--------------|
+| EKUK               | ✅ included from v5.4.0                                                                     | 2024-12-24   |
+| EPD HK             | ✅ included from v5.4.0                                                                     | 2024-12-19   |
 | GeoNames           | ✅ included from v4.5.0                                                                     |              | 
 | HERE               | ✅ included from v4.5.0                                                                     |              |
 | Natural Earth      | ✅ included from v5.0.3                                                                     |              |

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -7,7 +7,7 @@ By default, when you add a location manually, Breezy Weather will auto-suggest y
 Below, you can find details about the support and implementation status for features on each weather source. Note that no forecast above 7 days is reliable, so you should not decide based on the highest number of days available.
 
 > Note: The following features and sources are only available starting from (unreleased) v5.4.0:
-> - Sources: ATMO GrandEst, Atmo Hauts-de-France, AtmoSud, EPD
+> - Sources: ATMO GrandEst, Atmo Hauts-de-France, AtmoSud, EKUK, EPD, Ilmateenistus
 
 ## Summary
 | Country/Territory                  | Source                                             | Supported features                                                                   |
@@ -29,6 +29,8 @@ Below, you can find details about the support and implementation status for feat
 | 🇨🇳 China                         | [China](#china)                                    | Forecast, Current, Air quality, Nowcasting, Alerts, Reverse                          |
 | 🇨🇩 Democratic Republic of Congo  | [ClimWeb](#climweb)                                | Alerts                                                                               |
 | 🇩🇰 Denmark                       | [DMI](#danmarks-meteorologiske-institut)           | Forecast, Alerts, Reverse                                                            |
+| 🇪🇪 Estonia                       | [Ilmateenistus](#ilmateenistus)                    | Forecast, Reverse                                                                    |
+| 🇪🇪 Estonia                       | [EKUK](#ekuk)                                      | Air quality, Pollen                                                                  |
 | 🇪🇹 Ethiopia                      | [ClimWeb](#climweb)                                | Alerts, Normals                                                                      |
 | 🇫🇰 Falkland Is.                  | [Met Office](#met-office) 🔐                       | Forecast, Reverse                                                                    |
 | 🇫🇴 Faroe Is.                     | [DMI](#danmarks-meteorologiske-institut)           | Forecast, Alerts, Reverse                                                            |
@@ -552,7 +554,7 @@ This source aggregates data from Beijing Meteorological Service, ColorfulClouds 
 | 📆 **Daily forecast**          | Up to 9 days                                                                                                                                      |
 | ⏱️ **Hourly forecast**         | Up to 9 days                                                                                                                                      |
 | ▶️ **Current observation**     | Available: can complement another source as a **Secondary Current Source**                                                                        |
-| 😶‍🌫️ **Air quality**         | Not available                                                                                                                                     |
+| 😶‍🌫️ **Air quality**         | Not available: Users can add [EPD](#environmental-protection-department) as a secondary source                                                    |
 | 🤧 **Pollen**                  | Not available                                                                                                                                     |
 | ☔ **Precipitation nowcasting** | Not available                                                                                                                                     |
 | ⚠️ **Alerts**                  | Available in English, Traditional Chines, and Simplified Chinese. Alert headlines are additionally available in Hindi, Indonesian, and Vietnamese |
@@ -571,6 +573,38 @@ This source aggregates data from Beijing Meteorological Service, ColorfulClouds 
 | Wind                      | ✅         | Cloud Cover       | ❌           |
 | Humidity                  | ✅         | Visibility        | ❌           |
 | Dew Point                 | ✅         | Ceiling           | ❌           |
+</details>
+
+### Ilmateenistus
+> Coming soon: will be available starting from v5.4.0
+
+**[Ilmateeniustus](https://www.ilmateenistus.ee/)** is the official meteorological service of Estonia.
+
+| Feature                        | Detail                                                           |
+|--------------------------------|------------------------------------------------------------------|
+| 🗺️ **Coverage**               | 🇪🇪 Estonia                                                     |
+| 📆 **Daily forecast**          | Up to 4 days                                                     |
+| ⏱️ **Hourly forecast**         | Up to 4 days                                                     |
+| ▶️ **Current observation**     | Not available: will show hourly forecast data                    |
+| 😶‍🌫️ **Air quality**         | Not available: Users can add [EKUK](#ekuk) as a secondary source |
+| 🤧 **Pollen**                  | Not available: Users can add [EKUK](#ekuk) as a secondary source |
+| ☔ **Precipitation nowcasting** | Not available                                                    |
+| ⚠️ **Alerts**                  | Not available                                                    |
+| 📊 **Normals**                 | Not available                                                    |
+| 🧭 **Reverse geocoding**       | Available: will show the name of the nearest location in Estonia |
+
+<details><summary><h4>Details of available data from Ilmateenistus</h4></summary>
+
+| Data                      | Available | Data              | Available |
+|---------------------------|-----------|-------------------|-----------|
+| Weather Condition         | ✅         | Pressure          | ✅         |
+| Temperature               | ✅         | UV Index          | ❌         |
+| Precipitation             | ✅         | Sunshine Duration | ❌         |
+| Precipitation Probability | ❌         | Sun &amp; Moon    | ❌         |
+| Precipitation Duration    | ❌         | Moon Phase        | ❌         |
+| Wind                      | ✅         | Cloud Cover       | ❌         |
+| Humidity                  | ❌         | Visibility        | ❌         |
+| Dew Point                 | ❌         | Ceiling           | ❌         |
 </details>
 
 ### India Meteorological Department
@@ -1165,6 +1199,11 @@ ATMO sources can be added as a secondary **Air Quality** source for some regions
 | 🇿🇼 Zimbabwe                     | [MSD](https://www.weatherzw.org.zw/)       |
 
 These sources can be added as a secondary **Alert** and **Temperature normals** source for their respective countries.
+
+### EKUK
+> Coming soon: will be available starting from v5.4.0
+
+**[Eesti Keskkonnauuringute Keskus](https://www.ohuseire.ee/)** (EKUK) can be added as a secondary **Air quality** and **Pollen** source for Estonia.
 
 ### Environmental Protection Department
 > Coming soon: will be available starting from v5.4.0


### PR DESCRIPTION
I have added Ilmateenistus and EKUK for Estonia. Both sources are under direct control of Keskkonnaagentuur, the official Environment Agency in Estonia. I have implemented the following:

- Hourly forecast from Ilmateenistus
- Current air quality and current pollen from EKUK

There are seven pollen types which are not currently covered by Breezy Weather. They are:

| Genus      | Pollen type |
|------------|-------------|
| Acer       | Maple       |
| Alternaria | Alternaria  |
| Atriplex   | Saltbush    |
| Juniperus  | Juniper     |
| Picea      | Spruce      |
| Pinus      | Pine        |
| Ulmus      | Elm         |

The details of these pollen types and the corresponding concentration levels can be found [here](https://www.ohuseire.ee/api/indicator/en?type=POLLEN). I'll leave migrating the databases with you.

I have yet to replace the use of `SimpleDateFormat` with a national date serializer. I will do that with a round of refactoring of other sources for the next minor version.