### PR TITLE
Fix #1977 - NCEI

### DIFF
--- a/app/src/main/java/org/breezyweather/common/source/LocationPreset.kt
+++ b/app/src/main/java/org/breezyweather/common/source/LocationPreset.kt
@@ -78,7 +78,7 @@ enum class LocationPreset(
         pollen = "openmeteo",
         minutely = "openmeteo",
         alert = "nws",
-        normals = "accu"
+        normals = "ncei"
     ),
 
     // Europe

--- a/app/src/src_nonfreenet/org/breezyweather/sources/SourceManager.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/SourceManager.kt
@@ -96,6 +96,7 @@ import org.breezyweather.sources.mf.MfService
 import org.breezyweather.sources.mgm.MgmService
 import org.breezyweather.sources.namem.NamemService
 import org.breezyweather.sources.naturalearth.NaturalEarthService
+import org.breezyweather.sources.ncei.NceiService
 import org.breezyweather.sources.nominatim.NominatimService
 import org.breezyweather.sources.nws.NwsService
 import org.breezyweather.sources.openmeteo.OpenMeteoService
@@ -167,6 +168,7 @@ class SourceManager @Inject constructor(
     msdZwService: MsdZwService,
     namemService: NamemService,
     naturalEarthService: NaturalEarthService,
+    nceiService: NceiService,
     nominatimService: NominatimService,
     nwsService: NwsService,
     openMeteoService: OpenMeteoService,
@@ -209,6 +211,7 @@ class SourceManager @Inject constructor(
         accuService,
         hereService,
         metNoService,
+        nceiService,
         openWeatherService,
         pirateWeatherService,
         wmoSevereWeatherService

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ncei/NceiApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ncei/NceiApi.kt
@@ -1,0 +1,50 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ncei
+
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.sources.ncei.json.NceiDataResult
+import org.breezyweather.sources.ncei.json.NceiStationsResult
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface NceiApi {
+    @GET("access/services/search/v1/data")
+    fun getStations(
+        @Query("dataTypes") dataTypes: String = "TMAX,TMIN",
+        @Query("bbox") bbox: String,
+        @Query("startDate") startDate: String,
+        @Query("endDate") endDate: String,
+        @Query("dataset") dataset: String = "global-summary-of-the-month",
+        @Query("limit") limit: Int = 10,
+        @Query("offset") offset: Int = 0,
+    ): Observable<NceiStationsResult>
+
+    @GET("access/services/data/v1")
+    fun getData(
+        @Query("dataset") dataset: String = "global-summary-of-the-month",
+        @Query("dataTypes") dataTypes: String = "TMAX,TMIN",
+        @Query("stations") stations: String,
+        @Query("startDate") startDate: String,
+        @Query("endDate") endDate: String,
+        @Query("includeAttributes") includeAttributes: Boolean = true,
+        @Query("includeStationName") includeStationName: Boolean = true,
+        @Query("includeStationLocation") includeStationLocation: Boolean = true,
+        @Query("units") units: String = "metric",
+        @Query("format") format: String = "json",
+    ): Observable<List<NceiDataResult>>
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ncei/NceiResultConverter.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ncei/NceiResultConverter.kt
@@ -1,0 +1,95 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ncei
+
+import breezyweather.domain.weather.model.Normals
+import org.breezyweather.sources.ncei.json.NceiDataResult
+import kotlin.math.PI
+import kotlin.math.exp
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+internal fun getNormals(
+    month: Int,
+    normalsList: List<NceiDataResult>? = null,
+    stationMap: Map<String, Double>,
+): Normals {
+    var tMaxWeightedSum = 0.0
+    var tMaxWeightTotal = 0.0
+    var tMinWeightedSum = 0.0
+    var tMinWeightTotal = 0.0
+    val monthEnding: String = if (month >= 1 && month <= 9) {
+        "-0$month"
+    } else {
+        "-$month"
+    }
+
+    // Assign a weight to each station as a function of its distance from the weather location.
+    // We calculate weights here so that we won't have to force reload location parameters
+    // even if the weight function changes in the future.
+    val stationWeights = stationMap.mapValues {
+        getWeight(it.value)
+    }
+
+    // Add each relevant monthly record to the weighted sum of tMax and tMin,
+    // using the weight of the reporting station,
+    // so that we can calculate the weighted average later.
+    normalsList?.forEach {
+        if (it.date.endsWith(monthEnding)) {
+            if (it.station in stationWeights.keys) {
+                if (it.tMax != null) {
+                    tMaxWeightedSum += it.tMax.toDouble().times(stationWeights[it.station]!!)
+                    tMaxWeightTotal += stationWeights[it.station]!!
+                }
+                if (it.tMin != null) {
+                    tMinWeightedSum += it.tMin.toDouble().times(stationWeights[it.station]!!)
+                    tMinWeightTotal += stationWeights[it.station]!!
+                }
+            }
+        }
+    }
+    return Normals(
+        month = month,
+        daytimeTemperature = if (tMaxWeightTotal > 0) {
+            tMaxWeightedSum / tMaxWeightTotal
+        } else {
+            null
+        },
+        nighttimeTemperature = if (tMinWeightTotal > 0) {
+            tMinWeightedSum / tMinWeightTotal
+        } else {
+            null
+        }
+    )
+}
+
+// Models the weight for each nearby station after the normal distribution.
+// Let μ = 0
+//     σ = 1 representing an arbitrary distance of 20km
+//     x = distance between station and location in multiples of 20km
+// Illustrative weights at various distances:
+//  - Station at location: 0.399 (100% weight)
+//  - Station 20km away:   0.242 (60% weight)
+//  - Station 40km away:   0.054 (14% weight)
+//  - Station 60km away:   0.004 (1% weight)
+// Source: https://en.wikipedia.org/wiki/Normal_distribution
+private fun getWeight(distance: Double): Double {
+    val sigmaDistance = NceiService.DISTANCE_LIMIT / 3.0
+    val x = distance / sigmaDistance
+    val weight = 1.0 / sqrt(2.0 * PI) * exp(-x.pow(2.0) / 2.0)
+    return weight
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ncei/NceiService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ncei/NceiService.kt
@@ -1,0 +1,178 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ncei
+
+import android.content.Context
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.source.SourceContinent
+import breezyweather.domain.source.SourceFeature
+import breezyweather.domain.weather.wrappers.WeatherWrapper
+import com.google.maps.android.SphericalUtil
+import com.google.maps.android.model.LatLng
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.reactivex.rxjava3.core.Observable
+import kotlinx.serialization.json.Json
+import org.breezyweather.common.extensions.toCalendarWithTimeZone
+import org.breezyweather.common.source.HttpSource
+import org.breezyweather.common.source.LocationParametersSource
+import org.breezyweather.common.source.WeatherSource
+import retrofit2.Retrofit
+import java.util.Calendar
+import java.util.Date
+import javax.inject.Inject
+import javax.inject.Named
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.floor
+import kotlin.math.max
+import kotlin.math.min
+
+class NceiService @Inject constructor(
+    @ApplicationContext context: Context,
+    @Named("JsonClient") client: Retrofit.Builder,
+) : HttpSource(), WeatherSource, LocationParametersSource {
+
+    override val id = "ncei"
+    override val name = "NCEI"
+    override val continent = SourceContinent.WORLDWIDE
+    override val privacyPolicyUrl = "https://www.ncei.noaa.gov/privacy"
+
+    private val mApi by lazy {
+        client
+            .baseUrl(NCEI_BASE_URL)
+            .build()
+            .create(NceiApi::class.java)
+    }
+
+    private val weatherAttribution = "National Centers for Environmental Information"
+    override val supportedFeatures = mapOf(
+        SourceFeature.NORMALS to weatherAttribution
+    )
+    override val attributionLinks = mapOf(
+        weatherAttribution to "https://www.ncei.noaa.gov/"
+    )
+
+    // NCEI is temporarily disabled for Current Location
+    // until better caching is implemented (#1996)
+    override fun isFeatureSupportedForLocation(
+        location: Location,
+        feature: SourceFeature,
+    ): Boolean {
+        return !location.isCurrentPosition
+    }
+
+    override val testingLocations: List<Location> = emptyList()
+
+    override fun requestWeather(
+        context: Context,
+        location: Location,
+        requestedFeatures: List<SourceFeature>,
+    ): Observable<WeatherWrapper> {
+        val month = Date().toCalendarWithTimeZone(location.javaTimeZone)[Calendar.MONTH] + 1
+        val finalYear = floor(Date().toCalendarWithTimeZone(location.javaTimeZone)[Calendar.YEAR] / 10.0) * 10.0
+        val initialYear = finalYear - 29
+
+        val failedFeatures = mutableMapOf<SourceFeature, Throwable>()
+
+        val stationMap: Map<String, Double> = Json.decodeFromString<Map<String, Double>>(
+            location.parameters.getOrElse(id) {
+                emptyMap()
+            }.getOrElse("stations") { "" }
+        )
+        val stations = stationMap.keys.joinToString(",")
+        val normals = if (stations != "") {
+            mApi.getData(
+                stations = stations,
+                startDate = "${initialYear.toInt()}-01-01",
+                endDate = "${finalYear.toInt()}-12-31"
+            ).onErrorResumeNext {
+                failedFeatures[SourceFeature.NORMALS] = it
+                Observable.just(emptyList())
+            }
+        } else {
+            Observable.just(emptyList())
+        }
+
+        return normals.map {
+            WeatherWrapper(
+                normals = getNormals(month, it, stationMap),
+                failedFeatures = failedFeatures
+            )
+        }
+    }
+
+    override fun needsLocationParametersRefresh(
+        location: Location,
+        coordinatesChanged: Boolean,
+        features: List<SourceFeature>,
+    ): Boolean {
+        if (coordinatesChanged) return true
+        val stations = location.parameters.getOrElse(id) { null }?.getOrElse("stations") { null }
+        return stations.isNullOrEmpty()
+    }
+
+    override fun requestLocationParameters(context: Context, location: Location): Observable<Map<String, String>> {
+        // set a bbox of 120km x 120km (60km to each cardinal direction)
+        // TODO: Handle wraparounds for locations near the IDL (180° longitude) more gracefully
+        val north = min(location.latitude + DISTANCE_LIMIT / (2 * PI * EARTH_POLAR_RADIUS) * 360, 90.0)
+        val south = max(location.latitude - DISTANCE_LIMIT / (2 * PI * EARTH_POLAR_RADIUS) * 360, -90.0)
+        val multiple = cos(location.latitude / 180 * PI)
+        val east = if (multiple != 0.0) {
+            min(location.longitude + DISTANCE_LIMIT / (2 * PI * EARTH_EQUATORIAL_RADIUS * multiple) * 360, 180.0)
+        } else {
+            180.0
+        }
+        val west = if (multiple != 0.0) {
+            max(location.longitude - DISTANCE_LIMIT / (2 * PI * EARTH_EQUATORIAL_RADIUS * multiple) * 360, -180.0)
+        } else {
+            -180.0
+        }
+        val bbox = "$north,$west,$south,$east"
+
+        val finalYear = floor(Date().toCalendarWithTimeZone(location.javaTimeZone)[Calendar.YEAR] / 10.0) * 10.0
+        val initialYear = finalYear - 29
+
+        return mApi.getStations(
+            bbox = bbox,
+            startDate = "${initialYear.toInt()}-01-01T00:00:00",
+            endDate = "${finalYear.toInt()}-12-31T23:59:59"
+        ).map {
+            // The nearest station from a location may not have the most complete historical weather record.
+            // Therefore we will obtain and store all the stations within the 120km x 120km area,
+            // and apply weighting to records based on their respective station distance.
+            val stationMap = mutableMapOf<String, Double>()
+            it.results?.forEach { results ->
+                results.stations.getOrNull(0)?.let { station ->
+                    stationMap[station.id] = SphericalUtil.computeDistanceBetween(
+                        LatLng(location.latitude, location.longitude),
+                        LatLng(results.centroid.point[1], results.centroid.point[0])
+                    )
+                }
+            }
+            buildMap {
+                put("stations", Json.encodeToString(stationMap))
+            }
+        }
+    }
+
+    companion object {
+        private const val NCEI_BASE_URL = "https://www.ncei.noaa.gov/"
+        private const val EARTH_POLAR_RADIUS = 6356752
+        private const val EARTH_EQUATORIAL_RADIUS = 6378137
+        const val DISTANCE_LIMIT = 60000
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ncei/json/NceiDataResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ncei/json/NceiDataResult.kt
@@ -1,0 +1,27 @@
+package org.breezyweather.sources.ncei.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+@Serializable
+data class NceiDataResult(
+    @SerialName("DATE") val date: String,
+    @SerialName("STATION") val station: String,
+    @SerialName("TMAX") val tMax: String?,
+    @SerialName("TMIN") val tMin: String?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ncei/json/NceiStationsCentroid.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ncei/json/NceiStationsCentroid.kt
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ncei.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NceiStationsCentroid(
+    val point: List<Double>,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ncei/json/NceiStationsResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ncei/json/NceiStationsResult.kt
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ncei.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NceiStationsResult(
+    val results: List<NceiStationsResultResults>? = null,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ncei/json/NceiStationsResultResults.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ncei/json/NceiStationsResultResults.kt
@@ -1,0 +1,25 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ncei.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NceiStationsResultResults(
+    val stations: List<NceiStationsResultResultsStation>,
+    val centroid: NceiStationsCentroid,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ncei/json/NceiStationsResultResultsStation.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ncei/json/NceiStationsResultResultsStation.kt
@@ -1,0 +1,25 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ncei.json
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NceiStationsResultResultsStation(
+    val id: String,
+    val name: String,
+)


### PR DESCRIPTION
This fix incorporates the [Global Summary of the Month](https://www.ncei.noaa.gov/access/metadata/landing-page/bin/iso?id=gov.noaa.ncdc%3AC00946) database from the [National Centers for Environmental Information](https://www.ncei.noaa.gov/). The database provides temperature normals from meteorological stations worldwide.

This fix sets NCEI as the new preset for normals for locations in the U.S. (Other countries the preset is kept as either national source or Accuweather.) It can be used for locations worldwide.