### PR TITLE
Fix content jumping up and down when vertically scrolling in the HomeFragment

### DIFF
--- a/app/src/main/java/org/breezyweather/ui/main/layouts/MainLayoutManager.kt
+++ b/app/src/main/java/org/breezyweather/ui/main/layouts/MainLayoutManager.kt
@@ -104,7 +104,7 @@ class MainLayoutManager : RecyclerView.LayoutManager() {
     override fun scrollVerticallyBy(dy: Int, recycler: Recycler, state: RecyclerView.State): Int {
         // dy : + ===> content scroll up.   / show bottom content.
         //      - ===> content scroll down. / show top content.
-        if (childCount == 0 || dy == 0) return 0
+        if (childCount == 0 || dy == 0 || height > mMeasuredHeight) return 0
         var consumed = dy
         if (scrollOffset + consumed + height > mMeasuredHeight) {
             consumed = mMeasuredHeight - scrollOffset - height


### PR DESCRIPTION
Based on [the discussion](https://github.com/breezy-weather/breezy-weather/issues/1614#issuecomment-2637571663) in #1614 I realized that the jumping effect can still occur in cases where the entire content of the recycler view fits on the screen while having valid weather data.

This is most likely a rather rare scenario when users have very few cards displayed in the home fragment and is probably mostly happening on larger screens (tablets) when used in portrait mode.

This PR adds a new check as described above.

Successfully tested on the following devices: Google Pixel 6a (Android 15) and an emulated tablet (Android 12L).

<details>

<summary>screen recording</summary>

| issue | fixed |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/58925122-3631-4544-bfee-867115250f51" /> | <video src="https://github.com/user-attachments/assets/9e1a5857-ec72-4007-ac60-c10b455bcf41" /> |

</details>
