### PR TITLE
Fix #1925 - fixed Sun/Moon charts

### DIFF
--- a/app/src/main/java/org/breezyweather/ui/common/charts/EphemerisChart.kt
+++ b/app/src/main/java/org/breezyweather/ui/common/charts/EphemerisChart.kt
@@ -56,6 +56,7 @@ import org.breezyweather.common.extensions.toDate
 import org.breezyweather.common.extensions.windowHeightInDp
 import org.breezyweather.ui.main.utils.MainThemeColorProvider
 import java.util.Date
+import kotlin.math.PI
 import kotlin.math.max
 import kotlin.math.roundToInt
 
@@ -124,7 +125,9 @@ fun EphemerisChart(
                                 ),
                                 context.isRtl
                             ),
-                            pointConnector = LineCartesianLayer.PointConnector.cubic(curvature = 0.3f)
+                            pointConnector = LineCartesianLayer.PointConnector.cubic(
+                                curvature = ((PI - 2.0) / PI).toFloat()
+                            )
                         )
                     }
                 ),

--- a/app/src/main/java/org/breezyweather/ui/details/DetailsScreen.kt
+++ b/app/src/main/java/org/breezyweather/ui/details/DetailsScreen.kt
@@ -70,6 +70,7 @@ import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.semantics.traversalIndex
 import androidx.lifecycle.viewmodel.compose.viewModel
 import breezyweather.domain.location.model.Location
+import breezyweather.domain.weather.model.Astro
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -357,13 +358,18 @@ fun DailyPagerContent(
     val daily = remember(selected) {
         location.weather!!.dailyForecast[selected]
     }
-    val yesterday = remember(selected) {
-        if (selected > 0) {
-            location.weather!!.dailyForecast[selected - 1]
-        } else {
-            null
+    val sunTimes = mutableListOf<Astro>()
+    val moonTimes = mutableListOf<Astro>()
+
+    location.weather!!.dailyForecast.forEach {
+        if (it.sun != null) {
+            sunTimes.add(it.sun!!)
+        }
+        if (it.moon != null) {
+            moonTimes.add(it.moon!!)
         }
     }
+
     val hourlyList = remember(selected) {
         val startingDate = daily.date.toTimezoneSpecificHour(location.javaTimeZone, 0)
         val endingDate = daily.date.toCalendarWithTimeZone(location.javaTimeZone).apply {
@@ -408,7 +414,7 @@ fun DailyPagerContent(
             DetailScreen.TAG_PRESSURE -> DetailsPressure(location, hourlyList, daily.date)
             DetailScreen.TAG_CLOUD_COVER -> DetailsCloudCover(location, hourlyList, daily)
             DetailScreen.TAG_VISIBILITY -> DetailsVisibility(location, hourlyList, daily.date)
-            DetailScreen.TAG_SUN_MOON -> DetailsSunMoon(location, daily, yesterday)
+            DetailScreen.TAG_SUN_MOON -> DetailsSunMoon(location, daily, sunTimes, moonTimes)
         }
     }
 }


### PR DESCRIPTION
This patch fixes Issue #1925 over the erratic appearance of the sun/moon charts in the Daily Summary screens, introduced in 6.0.0.

- The sun and moon will now stay well within +90° and -90°.
- The peaks and troughs are evenly spaced.
- The altitudes match up from just before midnight one day and just after midnight the next day.

This patch assumes the sun/moon's altitude always alternates in a sinusoidal pattern. However, this is not always the case for tropical and subtropical locations. On or near Lahaina Noon days, where the sun culminates at zenith, the actual solar altitude moves linearly from 0° at sunrise till 90° noon, then turns a sharp angle and moves linearly from 90° at noon till 0° at sunset.

This patch does not model that true behavior, as it will require much more computation than is practical for a weather app.

This patch also does not deal well with midnight sun and polar nights, or the lunar equivalent of those phenomena. Expect odd behavior for polar locations.