### PR TITLE
Settings notification permission card

### DIFF
--- a/app/src/main/java/org/breezyweather/Migrations.kt
+++ b/app/src/main/java/org/breezyweather/Migrations.kt
@@ -16,7 +16,9 @@
 
 package org.breezyweather
 
+import android.Manifest
 import android.content.Context
+import android.os.Build
 import breezyweather.data.location.LocationRepository
 import breezyweather.domain.source.SourceFeature
 import kotlinx.coroutines.runBlocking
@@ -28,6 +30,7 @@ import org.breezyweather.common.basic.models.options.appearance.DailyTrendDispla
 import org.breezyweather.common.basic.models.options.appearance.HourlyTrendDisplay
 import org.breezyweather.domain.settings.SettingsManager
 import org.breezyweather.sources.SourceManager
+import org.breezyweather.ui.main.utils.StatementManager
 import java.io.File
 
 object Migrations {
@@ -76,6 +79,7 @@ object Migrations {
                         }
                     }
                 }
+
                 if (oldVersion < 50102) {
                     // V5.1.2 adds daily sunshine chart
                     try {
@@ -165,6 +169,18 @@ object Migrations {
                                     )
                                 }
                             }
+                    }
+                }
+
+                if (oldVersion < 50402) {
+                    try {
+                        // We cannot determine if the permission was permanently denied in the past. That is why we
+                        // need to update the state for all users updating from an older version.
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                            StatementManager(context).setPermissionDenied(Manifest.permission.POST_NOTIFICATIONS)
+                        }
+                    } catch (ignored: Throwable) {
+                        // ignored
                     }
                 }
             }

--- a/app/src/main/java/org/breezyweather/background/forecast/TodayForecastNotificationJob.kt
+++ b/app/src/main/java/org/breezyweather/background/forecast/TodayForecastNotificationJob.kt
@@ -30,6 +30,7 @@ import breezyweather.data.weather.WeatherRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import org.breezyweather.common.extensions.cancelNotification
+import org.breezyweather.common.extensions.hasNotificationPermission
 import org.breezyweather.common.extensions.isRunning
 import org.breezyweather.common.extensions.setForegroundSafely
 import org.breezyweather.common.extensions.workManager
