### PR TITLE
Fix FAB icon not updating correctly when switching charts

### DIFF
--- a/app/src/main/java/org/breezyweather/ui/details/DetailsScreen.kt
+++ b/app/src/main/java/org/breezyweather/ui/details/DetailsScreen.kt
@@ -292,7 +292,7 @@ fun DetailsDropdownMenu(
                     checked = fabMenuExpanded,
                     onCheckedChange = { fabMenuExpanded = !fabMenuExpanded }
                 ) {
-                    val imageVector by remember {
+                    val imageVector by remember(selectedChart.iconId) {
                         derivedStateOf {
                             if (checkedProgress > 0.5f) {
                                 R.drawable.ic_close


### PR DESCRIPTION
This contributes to #1902 and fixes the issue of the FAB icon not updating when switching charts.

This was caused by `derivedStateOf` still using the old value of `selectedChart.iconId` when switching charts. Thanks to [this info here](https://saurabharora.dev/posts/navigating-pitfalls-when-to-use-derivedStateOf-with-keys/#the-solution), I found out that the solution is to use `selectedChart.iconId` as the key for the `remember` function of `imageVector` to trigger an update whenever it changes.

Successfully tested on the following devices: Google Pixel 6a (Android 15)

https://github.com/user-attachments/assets/cb525052-6be8-44da-bff3-93b43ba7e743

