### PR TITLE
Defined bBox for Pollen in Accu, consolidated other bBox usages

### DIFF
--- a/app/src/main/java/org/breezyweather/sources/openmeteo/OpenMeteoService.kt
+++ b/app/src/main/java/org/breezyweather/sources/openmeteo/OpenMeteoService.kt
@@ -121,7 +121,7 @@ class OpenMeteoService @Inject constructor(
         feature: SourceFeature,
     ): Boolean {
         return when (feature) {
-            SourceFeature.POLLEN -> OPEN_METEO_POLLEN_BBOX.contains(LatLng(location.latitude, location.longitude))
+            SourceFeature.POLLEN -> COPERNICUS_POLLEN_BBOX.contains(LatLng(location.latitude, location.longitude))
             else -> true
         }
     }
@@ -614,7 +614,7 @@ class OpenMeteoService @Inject constructor(
         // Coverage area of CAMS European air quality forecasts:
         // Europe (west boundary=25.0° W, east=45.0° E, south=30.0° N, north=72.0°)
         // Source: https://ads.atmosphere.copernicus.eu/datasets/cams-europe-air-quality-forecasts?tab=overview
-        private val OPEN_METEO_POLLEN_BBOX = LatLngBounds(
+        val COPERNICUS_POLLEN_BBOX = LatLngBounds(
             LatLng(30.0, -25.0),
             LatLng(72.0, 45.0)
         )

--- a/app/src/src_nonfreenet/org/breezyweather/sources/cwa/CwaService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/cwa/CwaService.kt
@@ -24,7 +24,6 @@ import breezyweather.domain.source.SourceFeature
 import breezyweather.domain.weather.wrappers.AirQualityWrapper
 import breezyweather.domain.weather.wrappers.WeatherWrapper
 import com.google.maps.android.model.LatLng
-import com.google.maps.android.model.LatLngBounds
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.rxjava3.core.Observable
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -52,6 +51,11 @@ import org.breezyweather.sources.cwa.json.CwaAssistantResult
 import org.breezyweather.sources.cwa.json.CwaCurrentResult
 import org.breezyweather.sources.cwa.json.CwaForecastResult
 import org.breezyweather.sources.cwa.json.CwaNormalsResult
+import org.breezyweather.sources.nlsc.NlscService.Companion.KINMEN_BBOX
+import org.breezyweather.sources.nlsc.NlscService.Companion.MATSU_BBOX
+import org.breezyweather.sources.nlsc.NlscService.Companion.PENGHU_BBOX
+import org.breezyweather.sources.nlsc.NlscService.Companion.TAIWAN_BBOX
+import org.breezyweather.sources.nlsc.NlscService.Companion.WUQIU_BBOX
 import retrofit2.Retrofit
 import java.util.Calendar
 import java.util.Date
@@ -508,11 +512,5 @@ class CwaService @Inject constructor(
     companion object {
         private const val CWA_BASE_URL = "https://opendata.cwa.gov.tw/"
         private val LINE_FEED_SPACES = Regex("""\n\s*""")
-
-        private val TAIWAN_BBOX = LatLngBounds.parse(119.99690416, 21.756143532, 122.10915909, 25.633378776)
-        private val PENGHU_BBOX = LatLngBounds.parse(119.314301816, 23.186561404, 119.726986388, 23.810692086)
-        private val KINMEN_BBOX = LatLngBounds.parse(118.137979837, 24.160255444, 118.505977425, 24.534228163)
-        private val WUQIU_BBOX = LatLngBounds.parse(119.443195363, 24.97760013, 119.479213453, 24.999614154)
-        private val MATSU_BBOX = LatLngBounds.parse(119.908905081, 25.940995457, 120.511750672, 26.385275262)
     }
 }

--- a/app/src/src_nonfreenet/org/breezyweather/sources/ncdr/NcdrService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ncdr/NcdrService.kt
@@ -25,10 +25,8 @@ import breezyweather.domain.weather.model.Alert
 import breezyweather.domain.weather.model.AlertSeverity
 import breezyweather.domain.weather.wrappers.WeatherWrapper
 import com.google.maps.android.model.LatLng
-import com.google.maps.android.model.LatLngBounds
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.reactivex.rxjava3.core.Observable
-import kotlinx.coroutines.rx3.awaitFirstOrElse
 import org.breezyweather.common.exceptions.InvalidLocationException
 import org.breezyweather.common.exceptions.InvalidOrIncompleteDataException
 import org.breezyweather.common.exceptions.WeatherException
@@ -40,14 +38,17 @@ import org.breezyweather.common.source.WeatherSource
 import org.breezyweather.common.source.WeatherSource.Companion.PRIORITY_HIGHEST
 import org.breezyweather.common.source.WeatherSource.Companion.PRIORITY_NONE
 import org.breezyweather.sources.common.xml.CapAlert
-import org.breezyweather.sources.ncdr.xml.NcdrAlertsResult
 import org.breezyweather.sources.nlsc.NlscApi
+import org.breezyweather.sources.nlsc.NlscService.Companion.KINMEN_BBOX
+import org.breezyweather.sources.nlsc.NlscService.Companion.MATSU_BBOX
+import org.breezyweather.sources.nlsc.NlscService.Companion.PENGHU_BBOX
+import org.breezyweather.sources.nlsc.NlscService.Companion.TAIWAN_BBOX
+import org.breezyweather.sources.nlsc.NlscService.Companion.WUQIU_BBOX
 import retrofit2.Retrofit
 import java.util.Locale
 import java.util.Objects
 import javax.inject.Inject
 import javax.inject.Named
-import kotlin.lazy
 
 class NcdrService @Inject constructor(
     @ApplicationContext context: Context,
@@ -262,11 +263,5 @@ class NcdrService @Inject constructor(
     companion object {
         private const val NCDR_BASE_URL = "https://alerts.ncdr.nat.gov.tw/"
         private const val NLSC_BASE_URL = "https://api.nlsc.gov.tw/"
-
-        private val TAIWAN_BBOX = LatLngBounds.parse(119.99690416, 21.756143532, 122.10915909, 25.633378776)
-        private val PENGHU_BBOX = LatLngBounds.parse(119.314301816, 23.186561404, 119.726986388, 23.810692086)
-        private val KINMEN_BBOX = LatLngBounds.parse(118.137979837, 24.160255444, 118.505977425, 24.534228163)
-        private val WUQIU_BBOX = LatLngBounds.parse(119.443195363, 24.97760013, 119.479213453, 24.999614154)
-        private val MATSU_BBOX = LatLngBounds.parse(119.908905081, 25.940995457, 120.511750672, 26.385275262)
     }
 }

--- a/app/src/src_nonfreenet/org/breezyweather/sources/nlsc/NlscService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/nlsc/NlscService.kt
@@ -109,10 +109,10 @@ class NlscService @Inject constructor(
     companion object {
         private const val NLSC_BASE_URL = "https://api.nlsc.gov.tw/"
 
-        private val TAIWAN_BBOX = LatLngBounds.parse(119.99690416, 21.756143532, 122.10915909, 25.633378776)
-        private val PENGHU_BBOX = LatLngBounds.parse(119.314301816, 23.186561404, 119.726986388, 23.810692086)
-        private val KINMEN_BBOX = LatLngBounds.parse(118.137979837, 24.160255444, 118.505977425, 24.534228163)
-        private val WUQIU_BBOX = LatLngBounds.parse(119.443195363, 24.97760013, 119.479213453, 24.999614154)
-        private val MATSU_BBOX = LatLngBounds.parse(119.908905081, 25.940995457, 120.511750672, 26.385275262)
+        val TAIWAN_BBOX = LatLngBounds.parse(119.99690416, 21.756143532, 122.10915909, 25.633378776)
+        val PENGHU_BBOX = LatLngBounds.parse(119.314301816, 23.186561404, 119.726986388, 23.810692086)
+        val KINMEN_BBOX = LatLngBounds.parse(118.137979837, 24.160255444, 118.505977425, 24.534228163)
+        val WUQIU_BBOX = LatLngBounds.parse(119.443195363, 24.97760013, 119.479213453, 24.999614154)
+        val MATSU_BBOX = LatLngBounds.parse(119.908905081, 25.940995457, 120.511750672, 26.385275262)
     }
 }


### PR DESCRIPTION
This patch limits the availability of Pollen in AccuWeather to the 48 contiguous U.S. states plus Washington D.C., Canada, as well as the bounding box of [CAMS European air quality forecasts](https://ads.atmosphere.copernicus.eu/datasets/cams-europe-air-quality-forecasts?tab=overview) (west boundary=25.0° W, east=45.0° E, south=30.0° N, north=72.0°).