### PR TITLE
Remove unused context parameter from setSystemBarStyle

### DIFF
--- a/app/src/main/java/org/breezyweather/ui/alert/AlertScreen.kt
+++ b/app/src/main/java/org/breezyweather/ui/alert/AlertScreen.kt
@@ -100,7 +100,6 @@ internal fun AlertScreen(
                 .getInstance(context)
                 .weatherThemeDelegate
                 .setSystemBarStyle(
-                    context = context,
                     window = activity.window,
                     statusShader = false,
                     lightStatus = isLightTheme,

--- a/app/src/main/java/org/breezyweather/ui/daily/DailyScreen.kt
+++ b/app/src/main/java/org/breezyweather/ui/daily/DailyScreen.kt
@@ -95,7 +95,6 @@ internal fun DailyWeatherScreen(
                 .getInstance(context)
                 .weatherThemeDelegate
                 .setSystemBarStyle(
-                    context = context,
                     window = activity.window,
                     statusShader = false,
                     lightStatus = isLightTheme,

--- a/app/src/main/java/org/breezyweather/ui/main/fragments/HomeFragment.kt
+++ b/app/src/main/java/org/breezyweather/ui/main/fragments/HomeFragment.kt
@@ -143,7 +143,6 @@ class HomeFragment : MainModuleFragment() {
             .getInstance(requireContext())
             .weatherThemeDelegate
             .setSystemBarStyle(
-                requireContext(),
                 requireActivity().window,
                 statusShader = scrollListener?.topOverlap == true,
                 lightStatus = false,

--- a/app/src/main/java/org/breezyweather/ui/main/fragments/ManagementFragment.kt
+++ b/app/src/main/java/org/breezyweather/ui/main/fragments/ManagementFragment.kt
@@ -132,7 +132,6 @@ class PushedManagementFragment : ManagementFragment() {
             .getInstance(requireContext())
             .weatherThemeDelegate
             .setSystemBarStyle(
-                requireContext(),
                 requireActivity().window,
                 statusShader = false,
                 lightStatus = !requireActivity().isDarkMode,

--- a/app/src/main/java/org/breezyweather/ui/pollen/PollenScreen.kt
+++ b/app/src/main/java/org/breezyweather/ui/pollen/PollenScreen.kt
@@ -75,7 +75,6 @@ internal fun PollenScreen(
                 .getInstance(context)
                 .weatherThemeDelegate
                 .setSystemBarStyle(
-                    context = context,
                     window = activity.window,
                     statusShader = false,
                     lightStatus = isLightTheme,

--- a/app/src/main/java/org/breezyweather/ui/theme/weatherView/WeatherThemeDelegate.kt
+++ b/app/src/main/java/org/breezyweather/ui/theme/weatherView/WeatherThemeDelegate.kt
@@ -56,7 +56,6 @@ interface WeatherThemeDelegate {
     fun getHeaderTextColor(context: Context): Int
 
     fun setSystemBarStyle(
-        context: Context,
         window: Window,
         statusShader: Boolean,
         lightStatus: Boolean,

--- a/app/src/main/java/org/breezyweather/ui/theme/weatherView/materialWeatherView/MaterialWeatherThemeDelegate.kt
+++ b/app/src/main/java/org/breezyweather/ui/theme/weatherView/materialWeatherView/MaterialWeatherThemeDelegate.kt
@@ -128,7 +128,6 @@ class MaterialWeatherThemeDelegate : WeatherThemeDelegate {
     }
 
     override fun setSystemBarStyle(
-        context: Context,
         window: Window,
         statusShader: Boolean,
         lightStatus: Boolean,


### PR DESCRIPTION
This PR removes another parameter from `setSystemBarStyle` which is not needed anymore.