### PR TITLE
Fix: Don't open location list in landscape by default when there is only 1 location

### DIFF
--- a/app/src/main/java/org/breezyweather/ui/main/MainActivity.kt
+++ b/app/src/main/java/org/breezyweather/ui/main/MainActivity.kt
@@ -345,8 +345,11 @@ class MainActivity : GeoActivity(), HomeFragment.Callback, ManagementFragment.Ca
                 // Note that this happens when lifecycle is STARTED and stops
                 // collecting when the lifecycle is STOPPED
                 viewModel.validLocationList.collect {
-                    if (it.isEmpty()) {
+                    val isLandscape = resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+                    if (it.isEmpty() || (isLandscape && it.size > 1)) {
                         setManagementFragmentVisibility(true)
+                    } else {
+                        setManagementFragmentVisibility(false)
                     }
                     refreshBackgroundViews(it)
                 }


### PR DESCRIPTION
I fixed the issue in #1619 "Don't open location list in landscape by default when there is only 1 location". I did Landscape check and edited it so that if the location list is greater than 1, ManagementFragment will appear by default, otherwise not. 