### PR TITLE
Improve transition between splash screen and home screen

### DIFF
--- a/app/src/main/java/org/breezyweather/ui/main/fragments/HomeFragment.kt
+++ b/app/src/main/java/org/breezyweather/ui/main/fragments/HomeFragment.kt
@@ -252,6 +252,10 @@ class HomeFragment : MainModuleFragment() {
         binding.recyclerView.addOnScrollListener(OnScrollListener().also { scrollListener = it })
         binding.recyclerView.setOnTouchListener(indicatorStateListener)
 
+        if (isAdded && context != null) {
+            updatePreviewSubviews()
+        }
+
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.currentLocation.collect {
@@ -292,14 +296,6 @@ class HomeFragment : MainModuleFragment() {
                 }
             }
         }
-
-        previewOffset.observe(viewLifecycleOwner) {
-            binding.root.post {
-                if (isFragmentViewCreated) {
-                    updatePreviewSubviews()
-                }
-            }
-        }
     }
 
     private fun updateDayNightColors() {
@@ -315,10 +311,8 @@ class HomeFragment : MainModuleFragment() {
     fun updateViews(location: Location? = viewModel.currentLocation.value?.location) {
         ensureResourceProvider()
         updateContentViews(location = location)
-        binding.root.post {
-            if (isFragmentViewCreated) {
-                updatePreviewSubviews()
-            }
+        if (isAdded && context != null) {
+            updatePreviewSubviews()
         }
     }
 


### PR DESCRIPTION
This mitigates an issue where the window background is shortly visible in the home fragment before the actual layout is displayed. On slower devices the background might still be noticeable. Especially when background animations and gravity sensor animations are enabled.

<details><summary>screen recordings (LG G6 Android 9)</summary>

The recordings are slowed down a bit to simplify understanding of the issue.

| issue | fix |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/8439fd14-9bbb-48ec-96a2-6962ec21a02c" /> | <video src="https://github.com/user-attachments/assets/42ca16b2-a4b1-421b-baa0-dcaab84ee50f" /> |

</details>