### PR TITLE
Fix horizontal and bottom insets for DailyScreen

### DIFF
--- a/app/src/main/java/org/breezyweather/ui/daily/DailyScreen.kt
+++ b/app/src/main/java/org/breezyweather/ui/daily/DailyScreen.kt
@@ -21,13 +21,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -46,6 +47,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
@@ -108,8 +110,7 @@ internal fun DailyWeatherScreen(
             topBar = {
                 BWCenterAlignedTopAppBar(
                     title = stringResource(R.string.daily_forecast),
-                    onBackPressed = onBackPressed,
-                    windowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top)
+                    onBackPressed = onBackPressed
                 )
             }
         ) { paddings ->
@@ -129,7 +130,8 @@ internal fun DailyWeatherScreen(
                         .fillMaxSize()
                         .padding(
                             top = paddings.calculateTopPadding(),
-                            bottom = paddings.calculateBottomPadding()
+                            start = paddings.calculateStartPadding(LocalLayoutDirection.current),
+                            end = paddings.calculateEndPadding(LocalLayoutDirection.current)
                         )
                 ) {
                     DailyPagerIndicator(
@@ -358,6 +360,9 @@ fun DailyPagerContent(
                     )
                 }
             }
+        }
+        item {
+            Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
         }
     }
 }


### PR DESCRIPTION
This PR fixes the horizontal insets to ensure that elements are not hidden by the navigation bar or the display cutout area when used in landscape mode. Additionally, the bottom insets are replaced by a spacer at the bottom of the list to match the behavior in other screens where elements can be seen when they are behind the navigation bar.

Successfully tested on the following devices: Google Pixel 6a (Android 15).

<details>

<summary>screenshots</summary>

| old | new |
| --- | --- |
| ![Screenshot_20250222-193057](https://github.com/user-attachments/assets/4b7f8751-b2f4-481d-8c0d-59d8f52ec15d) | ![Screenshot_20250222-193027](https://github.com/user-attachments/assets/bc99474a-24f7-4dbf-a995-28e6a511727f) |
| ![Screenshot_20250222-193131](https://github.com/user-attachments/assets/33f7e03e-0764-4318-9126-836943a7f8ef) | ![Screenshot_20250222-193034](https://github.com/user-attachments/assets/029fbb37-f626-487d-9338-9b55fdf0f93e) |

</details>