### PR TITLE
Reduce calls to set the system bars' style when scrolling vertically in the HomeFragment

### DIFF
--- a/app/src/main/java/org/breezyweather/ui/main/fragments/HomeFragment.kt
+++ b/app/src/main/java/org/breezyweather/ui/main/fragments/HomeFragment.kt
@@ -502,9 +502,7 @@ class HomeFragment : MainModuleFragment() {
 
     private inner class OnScrollListener : RecyclerView.OnScrollListener() {
 
-        private var mTopChanged: Boolean? = null
         var topOverlap = false
-        private var mFirstCardMarginTop = 0
         private var mScrollY = 0
         private var mLastAppBarTranslationY = 0f
 
@@ -513,9 +511,7 @@ class HomeFragment : MainModuleFragment() {
                 if (!isFragmentViewCreated) {
                     return@post
                 }
-                mTopChanged = null
                 topOverlap = false
-                mFirstCardMarginTop = 0
                 mScrollY = 0
                 mLastAppBarTranslationY = 0f
                 onScrolled(recyclerView, 0, 0)
@@ -523,12 +519,6 @@ class HomeFragment : MainModuleFragment() {
         }
 
         override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
-            mFirstCardMarginTop = if (recyclerView.childCount > 0) {
-                recyclerView.getChildAt(0).top
-            } else {
-                -1
-            }
-
             mScrollY = recyclerView.computeVerticalScrollOffset()
             mLastAppBarTranslationY = binding.appBar.translationY
             weatherView.onScroll(mScrollY)
@@ -551,13 +541,9 @@ class HomeFragment : MainModuleFragment() {
             }
 
             // set system bar style.
-            mTopChanged = if (mFirstCardMarginTop <= 0) {
-                (binding.appBar.translationY != 0f) != (mLastAppBarTranslationY != 0f)
-            } else {
-                true
-            }
             topOverlap = binding.appBar.translationY != 0f
-            if (mTopChanged!!) {
+            if ((binding.appBar.translationY == 0f) != (mLastAppBarTranslationY == 0f)) {
+                // Only update the system bars when the app bar actually starts collapsing or stops expanding.
                 checkToSetSystemBarStyle()
             }
         }


### PR DESCRIPTION
Currently, when scrolling vertically in the HomeFragment `checkToSetSystemBarStyle` is called whenever the vertical location (translation y) of the top app bar changes. As a result, multiple unnecessary calls are made to [update the system bars' style](https://github.com/breezy-weather/breezy-weather/blob/22da48c72f2421e96300a160af059945ce1037bf/app/src/main/java/org/breezyweather/ui/main/MainActivity.kt#L762).

The PR simplifies the previous solution and only calls `checkToSetSystemBarStyle` when the top app bar is actually starting to collapse or is fully expanded. This still ensures that the status bar is shaded when the top app bar is collapsing/collapsed and that it stays transparent when expanded.

Successfully tested on the following devices: Google Pixel 6a (Android 15) and LG G6 (Android 9).