### PR TITLE
Fix shade of 3-button navigation bar in HomeFragment on app start

### DIFF
--- a/app/src/main/java/org/breezyweather/common/basic/GeoActivity.kt
+++ b/app/src/main/java/org/breezyweather/common/basic/GeoActivity.kt
@@ -40,7 +40,6 @@ abstract class GeoActivity : AppCompatActivity() {
             window.setSystemBarStyle(
                 statusShaderP = false,
                 lightStatusP = !this.isDarkMode,
-                navigationShaderP = true,
                 lightNavigationP = !this.isDarkMode
             )
         }

--- a/app/src/main/java/org/breezyweather/common/extensions/DisplayExtensions.kt
+++ b/app/src/main/java/org/breezyweather/common/extensions/DisplayExtensions.kt
@@ -110,16 +110,14 @@ fun Context.getTypefaceFromTextAppearance(
     return TextAppearance(this, textAppearanceId).getFont(this)
 }
 
+@Suppress("DEPRECATION")
 fun Window.setSystemBarStyle(
     statusShaderP: Boolean,
     lightStatusP: Boolean,
-    navigationShaderP: Boolean,
     lightNavigationP: Boolean,
 ) {
     var lightStatus = lightStatusP
     var statusShader = statusShaderP
-    var lightNavigation = lightNavigationP
-    var navigationShader = navigationShaderP
 
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
         // Use default dark and light platform colors from EdgeToEdge
@@ -137,25 +135,20 @@ fun Window.setSystemBarStyle(
             Color.TRANSPARENT
         }
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            // Always apply a dark shader as a light or transparent navigation bar is not supported
-            lightNavigation = false
-            navigationShader = true
-        }
-        this.navigationBarColor = if (navigationShader) {
-            if (lightNavigation) colorSystemBarLight else colorSystemBarDark
+        this.navigationBarColor = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && lightNavigationP) {
+            colorSystemBarLight
         } else {
-            Color.TRANSPARENT
+            colorSystemBarDark
         }
     } else {
         this.isStatusBarContrastEnforced = statusShader
-        this.isNavigationBarContrastEnforced = navigationShaderP
+        this.isNavigationBarContrastEnforced = true
     }
 
     // Contrary to the documentation FALSE applies a light foreground color and TRUE a dark foreground color
     WindowInsetsControllerCompat(this, this.decorView).run {
         isAppearanceLightStatusBars = lightStatus
-        isAppearanceLightNavigationBars = lightNavigation
+        isAppearanceLightNavigationBars = lightNavigationP
     }
 }
 

--- a/app/src/main/java/org/breezyweather/ui/alert/AlertScreen.kt
+++ b/app/src/main/java/org/breezyweather/ui/alert/AlertScreen.kt
@@ -101,7 +101,6 @@ internal fun AlertScreen(
                     window = activity.window,
                     statusShader = false,
                     lightStatus = isLightTheme,
-                    navigationShader = true,
                     lightNavigation = isLightTheme
                 )
         }

--- a/app/src/main/java/org/breezyweather/ui/daily/DailyScreen.kt
+++ b/app/src/main/java/org/breezyweather/ui/daily/DailyScreen.kt
@@ -94,7 +94,6 @@ internal fun DailyWeatherScreen(
                     window = activity.window,
                     statusShader = false,
                     lightStatus = isLightTheme,
-                    navigationShader = true,
                     lightNavigation = isLightTheme
                 )
         }

--- a/app/src/main/java/org/breezyweather/ui/main/fragments/HomeFragment.kt
+++ b/app/src/main/java/org/breezyweather/ui/main/fragments/HomeFragment.kt
@@ -29,8 +29,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.graphics.ColorUtils
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
@@ -118,14 +116,6 @@ class HomeFragment : MainModuleFragment() {
             BackgroundAnimationMode.DISABLED -> false
         }
 
-    private fun isButtonNavigation(): Boolean {
-        val insets = ViewCompat.getRootWindowInsets(requireActivity().window.decorView)
-        val tappableElement = insets?.getInsets(WindowInsetsCompat.Type.tappableElement())
-        val bottomPixels = tappableElement?.bottom
-
-        return (bottomPixels != null && bottomPixels != 0)
-    }
-
     override fun onResume() {
         super.onResume()
         weatherView.setDrawable(!isHidden)
@@ -157,7 +147,7 @@ class HomeFragment : MainModuleFragment() {
                 requireActivity().window,
                 statusShader = scrollListener?.topOverlap == true,
                 lightStatus = false,
-                navigationShader = isButtonNavigation(), // no shade when gesture navigation is used
+                navigationShader = true,
                 lightNavigation = false
             )
     }

