### PR TITLE
Fix LiveData observer leaks in SettingsActivity (part of #24)

### DIFF
--- a/app/src/main/java/org/breezyweather/common/basic/livedata/BusLiveData.kt
+++ b/app/src/main/java/org/breezyweather/common/basic/livedata/BusLiveData.kt
@@ -18,6 +18,7 @@ package org.breezyweather.common.basic.livedata
 
 import android.os.Handler
 import android.os.Looper
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
@@ -36,6 +37,17 @@ class BusLiveData<T>(
 
     override fun observe(owner: LifecycleOwner, observer: Observer<in T>) {
         runOnMainThread {
+            innerObserver(owner, MyObserverWrapper(this, observer, version))
+        }
+    }
+
+    fun observeAutoRemove(owner: LifecycleOwner, observer: Observer<in T>) {
+        runOnMainThread {
+            owner.lifecycle.addObserver(object : DefaultLifecycleObserver {
+                override fun onDestroy(owner: LifecycleOwner) {
+                    removeObserver(observer)
+                }
+            })
             innerObserver(owner, MyObserverWrapper(this, observer, version))
         }
     }

--- a/app/src/main/java/org/breezyweather/common/bus/EventBus.kt
+++ b/app/src/main/java/org/breezyweather/common/bus/EventBus.kt
@@ -41,5 +41,9 @@ class EventBus private constructor() {
         return liveDataMap[key] as BusLiveData<T>
     }
 
+    fun remove(type: Class<*>) {
+        liveDataMap.remove(key(type))
+    }
+
     private fun <T> key(type: Class<T>) = type.name
 }

--- a/app/src/main/java/org/breezyweather/ui/settings/activities/SettingsActivity.kt
+++ b/app/src/main/java/org/breezyweather/ui/settings/activities/SettingsActivity.kt
@@ -114,7 +114,7 @@ class SettingsActivity : GeoActivity() {
             }
         }
 
-        EventBus.instance.with(SettingsChangedMessage::class.java).observe(this) {
+        EventBus.instance.with(SettingsChangedMessage::class.java).observeAutoRemove(this) {
             val updateInterval = SettingsManager.getInstance(this).updateInterval
             if (updateIntervalState.value != updateInterval) {
                 updateIntervalState.value = updateInterval
@@ -178,6 +178,11 @@ class SettingsActivity : GeoActivity() {
             }
             return
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        EventBus.instance.remove(SettingsChangedMessage::class.java)
     }
 
     @Composable


### PR DESCRIPTION
Issue is the inner livedata observer system doesn't automatically remove a custom observer even they observe with proper lifecycle owner. Please let me know if anything should be updated.

Preproduce step to know bug fixed: Go to Settings -> Press back -> Don't see leak warning anymore.
