### PR TITLE
Fix: Don't open location list in landscape by default when there is only 1 location

### DIFF
--- a/app/src/main/java/org/breezyweather/ui/main/MainActivity.kt
+++ b/app/src/main/java/org/breezyweather/ui/main/MainActivity.kt
@@ -77,6 +77,7 @@ import org.breezyweather.common.extensions.conditional
 import org.breezyweather.common.extensions.doOnApplyWindowInsets
 import org.breezyweather.common.extensions.hasPermission
 import org.breezyweather.common.extensions.isDarkMode
+import org.breezyweather.common.extensions.isLandscape
 import org.breezyweather.common.snackbar.SnackbarContainer
 import org.breezyweather.common.utils.helpers.IntentHelper
 import org.breezyweather.common.utils.helpers.SnackbarHelper
@@ -231,6 +232,10 @@ class MainActivity : GeoActivity(), HomeFragment.Callback, ManagementFragment.Ca
 
         initModel(savedInstanceState == null)
         initView()
+
+        if (viewModel.validLocationList.value.size == 1 && this.isLandscape && isDrawerLayoutVisible) {
+            setManagementFragmentVisibility(false)
+        }
 
         consumeIntentAction(intent)
 


### PR DESCRIPTION
I fixed the issue in #1619 "Don't open location list in landscape by default when there is only 1 location".

In the onCreate() function of MainActivity, I checked if the location list is strictly 1 AND if the screen is in landscape mode AND if the DrawerLayout is visible. And if it is, I called the setManagementFragmentVisibility(false) function.