### PR TITLE
FPAS debug

### DIFF
--- a/app/src/main/java/org/breezyweather/sources/fpas/FpasService.kt
+++ b/app/src/main/java/org/breezyweather/sources/fpas/FpasService.kt
@@ -86,7 +86,7 @@ class FpasService @Inject constructor(
             maxLon = location.longitude + 0.001
         ).execute().body() ?: return Observable.error(WeatherException())
 
-        if (alertUuids.isEmpty()) return Observable.empty()
+        if (alertUuids.isEmpty()) return Observable.just(WeatherWrapper())
 
         var someAlertsFailed = false
         return Observable.zip(


### PR DESCRIPTION
This patch updates FPAS so that BW does not throw an error when there is no alert for the location.