### PR TITLE
Remove large icon from notifications for alerts and precipitation

### DIFF
--- a/app/src/main/java/org/breezyweather/remoteviews/Notifications.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/Notifications.kt
@@ -20,7 +20,6 @@ import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.PendingIntent
 import android.content.Context
-import android.graphics.BitmapFactory
 import android.os.Build
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
@@ -155,7 +154,6 @@ object Notifications {
     ): NotificationCompat.Builder {
         return context.notificationBuilder(CHANNEL_ALERT).apply {
             setSmallIcon(iconId)
-            setLargeIcon(BitmapFactory.decodeResource(context.resources, R.drawable.ic_launcher))
             setContentTitle(title)
             setSubText(subtitle)
             setContentText(content)


### PR DESCRIPTION
Closes #1657.

This removes the large icon from the builder used for alerts and precipitation notifications.

Successfully tested on the following devices: Google Pixel 6a (Android 15) and LG G6 (Android 9).