--- a/app/src/main/java/org/breezyweather/ui/main/fragments/HomeFragment.kt
+++ b/app/src/main/java/org/breezyweather/ui/main/fragments/HomeFragment.kt
@@ -147,7 +147,6 @@ class HomeFragment : MainModuleFragment() {
                 requireActivity().window,
                 statusShader = scrollListener?.topOverlap == true,
                 lightStatus = false,
-                navigationShader = true,
                 lightNavigation = false
             )
     }

--- a/app/src/main/java/org/breezyweather/ui/main/fragments/ManagementFragment.kt
+++ b/app/src/main/java/org/breezyweather/ui/main/fragments/ManagementFragment.kt
@@ -136,7 +136,6 @@ class PushedManagementFragment : ManagementFragment() {
                 requireActivity().window,
                 statusShader = false,
                 lightStatus = !requireActivity().isDarkMode,
-                navigationShader = true,
                 lightNavigation = !requireActivity().isDarkMode
             )
     }

--- a/app/src/main/java/org/breezyweather/ui/pollen/PollenScreen.kt
+++ b/app/src/main/java/org/breezyweather/ui/pollen/PollenScreen.kt
@@ -79,7 +79,6 @@ internal fun PollenScreen(
                     window = activity.window,
                     statusShader = false,
                     lightStatus = isLightTheme,
-                    navigationShader = true,
                     lightNavigation = isLightTheme
                 )
         }

--- a/app/src/main/java/org/breezyweather/ui/theme/weatherView/WeatherThemeDelegate.kt
+++ b/app/src/main/java/org/breezyweather/ui/theme/weatherView/WeatherThemeDelegate.kt
@@ -60,7 +60,6 @@ interface WeatherThemeDelegate {
         window: Window,
         statusShader: Boolean,
         lightStatus: Boolean,
-        navigationShader: Boolean,
         lightNavigation: Boolean,
     )
 

--- a/app/src/main/java/org/breezyweather/ui/theme/weatherView/materialWeatherView/MaterialWeatherThemeDelegate.kt
+++ b/app/src/main/java/org/breezyweather/ui/theme/weatherView/materialWeatherView/MaterialWeatherThemeDelegate.kt
@@ -132,13 +132,11 @@ class MaterialWeatherThemeDelegate : WeatherThemeDelegate {
         window: Window,
         statusShader: Boolean,
         lightStatus: Boolean,
-        navigationShader: Boolean,
         lightNavigation: Boolean,
     ) {
         window.setSystemBarStyle(
             statusShaderP = statusShader,
             lightStatusP = lightStatus,
-            navigationShaderP = navigationShader,
             lightNavigationP = lightNavigation
         )
     }


### PR DESCRIPTION
In #1622 I missed an issue where the 3-button navigation bar in the HomeFragments stays transparent on app start. This is caused by [isButtonNavigation()](https://github.com/breezy-weather/breezy-weather/blob/96b82d2403e566e639fbf0feaaa43f3680e250dc/app/src/main/java/org/breezyweather/ui/main/fragments/HomeFragment.kt#L121C17-L121C35) which is called before the root view - used in [setSystemBarStyle()](https://github.com/breezy-weather/breezy-weather/blob/96b82d2403e566e639fbf0feaaa43f3680e250dc/app/src/main/java/org/breezyweather/ui/main/fragments/HomeFragment.kt#L155) to determine if a button navigation bar is present - is attached. As a result, the method always returns `false` and no shade is applied to the navigation bar. This didn't occur before because [checkToSetSystemBarStyle()](https://github.com/breezy-weather/breezy-weather/blob/96b82d2403e566e639fbf0feaaa43f3680e250dc/app/src/main/java/org/breezyweather/ui/main/fragments/HomeFragment.kt#L547) and thus `setSystemBarStyle` was called multiple times on app start which is not the case anymore.

However, I realized that with the changes made in #1457 `isButtonNavigation` is no longer needed. When [window.isNavigationBarContrastEnforced](https://github.com/breezy-weather/breezy-weather/blob/96b82d2403e566e639fbf0feaaa43f3680e250dc/app/src/main/java/org/breezyweather/common/extensions/DisplayExtensions.kt#L152) is `true`, it automatically determines if the navigation bar should be shaded. That way the navigation bar is shaded when 3-button navigation or a taskbar (on tablets) is used while keeping the navigation bar transparent when gesture navigation is active.

Thoroughly tested on the following devices with both navigation types:
- [x] Google Pixel 6a (Android 15)
- [x] emulator with Android 9 [only 3-button navigation available]
- [x] Galaxy S25 (Android 15) [via Samsung Remote Test Lab]
- [x] Galaxy A54 (Android 14) [via Samsung Remote Test Lab]
- [x] Galaxy Tab S9 (Android 14) [via Samsung Remote Test Lab]
- [x] emulator with Android 7 [only 3-button navigation and dark navigation bar available]