### PR TITLE
Fix #2040 - National Center for Disaster Reduction

### DIFF
--- a/app/src/main/java/org/breezyweather/sources/common/xml/CapAlert.kt
+++ b/app/src/main/java/org/breezyweather/sources/common/xml/CapAlert.kt
@@ -22,7 +22,6 @@ import com.google.maps.android.model.LatLng
 import kotlinx.serialization.Serializable
 import nl.adaptivity.xmlutil.serialization.XmlSerialName
 import nl.adaptivity.xmlutil.serialization.XmlValue
-import org.breezyweather.common.extensions.code
 import org.breezyweather.common.extensions.currentLocale
 import org.breezyweather.common.serializer.DateSerializer
 import java.util.Date
@@ -67,7 +66,8 @@ data class CapAlert(
         val headline: Headline? = null,
         val description: Description? = null,
         val instruction: Instruction? = null,
-        val area: List<Area>? = null,
+        val parameters: List<Parameter>? = null,
+        val areas: List<Area>? = null,
     ) {
         @Serializable
         @XmlSerialName("language", "", "cap")
@@ -142,11 +142,30 @@ data class CapAlert(
         )
 
         @Serializable
+        @XmlSerialName("parameter", "urn:oasis:names:tc:emergency:cap:1.2", "cap")
+        data class Parameter(
+            val valueName: ValueName? = null,
+            val value: Value? = null,
+        ) {
+            @Serializable
+            @XmlSerialName("valueName", "", "cap")
+            data class ValueName(
+                @XmlValue(true) val value: String? = null,
+            )
+
+            @Serializable
+            @XmlSerialName("value", "", "cap")
+            data class Value(
+                @XmlValue(true) val value: String? = null,
+            )
+        }
+
+        @Serializable
         @XmlSerialName("area", "urn:oasis:names:tc:emergency:cap:1.2", "cap")
         data class Area(
             val areaDesc: AreaDesc? = null,
-            val geocode: List<Geocode>? = null,
-            val polygon: List<Polygon>? = null,
+            val geocodes: List<Geocode>? = null,
+            val polygons: List<Polygon>? = null,
         ) {
             @Serializable
             @XmlSerialName("areaDesc", "", "cap")
@@ -184,8 +203,8 @@ data class CapAlert(
             valueName: String,
             value: String,
         ): Boolean {
-            this.area?.forEach { area ->
-                area.geocode?.forEach {
+            this.areas?.forEach { area ->
+                area.geocodes?.forEach {
                     if (it.valueName?.value == valueName && it.value?.value == value) {
                         return true
                     }
@@ -197,8 +216,8 @@ data class CapAlert(
         fun containsPoint(
             point: LatLng,
         ): Boolean {
-            this.area?.forEach { area ->
-                area.polygon?.forEach {
+            this.areas?.forEach { area ->
+                area.polygons?.forEach {
                     val polygon = mutableListOf<LatLng>()
                     it.value?.split(" ")?.forEach { vertex ->
                         val coords = vertex.split(",")

--- a/app/src/src_nonfreenet/org/breezyweather/sources/SourceManager.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/SourceManager.kt
@@ -92,7 +92,9 @@ import org.breezyweather.sources.mf.MfService
 import org.breezyweather.sources.mgm.MgmService
 import org.breezyweather.sources.namem.NamemService
 import org.breezyweather.sources.naturalearth.NaturalEarthService
+import org.breezyweather.sources.ncdr.NcdrService
 import org.breezyweather.sources.ncei.NceiService
+import org.breezyweather.sources.nlsc.NlscService
 import org.breezyweather.sources.nominatim.NominatimService
 import org.breezyweather.sources.nws.NwsService
 import org.breezyweather.sources.openmeteo.OpenMeteoService
@@ -165,7 +167,9 @@ class SourceManager @Inject constructor(
     msdZwService: MsdZwService,
     namemService: NamemService,
     naturalEarthService: NaturalEarthService,
+    ncdrService: NcdrService,
     nceiService: NceiService,
+    nlscService: NlscService,
     nominatimService: NominatimService,
     nwsService: NwsService,
     openMeteoService: OpenMeteoService,
@@ -262,6 +266,8 @@ class SourceManager @Inject constructor(
         mgmService,
         msdZwService,
         namemService,
+        ncdrService,
+        nlscService,
         nwsService,
         pagasaService,
         recosanteService,

--- a/app/src/src_nonfreenet/org/breezyweather/sources/cwa/CwaService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/cwa/CwaService.kt
@@ -91,18 +91,41 @@ class CwaService @Inject constructor(
             .create(CwaApi::class.java)
     }
 
-    private val weatherAttribution = "中央氣象署"
-    override val reverseGeocodingAttribution = weatherAttribution
+    private val weatherAttribution by lazy {
+        with(context.currentLocale.code) {
+            when {
+                startsWith("zh") -> "中央氣象署"
+                else -> "Central Weather Administration"
+            }
+        }
+    }
+    private val airQualityAttribution by lazy {
+        with(context.currentLocale.code) {
+            when {
+                startsWith("zh") -> "環境部"
+                else -> "Ministry of Environment"
+            }
+        }
+    }
+    override val reverseGeocodingAttribution by lazy {
+        with(context.currentLocale.code) {
+            when {
+                startsWith("zh") -> "內政部國土測繪中心"
+                else -> "National Land Survey and Mapping Center"
+            }
+        }
+    }
     override val supportedFeatures = mapOf(
         SourceFeature.FORECAST to weatherAttribution,
         SourceFeature.CURRENT to weatherAttribution,
-        SourceFeature.AIR_QUALITY to "環境部",
+        SourceFeature.AIR_QUALITY to airQualityAttribution,
         SourceFeature.ALERT to weatherAttribution,
         SourceFeature.NORMALS to weatherAttribution
     )
     override val attributionLinks = mapOf(
         weatherAttribution to "https://www.cwa.gov.tw/",
-        "環境部" to "https://airtw.moenv.gov.tw/"
+        airQualityAttribution to "https://airtw.moenv.gov.tw/",
+        reverseGeocodingAttribution to "https://www.nlsc.gov.tw/"
     )
 
     override fun isFeatureSupportedForLocation(
@@ -487,10 +510,6 @@ class CwaService @Inject constructor(
 
     companion object {
         private const val CWA_BASE_URL = "https://opendata.cwa.gov.tw/"
-        private const val SUN_ENDPOINT = "A-B0062-001"
-        private const val SUN_PARAMETERS = "SunRiseTime,SunSetTime"
-        private const val MOON_ENDPOINT = "A-B0063-001"
-        private const val MOON_PARAMETERS = "MoonRiseTime,MoonSetTime"
         private val LINE_FEED_SPACES = Regex("""\n\s*""")
 
         private val TAIWAN_BBOX = LatLngBounds.parse(119.99690416, 21.756143532, 122.10915909, 25.633378776)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ncdr/NcdrApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ncdr/NcdrApi.kt
@@ -1,0 +1,33 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ncdr
+
+import org.breezyweather.sources.common.xml.CapAlert
+import org.breezyweather.sources.ncdr.xml.NcdrAlertsResult
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Url
+
+interface NcdrApi {
+    @GET("RssAtomFeeds.ashx")
+    fun getAlerts(): Call<NcdrAlertsResult>
+
+    @GET
+    fun getAlert(
+        @Url url: String,
+    ): Call<CapAlert>
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ncdr/NcdrService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ncdr/NcdrService.kt
@@ -1,0 +1,268 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ncdr
+
+import android.content.Context
+import android.graphics.Color
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.source.SourceContinent
+import breezyweather.domain.source.SourceFeature
+import breezyweather.domain.weather.model.Alert
+import breezyweather.domain.weather.model.AlertSeverity
+import breezyweather.domain.weather.wrappers.WeatherWrapper
+import com.google.maps.android.model.LatLng
+import com.google.maps.android.model.LatLngBounds
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.common.exceptions.InvalidLocationException
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
+import org.breezyweather.common.source.HttpSource
+import org.breezyweather.common.source.LocationParametersSource
+import org.breezyweather.common.source.WeatherSource
+import org.breezyweather.common.source.WeatherSource.Companion.PRIORITY_HIGHEST
+import org.breezyweather.common.source.WeatherSource.Companion.PRIORITY_NONE
+import org.breezyweather.sources.ncdr.xml.NcdrAlertsResult
+import org.breezyweather.sources.nlsc.NlscApi
+import retrofit2.Retrofit
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Named
+import kotlin.lazy
+
+class NcdrService @Inject constructor(
+    @ApplicationContext context: Context,
+    @Named("XmlClient") xmlClient: Retrofit.Builder,
+) : HttpSource(), WeatherSource, LocationParametersSource {
+    override val id = "ncdr"
+    override val name by lazy {
+        with(context.currentLocale.code) {
+            when {
+                startsWith("zh") -> "國家災害防救科技中心"
+                else -> "NCDR"
+            }
+        } +
+            " (${Locale(context.currentLocale.code, "TW").displayCountry})"
+    }
+    override val continent = SourceContinent.ASIA
+    override val privacyPolicyUrl = "https://ncdr.nat.gov.tw/Page?itemid=40&mid=7"
+
+    private val mNcdrApi by lazy {
+        xmlClient
+            .baseUrl(NCDR_BASE_URL)
+            .build()
+            .create(NcdrApi::class.java)
+    }
+
+    val mNlscApi by lazy {
+        xmlClient
+            .baseUrl(NLSC_BASE_URL)
+            .build()
+            .create(NlscApi::class.java)
+    }
+
+    private val weatherAttribution by lazy {
+        with(context.currentLocale.code) {
+            when {
+                startsWith("zh") -> "國家災害防救科技中心"
+                else -> "National Science and Technology Center for Disaster Reduction"
+            }
+        }
+    }
+    override val supportedFeatures = mapOf(
+        SourceFeature.ALERT to weatherAttribution
+    )
+    override val attributionLinks = mapOf(
+        weatherAttribution to "https://ncdr.nat.gov.tw/"
+    )
+
+    override fun isFeatureSupportedForLocation(location: Location, feature: SourceFeature): Boolean {
+        val latLng = LatLng(location.latitude, location.longitude)
+        return location.countryCode.equals("TW", ignoreCase = true) ||
+            TAIWAN_BBOX.contains(latLng) ||
+            PENGHU_BBOX.contains(latLng) ||
+            KINMEN_BBOX.contains(latLng) ||
+            WUQIU_BBOX.contains(latLng) ||
+            MATSU_BBOX.contains(latLng)
+    }
+
+    override fun getFeaturePriorityForLocation(
+        location: Location,
+        feature: SourceFeature,
+    ): Int {
+        return when {
+            isFeatureSupportedForLocation(location, feature) -> PRIORITY_HIGHEST
+            else -> PRIORITY_NONE
+        }
+    }
+
+    override fun requestWeather(
+        context: Context,
+        location: Location,
+        requestedFeatures: List<SourceFeature>,
+    ): Observable<WeatherWrapper> {
+        val legacyTownshipCode = location.parameters.getOrElse(id) { null }?.getOrElse("legacyTownshipCode") { null }
+        if (legacyTownshipCode.isNullOrEmpty()) {
+            return Observable.error(InvalidLocationException())
+        }
+
+        val alerts = mNcdrApi.getAlerts().execute().body()
+        val cwaAlerts = alerts?.entries?.filter {
+            it.author.name.value == "中央氣象署"
+        }
+
+        return Observable.just(
+            WeatherWrapper(
+                alertList = convert(location, legacyTownshipCode, cwaAlerts)
+            )
+        )
+    }
+
+    internal fun convert(
+        location: Location,
+        legacyTownshipCode: String,
+        cwaAlerts: List<NcdrAlertsResult.Entry>?,
+    ): List<Alert> {
+        val alertList = mutableListOf<Alert>()
+        cwaAlerts?.forEach { cwaAlert ->
+            val alert = mNcdrApi.getAlert(cwaAlert.link.href).execute().body()
+            alert?.info?.forEach {
+                if (it.containsGeocode("Taiwan_Geocode_103", legacyTownshipCode) ||
+                    it.containsPoint(LatLng(location.latitude, location.longitude))
+                ) {
+                    val severity = when (it.severity?.value) {
+                        "Extreme" -> AlertSeverity.EXTREME
+                        "Severe" -> AlertSeverity.SEVERE
+                        "Moderate" -> AlertSeverity.MODERATE
+                        "Minor" -> AlertSeverity.MINOR
+                        else -> AlertSeverity.UNKNOWN
+                    }
+
+                    // Use the color provided in the CAP Alert where available.
+                    val websiteColor = it.parameters?.firstOrNull { parameter ->
+                        parameter.valueName?.value.equals("website_color")
+                    }?.value?.value
+                    val color = if (!websiteColor.isNullOrEmpty()) {
+                        val components = websiteColor.split(",")
+                        if (components.size == 3) {
+                            Color.rgb(components[0].toInt(), components[1].toInt(), components[2].toInt())
+                        } else {
+                            Alert.colorFromSeverity(severity)
+                        }
+                    } else {
+                        Alert.colorFromSeverity(severity)
+                    }
+
+                    var headline = it.headline?.value?.trim()
+
+                    // For Extremely Heavy Rain Advisories, replace the headline with severity level.
+                    if (headline == "豪雨特報") {
+                        val severityLevel = it.parameters?.firstOrNull { parameter ->
+                            parameter.valueName?.value == "severity_level"
+                        }?.value?.value
+                        if (!severityLevel.isNullOrEmpty()) {
+                            headline = severityLevel + "特報"
+                        }
+                    }
+
+                    alertList.add(
+                        Alert(
+                            alertId = alert.identifier?.value ?: cwaAlert.link.href,
+                            startDate = it.onset?.value ?: it.effective?.value ?: alert.sent?.value,
+                            endDate = it.expires?.value,
+                            headline = headline,
+                            description = it.description?.value?.trim(),
+                            instruction = it.instruction?.value?.trim(),
+                            source = it.senderName?.value?.trim(),
+                            severity = severity,
+                            color = color
+                        )
+                    )
+                }
+            }
+        }
+        return alertList
+    }
+
+    override fun needsLocationParametersRefresh(
+        location: Location,
+        coordinatesChanged: Boolean,
+        features: List<SourceFeature>,
+    ): Boolean {
+        if (coordinatesChanged) return true
+
+        val legacyTownshipCode = location.parameters.getOrElse(id) { null }?.getOrElse("legacyTownshipCode") { null }
+
+        return legacyTownshipCode.isNullOrEmpty()
+    }
+
+    override fun requestLocationParameters(context: Context, location: Location): Observable<Map<String, String>> {
+        val locationCodes = mNlscApi.getLocationCodes(
+            lon = location.longitude,
+            lat = location.latitude
+        ).execute().body()
+
+        if (locationCodes?.countyCode?.value.isNullOrEmpty() ||
+            locationCodes.townshipCode?.value.isNullOrEmpty() ||
+            locationCodes.villageCode?.value.isNullOrEmpty()
+        ) {
+            throw InvalidLocationException()
+        }
+
+        return Observable.just(
+            mapOf(
+                // Currently not used
+                // "countyCode" to locationCodes.countyCode.value,
+                // "townshipCode" to locationCodes.townshipCode.value,
+                // "villageCode" to locationCodes.villageCode.value,
+                "legacyTownshipCode" to getLegacyTownshipCode(locationCodes.townshipCode.value)
+            )
+        )
+    }
+
+    // This function converts the current standard 8-digit geocode
+    // to the 7-digit legacy geocodes still used in CWA's CAP Alerts
+    private fun getLegacyTownshipCode(
+        code: String,
+    ): String {
+        var output = code
+        val municipalityCodePattern = Regex("""(6\d)000(\d{2})0""")
+        val townshipCodePattern = Regex("""(1\d{6})0""")
+        val outlyingCodePattern = Regex("""(09\d{5})0""")
+        if (municipalityCodePattern.matches(code)) {
+            output = code.replace(municipalityCodePattern, "$10$200")
+        } else if (townshipCodePattern.matches(code)) {
+            output = code.replace(townshipCodePattern, "$1")
+        } else if (outlyingCodePattern.matches(code)) {
+            output = code.replace(outlyingCodePattern, "$1")
+        }
+        return output
+    }
+
+    override val testingLocations: List<Location> = emptyList()
+
+    companion object {
+        private const val NCDR_BASE_URL = "https://alerts.ncdr.nat.gov.tw/"
+        private const val NLSC_BASE_URL = "https://api.nlsc.gov.tw/"
+
+        private val TAIWAN_BBOX = LatLngBounds.parse(119.99690416, 21.756143532, 122.10915909, 25.633378776)
+        private val PENGHU_BBOX = LatLngBounds.parse(119.314301816, 23.186561404, 119.726986388, 23.810692086)
+        private val KINMEN_BBOX = LatLngBounds.parse(118.137979837, 24.160255444, 118.505977425, 24.534228163)
+        private val WUQIU_BBOX = LatLngBounds.parse(119.443195363, 24.97760013, 119.479213453, 24.999614154)
+        private val MATSU_BBOX = LatLngBounds.parse(119.908905081, 25.940995457, 120.511750672, 26.385275262)
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ncdr/xml/NcdrAlertsResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ncdr/xml/NcdrAlertsResult.kt
@@ -1,0 +1,92 @@
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.ncdr.xml
+
+import kotlinx.serialization.Serializable
+import nl.adaptivity.xmlutil.serialization.XmlKeyName
+import nl.adaptivity.xmlutil.serialization.XmlSerialName
+import nl.adaptivity.xmlutil.serialization.XmlValue
+import org.breezyweather.common.serializer.DateSerializer
+import java.util.Date
+
+@Serializable
+@XmlSerialName("feed", "http://www.w3.org/2005/Atom", "ncdr")
+data class NcdrAlertsResult(
+    val entries: List<Entry>? = null,
+) {
+    @Serializable
+    @XmlSerialName("entry", "http://www.w3.org/2005/Atom", "ncdr")
+    data class Entry(
+        val id: Id,
+        val title: Title? = null,
+        val updated: Updated,
+        val author: Author,
+        val link: Link,
+        val summary: Summary?,
+        val category: Category?,
+    ) {
+        @Serializable
+        @XmlSerialName("id", "", "ncdr")
+        data class Id(
+            @XmlValue(true) val value: String,
+        )
+
+        @Serializable
+        @XmlSerialName("title", "", "ncdr")
+        data class Title(
+            @XmlValue(true) val value: String,
+        )
+
+        @Serializable
+        @XmlSerialName("updated", "", "ncdr")
+        data class Updated(
+            @XmlValue(true) val value:
+            @Serializable(DateSerializer::class)
+            Date,
+        )
+
+        @Serializable
+        @XmlSerialName("author", "http://www.w3.org/2005/Atom", "ncdr")
+        data class Author(
+            val name: Name,
+        ) {
+            @Serializable
+            @XmlSerialName("name", "", "ncdr")
+            data class Name(
+                @XmlValue(true) val value: String,
+            )
+        }
+
+        @Serializable
+        @XmlSerialName("link", "", "ncdr")
+        data class Link(
+            @XmlKeyName("href", "", "ncdr") val href: String,
+        )
+
+        @Serializable
+        @XmlSerialName("summary", "", "ncdr")
+        data class Summary(
+            @XmlValue(true) val value: String,
+        )
+
+        @Serializable
+        @XmlSerialName("category", "", "ncdr")
+        data class Category(
+            @XmlKeyName("term", "", "ncdr") val term: String,
+        )
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/nlsc/NlscApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/nlsc/NlscApi.kt
@@ -1,0 +1,30 @@
+package org.breezyweather.sources.nlsc
+
+import org.breezyweather.sources.nlsc.xml.NlscLocationCodesResult
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+interface NlscApi {
+    @GET("other/TownVillagePointQuery1/{lon}/{lat}/{epsg}")
+    fun getLocationCodes(
+        @Path("lon") lon: Double,
+        @Path("lat") lat: Double,
+        @Path("epsg") epsg: Long = 4326,
+    ): Call<NlscLocationCodesResult>
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/nlsc/NlscService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/nlsc/NlscService.kt
@@ -1,0 +1,109 @@
+package org.breezyweather.sources.nlsc
+
+import android.content.Context
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.source.SourceContinent
+import com.google.maps.android.model.LatLng
+import com.google.maps.android.model.LatLngBounds
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.common.exceptions.InvalidLocationException
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
+import org.breezyweather.common.source.HttpSource
+import org.breezyweather.common.source.ReverseGeocodingSource
+import retrofit2.Retrofit
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Named
+
+class NlscService @Inject constructor(
+    @ApplicationContext context: Context,
+    @Named("XmlClient") xmlClient: Retrofit.Builder,
+) : HttpSource(), ReverseGeocodingSource {
+    override val id = "nlsc"
+    override val name by lazy {
+        with(context.currentLocale.code) {
+            when {
+                startsWith("zh") -> "內政部國土測繪中心"
+                else -> "NLSC"
+            }
+        } +
+            " (${Locale(context.currentLocale.code, "TW").displayCountry})"
+    }
+    override val continent = SourceContinent.ASIA
+    override val privacyPolicyUrl = "https://www.nlsc.gov.tw/cp.aspx?n=1633"
+
+    val mNlscApi by lazy {
+        xmlClient
+            .baseUrl(NLSC_BASE_URL)
+            .build()
+            .create(NlscApi::class.java)
+    }
+
+    override val reverseGeocodingAttribution by lazy {
+        with(context.currentLocale.code) {
+            when {
+                startsWith("zh") -> "內政部國土測繪中心"
+                else -> "National Land Survey and Mapping Center"
+            }
+        }
+    }
+    override val attributionLinks = mapOf(
+        reverseGeocodingAttribution to "https://www.nlsc.gov.tw/"
+    )
+
+    override fun isReverseGeocodingSupportedForLocation(location: Location): Boolean {
+        val latLng = LatLng(location.latitude, location.longitude)
+        return location.countryCode.equals("TW", ignoreCase = true) ||
+            TAIWAN_BBOX.contains(latLng) ||
+            PENGHU_BBOX.contains(latLng) ||
+            KINMEN_BBOX.contains(latLng) ||
+            WUQIU_BBOX.contains(latLng) ||
+            MATSU_BBOX.contains(latLng)
+    }
+
+    override fun requestReverseGeocodingLocation(context: Context, location: Location): Observable<List<Location>> {
+        val locationCodes = mNlscApi.getLocationCodes(
+            lon = location.longitude,
+            lat = location.latitude
+        ).execute().body()
+
+        if (locationCodes?.countyCode?.value.isNullOrEmpty() ||
+            locationCodes.townshipCode?.value.isNullOrEmpty() ||
+            locationCodes.villageCode?.value.isNullOrEmpty()
+        ) {
+            throw InvalidLocationException()
+        }
+
+        return Observable.just(
+            listOf(
+                location.copy(
+                    latitude = location.latitude,
+                    longitude = location.longitude,
+                    timeZone = "Asia/Taipei",
+                    country = Locale(context.currentLocale.code, "TW").displayCountry,
+                    countryCode = "TW",
+                    admin1 = locationCodes.countyName?.value,
+                    admin1Code = locationCodes.countyCode.value,
+                    admin2 = locationCodes.townshipName?.value,
+                    admin2Code = locationCodes.townshipCode.value,
+                    admin3 = locationCodes.villageName?.value,
+                    admin3Code = locationCodes.villageCode.value,
+                    city = locationCodes.townshipName?.value ?: "",
+                    district = locationCodes.villageName?.value
+                )
+            )
+        )
+    }
+
+    companion object {
+        private const val NLSC_BASE_URL = "https://api.nlsc.gov.tw/"
+
+        private val TAIWAN_BBOX = LatLngBounds.parse(119.99690416, 21.756143532, 122.10915909, 25.633378776)
+        private val PENGHU_BBOX = LatLngBounds.parse(119.314301816, 23.186561404, 119.726986388, 23.810692086)
+        private val KINMEN_BBOX = LatLngBounds.parse(118.137979837, 24.160255444, 118.505977425, 24.534228163)
+        private val WUQIU_BBOX = LatLngBounds.parse(119.443195363, 24.97760013, 119.479213453, 24.999614154)
+        private val MATSU_BBOX = LatLngBounds.parse(119.908905081, 25.940995457, 120.511750672, 26.385275262)
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/nlsc/xml/NlscLocationCodesResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/nlsc/xml/NlscLocationCodesResult.kt
@@ -1,0 +1,67 @@
+package org.breezyweather.sources.nlsc.xml
+
+import kotlinx.serialization.Serializable
+import nl.adaptivity.xmlutil.serialization.XmlSerialName
+import nl.adaptivity.xmlutil.serialization.XmlValue
+
+/**
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+@Serializable
+@XmlSerialName("townVillageItem", "", "nlsc")
+data class NlscLocationCodesResult(
+    val countyCode: CountyCode? = null,
+    val countyName: CountyName? = null,
+    val townshipCode: TownshipCode? = null,
+    val townshipName: TownshipName? = null,
+    val villageCode: VillageCode? = null,
+    val villageName: VillageName? = null,
+) {
+    @Serializable
+    @XmlSerialName("ctyCode", "", "nlsc")
+    data class CountyCode(
+        @XmlValue(true) val value: String,
+    )
+
+    @Serializable
+    @XmlSerialName("ctyName", "", "nlsc")
+    data class CountyName(
+        @XmlValue(true) val value: String,
+    )
+
+    @Serializable
+    @XmlSerialName("townCode", "", "nlsc")
+    data class TownshipCode(
+        @XmlValue(true) val value: String,
+    )
+
+    @Serializable
+    @XmlSerialName("townName", "", "nlsc")
+    data class TownshipName(
+        @XmlValue(true) val value: String,
+    )
+
+    @Serializable
+    @XmlSerialName("villageCode", "", "nlsc")
+    data class VillageCode(
+        @XmlValue(true) val value: String,
+    )
+
+    @Serializable
+    @XmlSerialName("villageName", "", "nlsc")
+    data class VillageName(
+        @XmlValue(true) val value: String,
+    )
+}


### PR DESCRIPTION
This patch implements [National Science and Technology Center for Disaster Reduction](https://www.ncdr.nat.gov.tw/) (NCDR) as an Alert source for Taiwan.

NCDR aggregates all alerts issued by the Central Weather Administration, and disseminates them in CAP Alert format, without requiring an API key. The alerts are available worldwide.

To incorporate all these alerts using CWA's Open Data service means a fragmented implementation of different formats: JSON, CAP-converted-into-JSON, CAP. Not only does this require multiple API calls (and using up daily quota for the API key), not every CWA alert type is accessible outside of Taiwan either due to server-side geoblocking. NCDR can therefore serve as a drop-in replacement for the Alert feature in the CWA source.

_Note:_ The requisite geocodes are obtained via a keyless API provided by the [National Land Surveying and Mapping Center](https://www.nlsc.gov.tw/) (NLSC). This has been attributed in the source code accordingly. NLSC also provides geocodes for the CWA API, which requires an API key.