### PR TITLE
Widget config: hint of subtitle input field

### DIFF
--- a/app/src/main/res/layout/activity_widget_config.xml
+++ b/app/src/main/res/layout/activity_widget_config.xml
@@ -361,7 +361,6 @@
                             android:textColorHighlight="@color/colorTextSubtitle"
                             android:textSize="@dimen/content_text_size"
                             android:textColor="@color/colorTextContent"
-                            android:layout_margin="@dimen/little_margin"
                             android:maxLines="1"
                             tools:ignore="Autofill" />
 


### PR DESCRIPTION
This fixes the alignment of the subtitle input field's hint text in the widget config when the input field is focused.

Successfully tested on the following devices: Google Pixel 6a (Android 15).

<details><summary>screenshots</summary>

| issue | fix |
| --- | --- |
| ![subtitle hint_issue](https://github.com/user-attachments/assets/78e58252-c813-41d3-8b10-106017c2ac9a) | ![subtitle hint_fixed](https://github.com/user-attachments/assets/256e29b8-f7d0-4d3f-bab7-f4a23e0d073b) |

</details>
