### PR TITLE
Fix #1211 - FMI

### DIFF
--- a/app/src/main/java/org/breezyweather/sources/SourceManager.kt
+++ b/app/src/main/java/org/breezyweather/sources/SourceManager.kt
@@ -80,6 +80,7 @@ import org.breezyweather.sources.dmi.DmiService
 import org.breezyweather.sources.eccc.EcccService
 import org.breezyweather.sources.ekuk.EkukService
 import org.breezyweather.sources.epdhk.EpdHkService
+import org.breezyweather.sources.fmi.FmiService
 import org.breezyweather.sources.fpas.FpasService
 import org.breezyweather.sources.gadgetbridge.GadgetbridgeService
 import org.breezyweather.sources.geonames.GeoNamesService
@@ -151,6 +152,7 @@ class SourceManager @Inject constructor(
     ekukService: EkukService,
     epdHkService: EpdHkService,
     ethioMetService: EthioMetService,
+    fmiService: FmiService,
     fpasService: FpasService,
     gadgetbridgeService: GadgetbridgeService,
     geoNamesService: GeoNamesService,
@@ -256,6 +258,7 @@ class SourceManager @Inject constructor(
         ekukService,
         epdHkService,
         ethioMetService,
+        fmiService,
         geoSphereAtService,
         gMetService,
         hkoService,

--- a/app/src/main/java/org/breezyweather/sources/fmi/FmiServiceStub.kt
+++ b/app/src/main/java/org/breezyweather/sources/fmi/FmiServiceStub.kt
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.fmi
+
+import android.content.Context
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.source.SourceContinent
+import breezyweather.domain.source.SourceFeature
+import com.google.maps.android.model.LatLng
+import com.google.maps.android.model.LatLngBounds
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
+import org.breezyweather.common.extensions.getCountryName
+import org.breezyweather.common.source.HttpSource
+import org.breezyweather.common.source.LocationParametersSource
+import org.breezyweather.common.source.NonFreeNetSource
+import org.breezyweather.common.source.WeatherSource
+import org.breezyweather.common.source.WeatherSource.Companion.PRIORITY_HIGHEST
+import org.breezyweather.common.source.WeatherSource.Companion.PRIORITY_NONE
+
+/**
+ * The actual implementation is in the src_freenet and src_nonfreenet folders
+ */
+abstract class FmiServiceStub(context: Context) :
+    HttpSource(),
+    WeatherSource,
+    LocationParametersSource,
+    NonFreeNetSource {
+
+    override val id = "fmi"
+    override val name = "FMI (${context.currentLocale.getCountryName("FI")})"
+    override val continent = SourceContinent.EUROPE
+
+    private val weatherAttribution by lazy {
+        with(context.currentLocale.code) {
+            when {
+                startsWith("fi") -> "Ilmatieteen Laitos"
+                startsWith("sv") -> "Meteorologiska Institutet"
+                else -> "Finnish Meteorological Institute"
+            }
+        }
+    }
+
+    override val supportedFeatures = mapOf(
+        SourceFeature.FORECAST to weatherAttribution,
+        SourceFeature.CURRENT to weatherAttribution,
+        SourceFeature.AIR_QUALITY to weatherAttribution,
+        SourceFeature.ALERT to weatherAttribution,
+        SourceFeature.NORMALS to weatherAttribution
+    )
+
+    override fun isFeatureSupportedForLocation(location: Location, feature: SourceFeature): Boolean {
+        return when (feature) {
+            SourceFeature.FORECAST -> FMI_FORECAST_BBOX.contains(LatLng(location.latitude, location.longitude))
+            SourceFeature.AIR_QUALITY -> FMI_SILAM_BBOX.contains(LatLng(location.latitude, location.longitude))
+            else -> arrayOf("FI", "AX").any { location.countryCode.equals(it, ignoreCase = true) }
+        }
+    }
+
+    override fun getFeaturePriorityForLocation(location: Location, feature: SourceFeature): Int {
+        return when {
+            arrayOf("FI", "AX").any { location.countryCode.equals(it, ignoreCase = true) } -> PRIORITY_HIGHEST
+            else -> PRIORITY_NONE
+        }
+    }
+
+    companion object {
+        private val FMI_FORECAST_BBOX = LatLngBounds(
+            LatLng(53.900000, 4.888770),
+            LatLng(72.269067, 32.931465)
+        )
+        private val FMI_SILAM_BBOX = LatLngBounds(
+            LatLng(30.050000, -24.950000),
+            LatLng(72.049999, 45.049999)
+        )
+    }
+}

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -778,4 +778,8 @@
     <string name="settings_weather_source_non_freenet">%s (ei-vapaa verkkopalvelu)</string>
     <string name="settings_appearance_dark_mode_custom">Tumma tila aikavälillä %1$s-%2$s</string>
     <string name="common_weather_text_mostly_cloudy">Enimmäkseen pilvistä</string>
+    <string name="fmi_weather_text_ice_pellets_light">Heikkoa jääjyvässadetta</string>
+    <string name="fmi_weather_text_ice_pellets_moderate">Kohtalaista jääjyväsadetta</string>
+    <string name="fmi_weather_text_ice_pellets_heavy">Kovaa jääjyväsadetta</string>
+    <string name="fmi_weather_text_ice_crystals">Jääkiteitä</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1232,6 +1232,11 @@
     <!-- Weather texts for Vedur.is -->
     <string name="veduris_weather_text_fog_drizzle" translatable="false">Fog drizzle</string>
     <string name="veduris_weather_text_thunderstorm_light" translatable="false">Light thunderstorm</string>
+    <!-- Weather texts for FMI -->
+    <string name="fmi_weather_text_ice_pellets_light" translatable="false">Light ice pellets</string>
+    <string name="fmi_weather_text_ice_pellets_moderate" translatable="false">Moderate ice pellets</string>
+    <string name="fmi_weather_text_ice_pellets_heavy" translatable="false">Heavy ice pellets</string>
+    <string name="fmi_weather_text_ice_crystals" translatable="false">@string/nws_weather_text_ice_crystals</string>
     <!-- Do NOT translate everything below -->
     <!-- Widgets -->
     <string name="widget_custom_subtitle_keyword_cw" translatable="false">$cw$</string>

--- a/app/src/src_freenet/org/breezyweather/sources/fmi/FmiService.kt
+++ b/app/src/src_freenet/org/breezyweather/sources/fmi/FmiService.kt
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.fmi
+
+import android.content.Context
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.source.SourceFeature
+import breezyweather.domain.weather.wrappers.WeatherWrapper
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.common.exceptions.NonFreeNetSourceException
+import javax.inject.Inject
+
+class FmiService @Inject constructor(
+    @ApplicationContext context: Context,
+) : FmiServiceStub(context) {
+
+    override val privacyPolicyUrl = ""
+
+    override fun requestWeather(
+        context: Context,
+        location: Location,
+        requestedFeatures: List<SourceFeature>,
+    ): Observable<WeatherWrapper> {
+        throw NonFreeNetSourceException()
+    }
+
+    override fun needsLocationParametersRefresh(
+        location: Location,
+        coordinatesChanged: Boolean,
+        features: List<SourceFeature>,
+    ): Boolean = false
+
+    override fun requestLocationParameters(
+        context: Context,
+        location: Location,
+    ): Observable<Map<String, String>> {
+        throw NonFreeNetSourceException()
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/fmi/FmiAlertsApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/fmi/FmiAlertsApi.kt
@@ -1,0 +1,18 @@
+package org.breezyweather.sources.fmi
+
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.sources.common.xml.CapAlert
+import org.breezyweather.sources.fmi.xml.FmiAlertsResult
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Url
+
+interface FmiAlertsApi {
+    @GET("cap/feed/rss_en-GB.rss")
+    fun getAlerts(): Call<FmiAlertsResult>
+
+    @GET
+    fun getAlert(
+        @Url url: String,
+    ): Observable<CapAlert>
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/fmi/FmiApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/fmi/FmiApi.kt
@@ -1,0 +1,47 @@
+package org.breezyweather.sources.fmi
+
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.sources.fmi.xml.FmiSimpleResult
+import org.breezyweather.sources.fmi.xml.FmiStationsResult
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface FmiApi {
+    @GET("wfs")
+    fun getForecast(
+        @Query("service") service: String = "WFS",
+        @Query("version") version: String = "2.0.0",
+        @Query("request") request: String = "getFeature",
+        @Query("storedquery_id") storedQueryId: String,
+        @Query("latlon") latlon: String, // e.g. 61.2,21
+        @Query("endtime") endtime: String,
+    ): Call<FmiSimpleResult>
+
+    @GET("wfs")
+    fun getCurrent(
+        @Query("service") service: String = "WFS",
+        @Query("version") version: String = "2.0.0",
+        @Query("request") request: String = "getFeature",
+        @Query("storedquery_id") storedQueryId: String = "fmi::observations::weather::simple",
+        @Query("fmisid") fmisid: String,
+        @Query("starttime") starttime: String,
+    ): Call<FmiSimpleResult>
+
+    @GET("wfs")
+    fun getStations(
+        @Query("service") service: String = "WFS",
+        @Query("version") version: String = "2.0.0",
+        @Query("request") request: String = "getFeature",
+        @Query("storedquery_id") storedQueryId: String = "fmi::ef::stations",
+    ): Observable<FmiStationsResult>
+
+    @GET("wfs")
+    fun getNormals(
+        @Query("service") service: String = "WFS",
+        @Query("version") version: String = "2.0.0",
+        @Query("request") request: String = "getFeature",
+        @Query("storedquery_id") storedQueryId: String = "fmi::observations::weather::monthly::30year::simple",
+        @Query("fmisid") fmisid: String,
+    ): Call<FmiSimpleResult>
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/fmi/FmiService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/fmi/FmiService.kt
@@ -1,0 +1,642 @@
+package org.breezyweather.sources.fmi
+
+import android.content.Context
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.source.SourceFeature
+import breezyweather.domain.weather.model.AirQuality
+import breezyweather.domain.weather.model.Alert
+import breezyweather.domain.weather.model.Normals
+import breezyweather.domain.weather.model.Precipitation
+import breezyweather.domain.weather.model.PrecipitationProbability
+import breezyweather.domain.weather.model.Wind
+import breezyweather.domain.weather.reference.AlertSeverity
+import breezyweather.domain.weather.reference.Month
+import breezyweather.domain.weather.reference.WeatherCode
+import breezyweather.domain.weather.wrappers.AirQualityWrapper
+import breezyweather.domain.weather.wrappers.CurrentWrapper
+import breezyweather.domain.weather.wrappers.DailyWrapper
+import breezyweather.domain.weather.wrappers.HourlyWrapper
+import breezyweather.domain.weather.wrappers.TemperatureWrapper
+import breezyweather.domain.weather.wrappers.WeatherWrapper
+import com.google.maps.android.model.LatLng
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.R
+import org.breezyweather.common.exceptions.InvalidLocationException
+import org.breezyweather.common.exceptions.InvalidOrIncompleteDataException
+import org.breezyweather.common.exceptions.WeatherException
+import org.breezyweather.common.extensions.CLOUD_COVER_BKN
+import org.breezyweather.common.extensions.CLOUD_COVER_FEW
+import org.breezyweather.common.extensions.CLOUD_COVER_OVC
+import org.breezyweather.common.extensions.CLOUD_COVER_SCT
+import org.breezyweather.common.extensions.CLOUD_COVER_SKC
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
+import org.breezyweather.common.extensions.getIsoFormattedDate
+import org.breezyweather.sources.common.xml.CapAlert
+import org.breezyweather.sources.fmi.xml.FmiSimpleResult
+import org.breezyweather.sources.fmi.xml.FmiStationsResult
+import org.breezyweather.unit.distance.Distance.Companion.meters
+import org.breezyweather.unit.pollutant.PollutantConcentration.Companion.microgramsPerCubicMeter
+import org.breezyweather.unit.precipitation.Precipitation.Companion.millimeters
+import org.breezyweather.unit.pressure.Pressure.Companion.hectopascals
+import org.breezyweather.unit.ratio.Ratio.Companion.percent
+import org.breezyweather.unit.speed.Speed.Companion.metersPerSecond
+import org.breezyweather.unit.temperature.Temperature.Companion.celsius
+import retrofit2.Retrofit
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.Objects
+import java.util.TimeZone
+import javax.inject.Inject
+import javax.inject.Named
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+
+class FmiService @Inject constructor(
+    @ApplicationContext context: Context,
+    @Named("XmlClient") client: Retrofit.Builder,
+) : FmiServiceStub(context) {
+
+    override val privacyPolicyUrl by lazy {
+        with(context.currentLocale.code) {
+            when {
+                startsWith("fi") -> "https://www.ilmatieteenlaitos.fi/tietosuoja"
+                startsWith("sv") -> "https://sv.ilmatieteenlaitos.fi/dataskydd"
+                else -> "https://en.ilmatieteenlaitos.fi/data-protection"
+            }
+        }
+    }
+
+    private val mApi by lazy {
+        client
+            .baseUrl(FMI_BASE_URL)
+            .build()
+            .create(FmiApi::class.java)
+    }
+
+    private val mAlertsApi by lazy {
+        client
+            .baseUrl(FMI_ALERTS_BASE_URL)
+            .build()
+            .create(FmiAlertsApi::class.java)
+    }
+
+    override val attributionLinks = mapOf(
+        "Ilmatieteen Laitos" to "https://www.ilmatieteenlaitos.fi/",
+        "Meteorologiska Institutet" to "https://sv.ilmatieteenlaitos.fi/",
+        "Finnish Meteorological Institute" to "https://en.ilmatieteenlaitos.fi/"
+    )
+
+    override fun requestWeather(
+        context: Context,
+        location: Location,
+        requestedFeatures: List<SourceFeature>,
+    ): Observable<WeatherWrapper> {
+        val currentStation = location.parameters.getOrElse(id) { null }?.getOrElse("currentStation") { null }
+        if (arrayOf(SourceFeature.CURRENT, SourceFeature.NORMALS).any { it in requestedFeatures } &&
+            currentStation.isNullOrEmpty()
+        ) {
+            return Observable.error(InvalidLocationException())
+        }
+
+        val hourFormatter = SimpleDateFormat("yyyy-MM-dd'T'HH':00:00Z'", Locale.ENGLISH)
+        hourFormatter.timeZone = TimeZone.getTimeZone("Etc/UTC")
+        val minuteFormatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm':00Z'", Locale.ENGLISH)
+        minuteFormatter.timeZone = TimeZone.getTimeZone("Etc/UTC")
+
+        val latlon = "${location.latitude},${location.longitude}"
+
+        val failedFeatures = mutableMapOf<SourceFeature, Throwable>()
+        val current = if (SourceFeature.CURRENT in requestedFeatures) {
+            // limit to the last hour, otherwise the call will download 720 minutes (12 hours)
+            val starttime = System.currentTimeMillis().minus(1.hours.inWholeMilliseconds)
+            val result = mApi.getCurrent(
+                fmisid = currentStation!!,
+                starttime = minuteFormatter.format(Date(starttime))
+            ).execute().body()
+            if (result == null) {
+                failedFeatures[SourceFeature.CURRENT] = WeatherException()
+                FmiSimpleResult()
+            } else {
+                result
+            }
+        } else {
+            FmiSimpleResult()
+        }
+
+        val forecast = if (SourceFeature.FORECAST in requestedFeatures) {
+            // FMI has 10-day forecast, but data points on the 10th day are non-uniformly sparse
+            // leading to random crashes of the app. Safer to keep to 9 days.
+            val endtime = System.currentTimeMillis().plus(9.days.inWholeMilliseconds)
+            val result = mApi.getForecast(
+                latlon = latlon,
+                storedQueryId = "fmi::forecast::edited::weather::scandinavia::point::simple",
+                endtime = hourFormatter.format(Date(endtime))
+            ).execute().body()
+            if (result == null) {
+                failedFeatures[SourceFeature.FORECAST] = WeatherException()
+                FmiSimpleResult()
+            } else {
+                result
+            }
+        } else {
+            FmiSimpleResult()
+        }
+
+        val airQuality = if (SourceFeature.AIR_QUALITY in requestedFeatures) {
+            // This endpoint gets the pollutant concentration forecasts only.
+            // There are also two endpoints for current/recent pollutant observations,
+            // but more work is needed figure out which station IDs report to either endpoint.
+            val endtime = System.currentTimeMillis().plus(4.days.inWholeMilliseconds)
+            val result = mApi.getForecast(
+                latlon = latlon,
+                storedQueryId = "fmi::forecast::silam::airquality::surface::point::simple",
+                endtime = hourFormatter.format(Date(endtime))
+            ).execute().body()
+            if (result == null) {
+                failedFeatures[SourceFeature.AIR_QUALITY] = WeatherException()
+                FmiSimpleResult()
+            } else {
+                result
+            }
+        } else {
+            FmiSimpleResult()
+        }
+
+        val normals = if (SourceFeature.NORMALS in requestedFeatures) {
+            val result = mApi.getNormals(
+                fmisid = currentStation!!
+            ).execute().body()
+            if (result == null) {
+                failedFeatures[SourceFeature.NORMALS] = WeatherException()
+                FmiSimpleResult()
+            } else {
+                result
+            }
+        } else {
+            FmiSimpleResult()
+        }
+
+        var someAlertsFailed = false
+        val alerts = if (SourceFeature.ALERT in requestedFeatures) {
+            val alertsResult = mAlertsApi.getAlerts().execute().body()
+            if (alertsResult != null) {
+                alertsResult.let { alertFeed ->
+                    alertFeed.channel?.items?.filter {
+                        !(it.title?.value?.startsWith("REMOVED:", ignoreCase = true) ?: false) &&
+                            !it.link?.value.isNullOrEmpty()
+                    }?.map {
+                        it.link?.value?.let { link ->
+                            mAlertsApi.getAlert(link).onErrorResumeNext {
+                                someAlertsFailed = true
+                                Observable.just(CapAlert())
+                            }
+                        } ?: Observable.just(CapAlert())
+                    }
+                } ?: listOf<Observable<CapAlert>>()
+            } else {
+                someAlertsFailed = true
+                listOf<Observable<CapAlert>>()
+            }
+        } else {
+            listOf<Observable<CapAlert>>()
+        }.map {
+            it.blockingFirst()
+        }
+        if (someAlertsFailed) {
+            failedFeatures[SourceFeature.ALERT] = InvalidOrIncompleteDataException()
+        }
+
+        return Observable.just(
+            WeatherWrapper(
+                current = getCurrent(context, current),
+                dailyForecast = getDailyForecast(location, forecast),
+                hourlyForecast = getHourlyForecast(context, forecast),
+                airQuality = getAirQuality(airQuality),
+                alertList = getAlertList(context, location, alerts),
+                normals = getNormals(normals),
+                failedFeatures = failedFeatures
+            )
+        )
+    }
+
+    private fun getCurrent(
+        context: Context,
+        currentResult: FmiSimpleResult,
+    ): CurrentWrapper? {
+        return currentResult.members?.let {
+            val cloudCover = extractLatest(it, "n_man")?.times(12.5)
+            CurrentWrapper(
+                weatherText = getCurrentWeatherText(context, (extractLatest(it, "wawa") ?: 0).toInt(), cloudCover),
+                weatherCode = getCurrentWeatherCode((extractLatest(it, "wawa") ?: 0).toInt(), cloudCover),
+                temperature = TemperatureWrapper(
+                    temperature = extractLatest(it, "t2m")?.celsius
+                ),
+                wind = Wind(
+                    degree = extractLatest(it, "wd_10min"),
+                    speed = extractLatest(it, "ws_10min")?.metersPerSecond,
+                    gusts = extractLatest(it, "wg_10min")?.metersPerSecond
+                ),
+                relativeHumidity = extractLatest(it, "rh")?.percent,
+                dewPoint = extractLatest(it, "td")?.celsius,
+                pressure = extractLatest(it, "p_sea")?.hectopascals,
+                cloudCover = cloudCover?.percent,
+                visibility = extractLatest(it, "vis")?.meters
+            )
+        }
+    }
+
+    private fun getDailyForecast(
+        location: Location,
+        forecastResult: FmiSimpleResult,
+    ): List<DailyWrapper>? {
+        val dates = forecastResult.members?.filter {
+            it.bsWfsElement?.parameterValue?.value != "NaN"
+        }?.groupBy {
+            it.bsWfsElement?.time?.value?.getIsoFormattedDate(location)
+        }?.keys?.sortedBy { it }
+        val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH)
+        formatter.timeZone = location.timeZone
+        return dates?.map {
+            DailyWrapper(
+                date = formatter.parse(it!!)!!
+            )
+        }
+    }
+
+    private fun getHourlyForecast(
+        context: Context,
+        forecastResult: FmiSimpleResult,
+    ): List<HourlyWrapper>? {
+        val hours = forecastResult.members?.groupBy { member ->
+            member.bsWfsElement?.time?.value
+        }?.keys?.sortedBy { it }
+
+        return hours?.map { hour ->
+            val members = forecastResult.members.filter {
+                it.bsWfsElement?.time?.value == hour
+            }
+            HourlyWrapper(
+                date = hour!!,
+                weatherText = getForecastWeatherText(context, (extract(members, "WeatherSymbol3") ?: 0).toInt()),
+                weatherCode = getForecastWeatherCode((extract(members, "WeatherSymbol3") ?: 0).toInt()),
+                temperature = TemperatureWrapper(
+                    temperature = extract(members, "Temperature")?.celsius
+                ),
+                precipitation = Precipitation(
+                    total = extract(members, "Precipitation1h")?.millimeters
+                ),
+                precipitationProbability = PrecipitationProbability(
+                    total = extract(members, "PoP")?.percent,
+                    thunderstorm = extract(members, "ProbabilityThunderstorm")?.percent
+                ),
+                wind = Wind(
+                    degree = extract(members, "WindDirection"),
+                    speed = extract(members, "WindSpeedMS")?.metersPerSecond,
+                    gusts = extract(members, "HourlyMaximumGust")?.metersPerSecond
+                ),
+                relativeHumidity = extract(members, "Humidity")?.percent,
+                dewPoint = extract(members, "DewPoint")?.celsius,
+                pressure = extract(members, "Pressure")?.hectopascals,
+                cloudCover = extract(members, "TotalCloudCover")?.percent
+            )
+        }
+    }
+
+    private fun getAirQuality(
+        airQualityResult: FmiSimpleResult,
+    ): AirQualityWrapper {
+        val hours = airQualityResult.members?.filter { member ->
+            member.bsWfsElement?.time?.value != null
+        }?.groupBy { member ->
+            member.bsWfsElement?.time?.value
+        }?.keys?.sortedBy { it }?.mapNotNull { it }
+
+        return AirQualityWrapper(
+            hourlyForecast = hours?.associateWith { hour ->
+                val members = airQualityResult.members.filter {
+                    it.bsWfsElement?.time?.value == hour
+                }
+                AirQuality(
+                    pM25 = extract(members, "PM25Concentration")?.microgramsPerCubicMeter,
+                    pM10 = extract(members, "PM10Concentration")?.microgramsPerCubicMeter,
+                    sO2 = extract(members, "SO2Concentration")?.microgramsPerCubicMeter,
+                    nO2 = extract(members, "NO2Concentration")?.microgramsPerCubicMeter,
+                    o3 = extract(members, "O3Concentration")?.microgramsPerCubicMeter,
+                    cO = extract(members, "COConcentration")?.microgramsPerCubicMeter
+                )
+            }
+        )
+    }
+
+    private fun getNormals(
+        normalsResult: FmiSimpleResult,
+    ): Map<Month, Normals> {
+        val formatter = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ENGLISH)
+        formatter.timeZone = TimeZone.getTimeZone("Etc/UTC")
+        return Month.entries.associateWith { month ->
+            val datePattern = Regex("""^\d{4}-${"%02d".format(month.value)}-01T00:00:00Z$""")
+            val monthlyRecords = normalsResult.members?.filter {
+                datePattern.matches(formatter.format(it.bsWfsElement?.time?.value!!))
+            }
+            if (!monthlyRecords.isNullOrEmpty()) {
+                Normals(
+                    daytimeTemperature = extract(monthlyRecords, "TAMAXP1M")?.celsius,
+                    nighttimeTemperature = extract(monthlyRecords, "TAMINP1M")?.celsius
+                )
+            } else {
+                Normals()
+            }
+        }
+    }
+
+    private fun getAlertList(
+        context: Context,
+        location: Location,
+        alerts: List<CapAlert>,
+    ): List<Alert> {
+        val regex = Regex("""^(Landskapet )?(.*)( Region)?$""")
+        return alerts.mapNotNull { capAlert ->
+            if (!capAlert.msgType?.value.equals("Cancel", ignoreCase = true)) {
+                capAlert.getInfoForContext(context)?.let { info ->
+                    // Try matching by region name/code first. It's much faster than calling containsPoint().
+                    // We should clean up region name, as Open-Meteo adds "Landskapet" or "Region" to some regions.
+                    // Then compare the region name against areas listed on the alert.
+                    // This check assumes the user did not change language between adding the location and
+                    // refreshing the location data. Otherwise, the region names won't match and it will
+                    // fall back to calling containsPoint().
+                    // If the location is added from Nominatim, there will likely be ISO 3166-2 code as well,
+                    // which can be used for matching by area code.
+                    val regionName = regex.replace(location.admin1 ?: "", "$2").trim()
+                    val regionCode = location.admin1Code
+                    val matchingRegion = (
+                        info.areas?.any { area -> area.areaDesc?.value.equals(regionName, ignoreCase = true) } ?: false
+                        ) || (!regionCode.isNullOrEmpty() && info.containsGeocode("ISO 3166-2", regionCode)) || (
+                        location.countryCode.equals("AX", ignoreCase = true) && info.areas?.any { area ->
+                            arrayOf("Åland", "Ahvenanmaa").any { area.areaDesc?.value.equals(it, ignoreCase = true) }
+                        } ?: false
+                        )
+
+                    if (info.category?.value.equals("Met", ignoreCase = true) &&
+                        !info.urgency?.value.equals("Past", ignoreCase = true) &&
+                        (matchingRegion || info.containsPoint(LatLng(location.latitude, location.longitude)))
+                    ) {
+                        val severity = when (info.severity?.value) {
+                            "Extreme" -> AlertSeverity.EXTREME
+                            "Severe" -> AlertSeverity.SEVERE
+                            "Moderate" -> AlertSeverity.MODERATE
+                            "Minor" -> AlertSeverity.MINOR
+                            else -> AlertSeverity.UNKNOWN
+                        }
+                        val title = info.event?.value ?: info.headline?.value
+                        val start = info.onset?.value ?: info.effective?.value ?: capAlert.sent?.value
+                        Alert(
+                            alertId = capAlert.identifier?.value ?: Objects.hash(title, severity, start).toString(),
+                            startDate = start,
+                            endDate = info.expires?.value,
+                            headline = title,
+                            description = info.formatAlertText(text = info.description?.value),
+                            instruction = info.formatAlertText(text = info.instruction?.value),
+                            source = info.senderName?.value,
+                            severity = severity,
+                            color = Alert.colorFromSeverity(severity)
+                        )
+                    } else {
+                        null
+                    }
+                }
+            } else {
+                null
+            }
+        }
+    }
+
+    // Source for "WaWa" codes (Sääsymbolien selitykset säähavainnoissa):
+    // https://www.ilmatieteenlaitos.fi/latauspalvelun-pikaohje
+    private fun getCurrentWeatherText(context: Context, symbol: Int, cloudCover: Double?): String? {
+        return when (symbol) {
+            0 -> cloudCover?.let {
+                when {
+                    it < 0.0 -> null
+                    it < CLOUD_COVER_SKC -> context.getString(R.string.common_weather_text_clear_sky)
+                    it < CLOUD_COVER_FEW -> context.getString(R.string.common_weather_text_mostly_clear)
+                    it < CLOUD_COVER_SCT -> context.getString(R.string.common_weather_text_partly_cloudy)
+                    it < CLOUD_COVER_BKN -> context.getString(R.string.common_weather_text_mostly_cloudy)
+                    it < CLOUD_COVER_OVC -> context.getString(R.string.common_weather_text_cloudy)
+                    it == CLOUD_COVER_OVC -> context.getString(R.string.common_weather_text_overcast)
+                    else -> null
+                }
+            }
+            4, 5 -> context.getString(R.string.weather_kind_haze)
+            10 -> context.getString(R.string.common_weather_text_mist)
+            20, 30, 31, 32, 33, 34 -> context.getString(R.string.common_weather_text_fog)
+            21, 23, 40, 41, 60 -> context.getString(R.string.common_weather_text_rain)
+            22, 50 -> context.getString(R.string.common_weather_text_drizzle)
+            24, 70 -> context.getString(R.string.common_weather_text_snow)
+            25 -> context.getString(R.string.common_weather_text_rain_freezing)
+            61 -> context.getString(R.string.common_weather_text_rain_light)
+            42, 63 -> context.getString(R.string.common_weather_text_rain_heavy)
+            51 -> context.getString(R.string.common_weather_text_drizzle_light)
+            52 -> context.getString(R.string.common_weather_text_drizzle_moderate)
+            53 -> context.getString(R.string.common_weather_text_drizzle_heavy)
+            54 -> context.getString(R.string.common_weather_text_drizzle_freezing_light)
+            55 -> context.getString(R.string.common_weather_text_drizzle_freezing)
+            56 -> context.getString(R.string.common_weather_text_drizzle_freezing_heavy)
+            62 -> context.getString(R.string.common_weather_text_rain_moderate)
+            64 -> context.getString(R.string.common_weather_text_rain_freezing_light)
+            65 -> context.getString(R.string.common_weather_text_rain_freezing)
+            66 -> context.getString(R.string.common_weather_text_rain_freezing_heavy)
+            67 -> context.getString(R.string.common_weather_text_rain_snow_mixed_light)
+            68 -> context.getString(R.string.common_weather_text_rain_snow_mixed)
+            71 -> context.getString(R.string.common_weather_text_snow_light)
+            72 -> context.getString(R.string.common_weather_text_snow_moderate)
+            73 -> context.getString(R.string.common_weather_text_snow_heavy)
+            74 -> context.getString(R.string.fmi_weather_text_ice_pellets_light)
+            75 -> context.getString(R.string.fmi_weather_text_ice_pellets_moderate)
+            76 -> context.getString(R.string.fmi_weather_text_ice_pellets_heavy)
+            77 -> context.getString(R.string.common_weather_text_snow_grains)
+            78 -> context.getString(R.string.fmi_weather_text_ice_crystals)
+            80 -> context.getString(R.string.common_weather_text_rain_showers)
+            81 -> context.getString(R.string.common_weather_text_rain_showers_light)
+            82 -> context.getString(R.string.common_weather_text_rain_showers_moderate)
+            83, 84 -> context.getString(R.string.common_weather_text_rain_showers_heavy)
+            85 -> context.getString(R.string.common_weather_text_snow_showers_light)
+            86 -> context.getString(R.string.common_weather_text_snow_showers)
+            87 -> context.getString(R.string.common_weather_text_snow_showers_heavy)
+            89 -> context.getString(R.string.weather_kind_hail)
+            else -> null
+        }
+    }
+
+    private fun getCurrentWeatherCode(symbol: Int, cloudCover: Double?): WeatherCode? {
+        return when (symbol) {
+            0 -> cloudCover?.let {
+                when {
+                    it < 0.0 -> null
+                    it < CLOUD_COVER_FEW -> WeatherCode.CLEAR
+                    it < CLOUD_COVER_SCT -> WeatherCode.PARTLY_CLOUDY
+                    it <= CLOUD_COVER_BKN -> WeatherCode.CLOUDY
+                    else -> null
+                }
+            }
+            4, 5 -> WeatherCode.HAZE
+            10, 20, 30, 31, 32, 33, 34 -> WeatherCode.FOG
+            21, 22, 23, 40, 41, 42, 50, 51, 52, 53, 60, 61, 62, 63, 80, 81, 82, 83, 84 -> WeatherCode.RAIN
+            24, 70, 71, 72, 73, 74, 75, 76, 77, 85, 86, 87 -> WeatherCode.SNOW
+            25, 54, 55, 56, 64, 65, 66, 67, 68 -> WeatherCode.SLEET
+            78 -> WeatherCode.FOG // ice crystals
+            89 -> WeatherCode.HAIL
+            else -> null
+        }
+    }
+
+    // Source for WeatherSymbol3 definitions:
+    // https://www.ilmatieteenlaitos.fi/latauspalvelun-pikaohje
+    private fun getForecastWeatherText(context: Context, symbol: Int): String? {
+        return when (symbol) {
+            1 -> context.getString(R.string.common_weather_text_clear_sky)
+            2 -> context.getString(R.string.common_weather_text_partly_cloudy)
+            3 -> context.getString(R.string.common_weather_text_cloudy)
+            21 -> context.getString(R.string.common_weather_text_rain_showers_light)
+            22 -> context.getString(R.string.common_weather_text_rain_showers)
+            23 -> context.getString(R.string.common_weather_text_rain_showers_heavy)
+            31 -> context.getString(R.string.common_weather_text_rain_light)
+            32 -> context.getString(R.string.common_weather_text_rain)
+            33 -> context.getString(R.string.common_weather_text_rain_heavy)
+            41 -> context.getString(R.string.common_weather_text_snow_showers_light)
+            42 -> context.getString(R.string.common_weather_text_snow_showers)
+            43 -> context.getString(R.string.common_weather_text_snow_showers_heavy)
+            51 -> context.getString(R.string.common_weather_text_snow_light)
+            52 -> context.getString(R.string.common_weather_text_snow)
+            53 -> context.getString(R.string.common_weather_text_snow_heavy)
+            // originally: Ukkoskuuroja (Thundershower)
+            61 -> context.getString(R.string.weather_kind_thunderstorm)
+            // originally: Voimakkaita ukkoskuuroja (Heavy thundershower)
+            62 -> context.getString(R.string.weather_kind_thunderstorm)
+            // originally: Ukkosta (Thunder)
+            63 -> context.getString(R.string.weather_kind_thunder)
+            // originally: Voimakasta ukkosta (Heavy thunder -- what does that even mean?)
+            64 -> context.getString(R.string.weather_kind_thunder)
+            71 -> context.getString(R.string.common_weather_text_rain_snow_mixed_showers_light)
+            72 -> context.getString(R.string.common_weather_text_rain_snow_mixed_showers)
+            73 -> context.getString(R.string.common_weather_text_rain_snow_mixed_showers_heavy)
+            81 -> context.getString(R.string.common_weather_text_rain_snow_mixed_light)
+            82 -> context.getString(R.string.common_weather_text_rain_snow_mixed)
+            83 -> context.getString(R.string.common_weather_text_rain_snow_mixed_heavy)
+            91 -> context.getString(R.string.common_weather_text_mist)
+            92 -> context.getString(R.string.common_weather_text_fog)
+            else -> null
+        }
+    }
+
+    private fun getForecastWeatherCode(symbol: Int): WeatherCode? {
+        return when (symbol) {
+            1 -> WeatherCode.CLEAR
+            2 -> WeatherCode.PARTLY_CLOUDY
+            3 -> WeatherCode.CLOUDY
+            21, 22, 23, 31, 32, 33 -> WeatherCode.RAIN
+            41, 42, 43, 51, 52, 53 -> WeatherCode.SNOW
+            61, 62 -> WeatherCode.THUNDERSTORM
+            63, 64 -> WeatherCode.THUNDER
+            71, 72, 73, 81, 82, 83 -> WeatherCode.SLEET
+            91, 92 -> WeatherCode.FOG
+            else -> null
+        }
+    }
+
+    private fun extract(
+        members: List<FmiSimpleResult.Member>,
+        parameter: String,
+    ): Double? {
+        val value = members.firstOrNull {
+            it.bsWfsElement?.parameterName?.value == parameter
+        }?.bsWfsElement?.parameterValue?.value
+        if (value.isNullOrEmpty() || value.equals("NaN", ignoreCase = true)) {
+            return null
+        } else {
+            return value.toDoubleOrNull()
+        }
+    }
+
+    // used only by getCurrent()
+    // which will only have access to observation data points in the last hour
+    // so should not check for data points that are no longer current
+    private fun extractLatest(
+        members: List<FmiSimpleResult.Member>,
+        parameter: String,
+    ): Double? {
+        val timestamp = members.filter {
+            it.bsWfsElement?.parameterName?.value == parameter
+        }.map {
+            it.bsWfsElement?.time?.value
+        }.sortedBy { it }.last()
+
+        val value = members.first {
+            it.bsWfsElement?.time?.value == timestamp &&
+                it.bsWfsElement?.parameterName?.value == parameter
+        }.bsWfsElement?.parameterValue?.value
+        if (value.isNullOrEmpty() || value.equals("NaN", ignoreCase = true)) {
+            return null
+        } else {
+            return value.toDoubleOrNull()
+        }
+    }
+
+    override fun needsLocationParametersRefresh(
+        location: Location,
+        coordinatesChanged: Boolean,
+        features: List<SourceFeature>,
+    ): Boolean {
+        if (coordinatesChanged) return true
+
+        val currentStation = location.parameters.getOrElse(id) { null }?.getOrElse("currentStation") { null }
+
+        return (SourceFeature.CURRENT in features && currentStation.isNullOrEmpty())
+    }
+
+    override fun requestLocationParameters(
+        context: Context,
+        location: Location,
+    ): Observable<Map<String, String>> {
+        val locationParameters = mutableMapOf<String, String>()
+        val posPattern = Regex("""^-?\d+(\.\d+)? -?\d+(\.\d+)?$""")
+        return mApi.getStations().map { stations ->
+            val currentStations = stations.members?.filter { member ->
+                member.environmentalMonitoringFacility.let {
+                    !(it?.identifier?.value.isNullOrEmpty()) &&
+                        posPattern.matches(it.representativePoint?.point?.pos?.value ?: "") &&
+                        it.belongsTo?.any { belongsTo ->
+                            belongsTo.title == "Automaattinen sääasema"
+                        } ?: false
+                }
+            } ?: emptyList()
+
+            locationParameters["currentStation"] = convertLocationParameters(location, currentStations) ?: ""
+            locationParameters
+        }
+    }
+
+    // location parameters
+    private fun convertLocationParameters(
+        location: Location,
+        members: List<FmiStationsResult.Member>,
+    ): String? {
+        val stationList = members.associate { member ->
+            member.environmentalMonitoringFacility.let {
+                val coords = it!!.representativePoint!!.point!!.pos!!.value!!.split(" ")
+                it.identifier!!.value!! to LatLng(
+                    coords[0].toDouble(),
+                    coords[1].toDouble()
+                )
+            }
+        }
+        return LatLng(location.latitude, location.longitude).getNearestLocation(stationList, 50000.0)
+    }
+
+    companion object {
+        private const val FMI_BASE_URL = "https://opendata.fmi.fi/"
+        private const val FMI_ALERTS_BASE_URL = "https://alerts.fmi.fi/"
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/fmi/xml/FmiAlertsResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/fmi/xml/FmiAlertsResult.kt
@@ -1,0 +1,36 @@
+package org.breezyweather.sources.fmi.xml
+
+import kotlinx.serialization.Serializable
+import nl.adaptivity.xmlutil.serialization.XmlSerialName
+import nl.adaptivity.xmlutil.serialization.XmlValue
+
+@Serializable
+@XmlSerialName("rss", "", "fmi")
+data class FmiAlertsResult(
+    val channel: Channel? = null,
+) {
+    @Serializable
+    @XmlSerialName("channel", "", "fmi")
+    data class Channel(
+        val items: List<Item>?,
+    ) {
+        @Serializable
+        @XmlSerialName("item", "", "fmi")
+        data class Item(
+            val title: Title?,
+            val link: Link?,
+        ) {
+            @Serializable
+            @XmlSerialName("title", "", "fmi")
+            data class Title(
+                @XmlValue(true) val value: String?,
+            )
+
+            @Serializable
+            @XmlSerialName("link", "", "fmi")
+            data class Link(
+                @XmlValue(true) val value: String?,
+            )
+        }
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/fmi/xml/FmiSimpleResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/fmi/xml/FmiSimpleResult.kt
@@ -1,0 +1,48 @@
+package org.breezyweather.sources.fmi.xml
+
+import kotlinx.serialization.Serializable
+import nl.adaptivity.xmlutil.serialization.XmlSerialName
+import nl.adaptivity.xmlutil.serialization.XmlValue
+import org.breezyweather.common.serializer.DateSerializer
+import java.util.Date
+
+@Serializable
+@XmlSerialName("FeatureCollection", NS_WFS, "fmi")
+data class FmiSimpleResult(
+    val members: List<Member>? = null,
+) {
+    @Serializable
+    @XmlSerialName("member", NS_WFS, "fmi")
+    data class Member(
+        val bsWfsElement: BsWfsElement?,
+    ) {
+        @Serializable
+        @XmlSerialName("BsWfsElement", NS_BSWFS, "fmi")
+        data class BsWfsElement(
+            val time: Time?,
+            val parameterName: ParameterName?,
+            val parameterValue: ParameterValue?,
+        ) {
+            @Serializable
+            @XmlSerialName("Time", NS_BSWFS, "fmi")
+            data class Time(
+                @XmlValue(true) @Serializable(DateSerializer::class) val value: Date?,
+            )
+
+            @Serializable
+            @XmlSerialName("ParameterName", NS_BSWFS, "fmi")
+            data class ParameterName(
+                @XmlValue(true) val value: String?,
+            )
+
+            @Serializable
+            @XmlSerialName("ParameterValue", NS_BSWFS, "fmi")
+            data class ParameterValue(
+                @XmlValue(true) val value: String?,
+            )
+        }
+    }
+}
+
+private const val NS_WFS = "http://www.opengis.net/wfs/2.0"
+private const val NS_BSWFS = "http://xml.fmi.fi/schema/wfs/2.0"

--- a/app/src/src_nonfreenet/org/breezyweather/sources/fmi/xml/FmiStationsResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/fmi/xml/FmiStationsResult.kt
@@ -1,0 +1,74 @@
+package org.breezyweather.sources.fmi.xml
+
+import kotlinx.serialization.Serializable
+import nl.adaptivity.xmlutil.serialization.XmlSerialName
+import nl.adaptivity.xmlutil.serialization.XmlValue
+
+@Serializable
+@XmlSerialName("FeatureCollection", NS_WFS, "fmi")
+data class FmiStationsResult(
+    val members: List<Member>? = null,
+) {
+    @Serializable
+    @XmlSerialName("member", NS_WFS, "fmi")
+    data class Member(
+        val environmentalMonitoringFacility: EnvironmentalMonitoringFacility?,
+    ) {
+        @Serializable
+        @XmlSerialName("EnvironmentalMonitoringFacility", NS_EF, "fmi")
+        data class EnvironmentalMonitoringFacility(
+            val identifier: Identifier?,
+            val name: Name?,
+            val representativePoint: RepresentativePoint?,
+            val mobile: Mobile?,
+            val belongsTo: List<BelongsTo>?,
+        ) {
+            @Serializable
+            @XmlSerialName("identifier", NS_GML, "fmi")
+            data class Identifier(
+                @XmlValue(true) val value: String?,
+            )
+
+            @Serializable
+            @XmlSerialName("name", NS_EF, "fmi")
+            data class Name(
+                @XmlValue(true) val value: String?,
+            )
+
+            @Serializable
+            @XmlSerialName("representativePoint", NS_EF, "fmi")
+            data class RepresentativePoint(
+                val point: Point?,
+            ) {
+                @Serializable
+                @XmlSerialName("Point", NS_GML, "fmi")
+                data class Point(
+                    val pos: Pos?,
+                ) {
+                    @Serializable
+                    @XmlSerialName("pos", NS_GML, "fmi")
+                    data class Pos(
+                        @XmlValue(true) val value: String?,
+                    )
+                }
+            }
+
+            @Serializable
+            @XmlSerialName("mobile", NS_EF, "fmi")
+            data class Mobile(
+                @XmlValue(true) val value: Boolean?,
+            )
+
+            @Serializable
+            @XmlSerialName("belongsTo", NS_EF, "fmi")
+            data class BelongsTo(
+                @XmlSerialName("title", NS_XLINK, "fmi") val title: String?,
+            )
+        }
+    }
+}
+
+private const val NS_WFS = "http://www.opengis.net/wfs/2.0"
+private const val NS_EF = "http://inspire.ec.europa.eu/schemas/ef/4.0"
+private const val NS_GML = "http://www.opengis.net/gml/3.2"
+private const val NS_XLINK = "http://www.w3.org/1999/xlink"

--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -142,7 +142,7 @@ In general, a weather source can be considered for inclusion in the official rel
 ## Europe
 | Country/Territory             | Agency                                                | Status                                                                                | Last Checked |
 |-------------------------------|-------------------------------------------------------|---------------------------------------------------------------------------------------|--------------|
-| 🇦🇽 Åland Is.                |                                                       |                                                                                       |              |
+| 🇦🇽 Åland Is.                | [FMI](https://en.ilmatieteenlaitos.fi/)               | coming soon                                                                           | 2025-08-26   |
 | 🇦🇱 Albania                  |                                                       |                                                                                       |              |
 | 🇦🇩 Andorra                  | [Météo-France](https://meteofrance.com/)              | ✅ included                                                                            |              |
 | 🇦🇹 Austria                  | [GeoSphere Austria](https://www.geosphere.at/)        | ✅ included from v5.2.0                                                                |              |
@@ -157,7 +157,7 @@ In general, a weather source can be considered for inclusion in the official rel
 | 🇩🇰 Denmark                  | [DMI](https://www.dmi.dk)                             | ✅ included from v5.0.0                                                                |              |
 | 🇪🇪 Estonia                  | [Ilmateenistus](https://www.ilmateenistus.ee/)        | ✅ included from v5.4.0                                                                | 2024-12-24   |
 | 🇫🇴 Faroe Is.                | [DMI](https://www.dmi.dk)                             | ✅ included from v5.0.0                                                                |              |
-| 🇫🇮 Finland                  | [FMI](https://en.ilmatieteenlaitos.fi/)               | [data in XML](https://github.com/breezy-weather/breezy-weather/issues/1211)           | 2024-07-22   |
+| 🇫🇮 Finland                  | [FMI](https://en.ilmatieteenlaitos.fi/)               | coming soon                                                                           | 2025-08-26   |
 | 🇫🇷 France                   | [Météo-France](https://meteofrance.com/)              | ✅ included                                                                            |              |
 | 🇬🇪 Georgia                  | [Georgia](https://meteo.gov.ge/)                      |                                                                                       |              |
 | 🇩🇪 Germany                  | [Bright Sky](https://brightsky.dev/)                  | ✅ included from v5.0.0                                                                |              |

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -19,6 +19,7 @@ Below, you can find details about the support and implementation status for feat
 | 🌐 Worldwide                       | [OpenWeather](#openweather) 🔓                                                                    | Forecast, Current, Air quality                                                       |
 | 🌐 Worldwide                       | [Pirate Weather](#pirate-weather) 🔐                                                              | Forecast, Current, Nowcasting, Alerts                                                |
 | 🌐 Worldwide                       | [WMO Severe Weather](#wmo-severe-weather)                                                         | Alerts                                                                               |
+| 🇦🇽 Åland Islands                 | [FMI](#finnish-meteorological-institute)                                                          | Forecast, Current, Air quality, Alerts, Normals                                      |
 | 🇦🇩 Andorra                       | [Météo-France](#météo-france)                                                                     | Forecast, Alert, Normals, Address                                                    |
 | 🇦🇹 Austria                       | [GeoSphere Austria](#geosphere-austria)                                                           | Forecast, Air quality, Nowcasting, Alerts                                            |
 | 🇧🇩 Bangladesh                    | [BMD](#bangladesh-meteorological-department)                                                      | Forecast, Address                                                                    |
@@ -35,6 +36,7 @@ Below, you can find details about the support and implementation status for feat
 | 🇪🇹 Ethiopia                      | [ClimWeb](#climweb)                                                                               | Alerts, Normals                                                                      |
 | 🇫🇰 Falkland Is.                  | [Met Office](#met-office) 🔐                                                                      | Forecast, Address                                                                    |
 | 🇫🇴 Faroe Is.                     | [DMI](#danmarks-meteorologiske-institut)                                                          | Forecast, Alerts, Address                                                            |
+| 🇫🇮 Finland                       | [FMI](#finnish-meteorological-institute)                                                          | Forecast, Current, Air quality, Alerts, Normals                                      |
 | 🇫🇷 France                        | [Météo-France](#météo-france)                                                                     | Forecast, Current, Nowcasting, Alerts, Normals, Address                              |
 | 🇫🇷 France                        | [Atmo France](#atmo-france)                                                                       | Pollen                                                                               |
 | 🇫🇷 France                        | [Recosanté](#recosanté)                                                                           | Pollen                                                                               |
@@ -236,15 +238,15 @@ For the United States, [Forecast Advisor](https://www.forecastadvisor.com/) has 
 
 <details><summary><h4>Details of available data from Pirate Weather</h4></summary>
 
-| Data                      | Available  | Data              | Available    |
-|---------------------------|------------|-------------------|--------------|
-| Weather Condition         | ✅         | Humidity          | ✅           |
-| Temperature               | ✅         | Dew Point         | ✅           |
-| Precipitation             | ✅ (RSI)   | UV Index          | ✅           |
-| Precipitation Probability | ✅         | Sunshine Duration | ❌           |
-| Precipitation Duration    | ❌         | Cloud Cover       | ✅           |
-| Wind                      | ✅         | Visibility        | ✅           |
-| Pressure                  | ✅         | Ceiling           | ❌           |
+| Data                      | Available | Data              | Available |
+|---------------------------|-----------|-------------------|-----------|
+| Weather Condition         | ✅         | Humidity          | ✅         |
+| Temperature               | ✅         | Dew Point         | ✅         |
+| Precipitation             | ✅ (RSI)   | UV Index          | ✅         |
+| Precipitation Probability | ✅         | Sunshine Duration | ❌         |
+| Precipitation Duration    | ❌         | Cloud Cover       | ✅         |
+| Wind                      | ✅         | Visibility        | ✅         |
+| Pressure                  | ✅         | Ceiling           | ❌         |
 </details>
 
 ## National sources
@@ -487,6 +489,37 @@ This source aggregates data from Beijing Meteorological Service, ColorfulClouds 
 | Precipitation Duration    | ❌           | Cloud Cover       | ❌           |
 | Wind                      | ✅           | Visibility        | ✅ (Current) |
 | Pressure                  | ✅ (Current) | Ceiling           | ❌           |
+</details>
+
+### Finnish Meteorological Institute
+> This source will be available in an upcoming release.
+
+**[Finnish Meteorological Institute](https://www.ilmatieteenlaitos.fi/)** is the official meteorological service of Finland, and the Åland Islands.
+
+| Feature                        | Detail                                                           |
+|--------------------------------|------------------------------------------------------------------|
+| 🗺️ **Coverage**               | 🇫🇮 Finland, 🇦🇽 Åland Islands ; air quality for 🌍 Europe     |
+| 📆 **Daily forecast**          | Up to 9 days                                                     |
+| ⏱️ **Hourly forecast**         | Up to 9 days                                                     |
+| ▶️ **Current observation**     | Available: can complement another source as a **Current Source** |
+| 😶‍🌫️ **Air quality**         | Up to 4 days                                                     |
+| 🤧 **Pollen**                  | Not available                                                    |
+| ☔ **Precipitation nowcasting** | Not available                                                    |
+| ⚠️ **Alerts**                  | Available                                                        |
+| 📊 **Normals**                 | Available                                                        |
+| 🧭 **Address lookup**          | Not available                                                    |
+
+<details><summary><h4>Details of available data from Finnish Meteorological Institute</h4></summary>
+
+| Data                      | Available | Data              | Available |
+|---------------------------|-----------|-------------------|-----------|
+| Weather Condition         | ✅         | Humidity          | ✅         |
+| Temperature               | ✅         | Dew Point         | ✅         |
+| Precipitation             | ✅         | UV Index          | ❌         |
+| Precipitation Probability | ✅         | Sunshine Duration | ❌         |
+| Precipitation Duration    | ❌         | Cloud Cover       | ✅         |
+| Wind                      | ✅         | Visibility        | Current   |
+| Pressure                  | ✅         | Ceiling           | ❌         |
 </details>
 
 ### GeoSphere Austria


### PR DESCRIPTION
This update implements Finnish Meteorological Institute as a national source. It supports the following features:
- Forecast (53.9°N to 72.269°N, 4.889°E to 32.931°E)
- Current (Finland only)
- Air Quality Forecast (30°N to 72°N, -24.95°E to 45.049°E - virtually the same area as Copernicus)
- Alert (Finland only)
- Normals (Finland only)

Note that FMI alerts are sent with full polygons of warning areas. I've included a mechanism to compare the region name for a given location against active alert regions, so as not to call the costlier containsPoint() function. But if there is no match, it will still fall back to that function.

Potential to-do list:
- Figure out list of stations to retrieve Air Quality Current
- Pollen