@@ -55,20 +56,22 @@ class TodayForecastNotificationJob @AssistedInject constructor(
         setForegroundSafely()
 
         return try {
-            val location = locationRepository.getFirstLocation(withParameters = false)
-            if (location != null) {
-                notifier.showComplete(
-                    location.copy(
-                        weather = weatherRepository.getWeatherByLocationId(
-                            location.formattedId,
-                            withDaily = true,
-                            withHourly = false,
-                            withMinutely = false,
-                            withAlerts = false
-                        )
-                    ),
-                    today = true
-                )
+            if (SettingsManager.getInstance(context).isTodayForecastEnabled) {
+                val location = locationRepository.getFirstLocation(withParameters = false)
+                if (location != null) {
+                    notifier.showComplete(
+                        location.copy(
+                            weather = weatherRepository.getWeatherByLocationId(
+                                location.formattedId,
+                                withDaily = true,
+                                withHourly = false,
+                                withMinutely = false,
+                                withAlerts = false
+                            )
+                        ),
+                        today = true
+                    )
+                }
             }
             Result.success()
         } catch (e: Exception) {
@@ -104,17 +107,21 @@ class TodayForecastNotificationJob @AssistedInject constructor(
         fun setupTask(context: Context, nextDay: Boolean) {
             val settings = SettingsManager.getInstance(context)
             if (settings.isTodayForecastEnabled) {
-                val request = OneTimeWorkRequestBuilder<TodayForecastNotificationJob>()
-                    .setInitialDelay(
-                        getForecastAlarmDelayInMinutes(settings.todayForecastTime, nextDay),
-                        TimeUnit.MINUTES
-                    )
-                    .addTag(TAG)
-                    .build()
-                context.workManager.enqueueUniqueWork(TAG, ExistingWorkPolicy.REPLACE, request)
-            } else {
-                context.workManager.cancelUniqueWork(TAG)
+                if (context.hasNotificationPermission) {
+                    val request = OneTimeWorkRequestBuilder<TodayForecastNotificationJob>()
+                        .setInitialDelay(
+                            getForecastAlarmDelayInMinutes(settings.todayForecastTime, nextDay),
+                            TimeUnit.MINUTES
+                        )
+                        .addTag(TAG)
+                        .build()
+                    context.workManager.enqueueUniqueWork(TAG, ExistingWorkPolicy.REPLACE, request)
+                    return
+                } else {
+                    settings.isTodayForecastEnabled = false
+                }
             }
+            context.workManager.cancelUniqueWork(TAG)
         }
 
         fun stop(context: Context) {

--- a/app/src/main/java/org/breezyweather/common/extensions/ContextExtensions.kt
+++ b/app/src/main/java/org/breezyweather/common/extensions/ContextExtensions.kt
@@ -16,6 +16,7 @@
 
 package org.breezyweather.common.extensions
 
+import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -23,6 +24,7 @@ import android.content.pm.ShortcutManager
 import android.hardware.SensorManager
 import android.location.LocationManager
 import android.net.Uri
+import android.os.Build
 import android.os.PowerManager
 import android.provider.Settings
 import android.view.WindowManager
@@ -48,6 +50,16 @@ import java.io.File
 fun Context.hasPermission(
     permission: String,
 ) = ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
+
+/**
+ * Checks if the notification permission is granted.
+ *
+ * @return true if the permission is granted. Always returns true on Android 12 and lower.
+ */
+val Context.hasNotificationPermission
+    get() = !(
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !hasPermission(Manifest.permission.POST_NOTIFICATIONS)
+        )
 
 val Context.inputMethodManager: InputMethodManager
     get() = getSystemService()!!

--- a/app/src/main/java/org/breezyweather/common/utils/helpers/IntentHelper.kt
+++ b/app/src/main/java/org/breezyweather/common/utils/helpers/IntentHelper.kt
@@ -21,7 +21,9 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
 import android.provider.Settings
+import androidx.annotation.RequiresApi
 import breezyweather.domain.location.model.Location
 import org.breezyweather.ui.about.AboutActivity
 import org.breezyweather.ui.alert.AlertActivity
@@ -220,6 +222,15 @@ object IntentHelper {
 
     fun startLocationSettingsActivity(context: Context) {
         context.startActivity(Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS))
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun startNotificationSettingsActivity(context: Context, pkgName: String? = context.packageName) {
+        context.startActivity(
+            Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+                putExtra(Settings.EXTRA_APP_PACKAGE, pkgName)
+            }
+        )
     }
 
     private fun isIntentAvailable(context: Context, intent: Intent): Boolean {

--- a/app/src/main/java/org/breezyweather/common/utils/helpers/PermissionHelper.kt
+++ b/app/src/main/java/org/breezyweather/common/utils/helpers/PermissionHelper.kt
@@ -1,0 +1,56 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.common.utils.helpers
+
+import android.app.Activity
+import androidx.core.app.ActivityCompat.requestPermissions
+import androidx.core.app.ActivityCompat.shouldShowRequestPermissionRationale
+import org.breezyweather.ui.main.utils.StatementManager
+
+object PermissionHelper {
+
+    /**
+     * Requests a permission via the default permission dialog and falls back to a custom action if the default
+     * dialog cannot be launched because it was previously denied by the user.
+     *
+     * Source: https://stackoverflow.com/a/50639402
+     */
+    fun requestPermissionWithFallback(
+        activity: Activity,
+        permission: String,
+        requestCode: Int = 0,
+        fallback: () -> Unit,
+    ) {
+        val statementManager = StatementManager(activity)
+        val showRationale = shouldShowRequestPermissionRationale(activity, permission)
+        val permissionDenied = statementManager.isPermissionDenied(permission)
+
+        if (!showRationale && permissionDenied) {
+            fallback()
+        } else {
+            requestPermissions(
+                activity,
+                arrayOf(permission),
+                requestCode
+            )
+
+            if (showRationale && !permissionDenied) {
+                statementManager.setPermissionDenied(permission)
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/breezyweather/ui/common/composables/AnimatedVisibility.kt
+++ b/app/src/main/java/org/breezyweather/ui/common/composables/AnimatedVisibility.kt
@@ -1,0 +1,51 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.ui.common.composables
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+
+@Composable
+fun AnimatedVisibilitySlideVertically(
+    visible: Boolean,
+    label: String = "",
+    expandFrom: Alignment.Vertical = Alignment.Top,
+    shrinkTowards: Alignment.Vertical = Alignment.Top,
+    content: @Composable (AnimatedVisibilityScope.() -> Unit),
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn() + expandVertically(
+            expandFrom = expandFrom
+        ) + slideInVertically(),
+        exit = slideOutVertically(
+            targetOffsetY = { -it / 2 }
+        ) + shrinkVertically(
+            shrinkTowards = shrinkTowards
+        ) + fadeOut(),
+        label = label,
+        content = content
+    )
+}

--- a/app/src/main/java/org/breezyweather/ui/main/fragments/ManagementFragment.kt
+++ b/app/src/main/java/org/breezyweather/ui/main/fragments/ManagementFragment.kt
@@ -94,6 +94,8 @@ import org.breezyweather.common.extensions.isDarkMode
 import org.breezyweather.common.extensions.plus
 import org.breezyweather.common.source.LocationPreset
 import org.breezyweather.common.source.getName
+import org.breezyweather.common.utils.helpers.IntentHelper
+import org.breezyweather.common.utils.helpers.PermissionHelper
 import org.breezyweather.common.utils.helpers.SnackbarHelper
 import org.breezyweather.domain.location.model.getPlace
 import org.breezyweather.domain.settings.SettingsManager
@@ -272,9 +274,13 @@ open class ManagementFragment : MainModuleFragment(), TouchReactor {
                                 onClick = {
                                     viewModel.statementManager.setPostNotificationDialogAlreadyShown()
                                     notificationDismissed = true
-                                    requireActivity().requestPermissions(
-                                        arrayOf(Manifest.permission.POST_NOTIFICATIONS),
-                                        0
+
+                                    PermissionHelper.requestPermissionWithFallback(
+                                        activity = requireActivity(),
+                                        permission = Manifest.permission.POST_NOTIFICATIONS,
+                                        fallback = {
+                                            IntentHelper.startNotificationSettingsActivity(requireActivity())
+                                        }
                                     )
                                 },
                                 onClose = {

--- a/app/src/main/java/org/breezyweather/ui/main/utils/StatementManager.kt
+++ b/app/src/main/java/org/breezyweather/ui/main/utils/StatementManager.kt
@@ -50,6 +50,9 @@ class StatementManager @Inject constructor(
             config.edit().putBoolean(KEY_APP_UPDATE_CHECK_ASKED, value).apply()
         }
 
+    private fun getPermissionDeniedKey(permission: String): String =
+        permission.replace(".", "_").lowercase() + "_denied"
+
     fun setLocationPermissionDialogAlreadyShown() {
         isLocationPermissionDialogAlreadyShown = true
     }
@@ -64,6 +67,13 @@ class StatementManager @Inject constructor(
 
     fun setAppUpdateCheckDialogAlreadyShown() {
         isAppUpdateCheckDialogAlreadyShown = true
+    }
+
+    fun isPermissionDenied(permission: String): Boolean =
+        config.getBoolean(getPermissionDeniedKey(permission), false)
+
+    fun setPermissionDenied(permission: String) {
+        config.edit().putBoolean(getPermissionDeniedKey(permission), true).apply()
     }
 
     companion object {

--- a/app/src/main/java/org/breezyweather/ui/main/utils/StatementManager.kt
+++ b/app/src/main/java/org/breezyweather/ui/main/utils/StatementManager.kt
@@ -25,53 +25,45 @@ class StatementManager @Inject constructor(
     @ApplicationContext context: Context,
 ) {
     private val config: ConfigStore = ConfigStore(context, SP_STATEMENT_RECORD)
-    var isLocationPermissionDialogAlreadyShown: Boolean = config.getBoolean(
-        KEY_LOCATION_PERMISSION_DECLARED,
-        false
-    )
-        private set
-    var isBackgroundLocationPermissionDialogAlreadyShown: Boolean = config.getBoolean(
-        KEY_BACKGROUND_LOCATION_DECLARED,
-        false
-    )
-        private set
-    var isPostNotificationDialogAlreadyShown: Boolean = config.getBoolean(
-        KEY_POST_NOTIFICATION_REQUIRED,
-        false
-    )
-        private set
-    var isAppUpdateCheckDialogAlreadyShown: Boolean = config.getBoolean(
-        KEY_APP_UPDATE_CHECK_ASKED,
-        false
-    )
-        private set
+
+    var isLocationPermissionDialogAlreadyShown: Boolean
+        get() = config.getBoolean(KEY_LOCATION_PERMISSION_DECLARED, false)
+        private set(value) {
+            config.edit().putBoolean(KEY_LOCATION_PERMISSION_DECLARED, value).apply()
+        }
+
+    var isBackgroundLocationPermissionDialogAlreadyShown: Boolean
+        get() = config.getBoolean(KEY_BACKGROUND_LOCATION_DECLARED, false)
+        private set(value) {
+            config.edit().putBoolean(KEY_BACKGROUND_LOCATION_DECLARED, value).apply()
+        }
+
+    var isPostNotificationDialogAlreadyShown: Boolean
+        get() = config.getBoolean(KEY_POST_NOTIFICATION_REQUIRED, false)
+        private set(value) {
+            config.edit().putBoolean(KEY_POST_NOTIFICATION_REQUIRED, value).apply()
+        }
+
+    var isAppUpdateCheckDialogAlreadyShown: Boolean
+        get() = config.getBoolean(KEY_APP_UPDATE_CHECK_ASKED, false)
+        private set(value) {
+            config.edit().putBoolean(KEY_APP_UPDATE_CHECK_ASKED, value).apply()
+        }
 
     fun setLocationPermissionDialogAlreadyShown() {
         isLocationPermissionDialogAlreadyShown = true
-        config.edit()
-            .putBoolean(KEY_LOCATION_PERMISSION_DECLARED, true)
-            .apply()
     }
 
     fun setBackgroundLocationPermissionDialogAlreadyShown() {
         isBackgroundLocationPermissionDialogAlreadyShown = true
-        config.edit()
-            .putBoolean(KEY_BACKGROUND_LOCATION_DECLARED, true)
-            .apply()
     }
 
     fun setPostNotificationDialogAlreadyShown() {
         isPostNotificationDialogAlreadyShown = true
-        config.edit()
-            .putBoolean(KEY_POST_NOTIFICATION_REQUIRED, true)
-            .apply()
     }
 
     fun setAppUpdateCheckDialogAlreadyShown() {
         isAppUpdateCheckDialogAlreadyShown = true
-        config.edit()
-            .putBoolean(KEY_APP_UPDATE_CHECK_ASKED, true)
-            .apply()
     }
 
     companion object {

--- a/app/src/main/java/org/breezyweather/ui/settings/preference/composables/SwitchPreference.kt
+++ b/app/src/main/java/org/breezyweather/ui/settings/preference/composables/SwitchPreference.kt
@@ -107,7 +107,7 @@ fun SwitchPreferenceView(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = themeRipple(),
                         onClick = {
-                            state.value = !state.value
+                            state.value = if (withState) !state.value else !checked
                             onValueChanged(state.value)
                         },
                         enabled = enabled

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -364,6 +364,7 @@
     <string name="action_download">Download</string>
     <string name="action_show_errors">Tap to see details</string>
     <string name="action_show">Show</string>
+    <string name="action_grant_permission">Tap to grant the permission.</string>
     <!-- Button shown in the weather selection dialog -->
     <string name="action_help_me_choose">Help me choose</string>
     <!-- Dialogs -->
@@ -652,6 +653,9 @@
     <string name="settings_notifications">Notifications</string>
     <string name="settings_notifications_summary">Notifications of weather alerts, precipitations or forecast for the first location</string>
     <string name="settings_notifications_app_updates_check">Notifications of app updates</string>
+    <string name="settings_notifications_permission">Notification permission required</string>
+    <!-- %s is the string with the key action_grant_permission -->
+    <string name="settings_notifications_permission_summary">Needed to notify about alerts, forecasts and app updates. %s</string>
     <string name="settings_notifications_section_general" translatable="false">@string/settings_section_general</string>
     <!-- “important” means we won’t send notifications for minor severity alerts -->
     <string name="settings_notifications_alerts_title">Notifications of severe weather alerts</string>
@@ -673,6 +677,8 @@
     <string name="settings_widgets_section_widgets_in_use">Widgets in use</string>
     <string name="settings_widgets_configure_widget_summary">Configure this widget</string>
     <string name="settings_widgets_section_notification_widget">Notification widget</string>
+    <!-- %s is the string with the key action_grant_permission -->
+    <string name="settings_widgets_notification_permission_summary">Needed to show the notification widget. %s</string>
     <string name="settings_widgets_notification_widget_title">Notification widget</string>
     <string name="settings_widgets_notification_persistent_switch">Persistent</string>
     <string name="settings_widgets_notification_style_title">Style</string>
@@ -684,6 +690,8 @@
     <string name="settings_widgets_broadcast_send_data_summary_empty">No compatible packages found</string>
     <string name="about_privacy_policy">Privacy policy</string>
     <string name="settings_debug">Debug</string>
+    <!-- %s is the string with the key action_grant_permission -->
+    <string name="settings_debug_notification_permission">Needed to notify about crash logs and failed weather updates. %s</string>
     <string name="settings_debug_summary">Crash logs</string>
     <string name="settings_debug_dump_crash_logs_title">Share crash logs</string>
     <string name="settings_debug_dump_crash_logs_summary">Saves error logs to a file for sharing with the developers</string>


### PR DESCRIPTION
This closes #812.

The PR includes the following changes:
- Ensure that preferences requiring the notification permission are only configurable when the permission is granted
- Show a card when the notification permission is missing (notification, widget and debug settings screen)
- Open Android notification settings via a fallback action if the permission cannot be requested via the default dialog (see screen recording below)

I decided to keep the configured value for `checked` in the `SwitchPreferenceView` and only set `enabled` to `false` when the permission is missing. In my opinion the info card should be sufficient for users to understand that those settings cannot be changed without the notification permission.

There preferences for the forecast notification are an exception to this. To prevent the notification worker jobs from being executed daily although the notification permission was missing, I decided to disable those settings and cancel the worker jobs in that case.

<details>

<summary>screen recording</summary>

https://github.com/user-attachments/assets/45085aab-0075-4cd6-9f14-6f987d8bfa38

</details>

Successfully tested on the following devices: Google Pixel 6a (Android 15) and LG G6 (Android 9).