### PR TITLE
Patch CWA for regression in Assistant feed

### DIFF
--- a/app/src/src_nonfreenet/org/breezyweather/sources/cwa/CwaResultConverter.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/cwa/CwaResultConverter.kt
@@ -84,6 +84,7 @@ internal fun getCurrent(
     val windGusts = getValid(current?.gustInfo?.peakGustSpeed) as Double?
     val weatherText = getValid(current?.weather) as String?
     var weatherCode: WeatherCode? = null
+    var dailyForecast: String? = null
 
     // The current observation result does not come with a "code".
     // We need to decipher the best code to use based on the text.
@@ -122,6 +123,15 @@ internal fun getCurrent(
         }
     }
 
+    // "Weather Assistant" returns a few paragraphs of human-written forecast summary.
+    // We only want the first paragraph to keep it concise.
+    dailyForecast = if (assistantResult.cwaopendata != null) {
+        assistantResult.cwaopendata.dataset?.parameterSet?.parameter?.getOrNull(0)?.parameterValue
+    } else {
+        // Just in case the Assistant feed regresses to "cwbopendata" as the root property.
+        assistantResult.cwbopendata?.dataset?.parameterSet?.parameter?.getOrNull(0)?.parameterValue
+    }
+
     return CurrentWrapper(
         weatherText = weatherText,
         weatherCode = weatherCode,
@@ -141,9 +151,7 @@ internal fun getCurrent(
             humidity = relativeHumidity,
             latitude = latitude
         ),
-        // "Weather Assistant" returns a few paragraphs of human-written forecast summary.
-        // We only want the first paragraph to keep it concise.
-        dailyForecast = assistantResult.cwaopendata?.dataset?.parameterSet?.parameter?.getOrNull(0)?.parameterValue
+        dailyForecast = dailyForecast
     )
 }
 

--- a/app/src/src_nonfreenet/org/breezyweather/sources/cwa/json/CwaAssistantResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/cwa/json/CwaAssistantResult.kt
@@ -21,4 +21,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CwaAssistantResult(
     val cwaopendata: CwaAssistantOpenData? = null,
+    val cwbopendata: CwaAssistantOpenData? = null,
 )


### PR DESCRIPTION
A patch to keep displaying the daily bulletin from CWA's "Weather Assistant" feed in case it regresses to using `cwbopendata` as the root property.

This quirk is due to the fact that the Central Weather Administration was called Central Weather Bureau for a long time. It was only renamed to CWA as of September 2023.