### PR TITLE
Added more countries for recommendation priorities

### DIFF
--- a/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/MeteoAmService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/meteoam/MeteoAmService.kt
@@ -75,7 +75,7 @@ class MeteoAmService @Inject constructor(
         feature: SourceFeature,
     ): Int {
         return when {
-            location.countryCode.equals("IT", ignoreCase = true) -> PRIORITY_HIGHEST
+            arrayOf("IT", "SM", "VA").any { location.countryCode.equals(it, ignoreCase = true) } -> PRIORITY_HIGHEST
             else -> PRIORITY_NONE
         }
     }

--- a/app/src/src_nonfreenet/org/breezyweather/sources/metoffice/MetOfficeService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/metoffice/MetOfficeService.kt
@@ -73,7 +73,9 @@ class MetOfficeService @Inject constructor(
         feature: SourceFeature,
     ): Int {
         return when {
-            location.countryCode.equals("GB", ignoreCase = true) -> PRIORITY_HIGHEST
+            arrayOf("GB", "GG", "IM", "JE", "GI", "FK").any {
+                location.countryCode.equals(it, ignoreCase = true)
+            } -> PRIORITY_HIGHEST
             else -> PRIORITY_NONE
         }
     }

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ncei/NceiService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ncei/NceiService.kt
@@ -86,7 +86,9 @@ class NceiService @Inject constructor(
         feature: SourceFeature,
     ): Int {
         return when {
-            location.countryCode.equals("US", ignoreCase = true) -> PRIORITY_HIGHEST
+            arrayOf("US", "PR", "VI", "MP", "GU").any {
+                location.countryCode.equals(it, ignoreCase = true)
+            } -> PRIORITY_HIGHEST
             else -> PRIORITY_NONE
         }
     }


### PR DESCRIPTION
This patch adds more countries for source recommendation priorities:
| Source | Added Countries and Territories |
|---|---|
| MeteoAM | San Marino, Vatican City |
| Met Office | Guernsey, Jersey, Isle of Man, Gibraltar, Falkland Islands |
| NCEI | Puerto Rico, U.S. Virgin Islands, Guam, Mariana Islands |