### PR TITLE
Allow loading of Resources from apps with a ApplicationIdSuffix

### DIFF
--- a/app/src/main/java/org/breezyweather/theme/resource/utils/ResourceUtils.kt
+++ b/app/src/main/java/org/breezyweather/theme/resource/utils/ResourceUtils.kt
@@ -30,12 +30,8 @@ object ResourceUtils {
                 .getField(resName)
                 .getInt(null)
         } catch (e: Exception) {
-            // TODO: Dirty way to avoid crashes on debug build (because of applicationIdSuffix ".debug")
             try {
-                context.classLoader
-                    .loadClass("org.breezyweather.R$$type")
-                    .getField(resName)
-                    .getInt(null)
+                context.resources.getIdentifier(resName, type, context.packageName)
             } catch (ignored: Exception) {
                 0
             }


### PR DESCRIPTION
[Arcticons](https://github.com/Arcticons-Team/Arcticons) has support as a breezy weather icon pack.
Some of its build variants use applicationIdSuffixes and with these breezy weather doesn't load the icons and falls back to the default with this change apps with a suffix are supported.