### PR TITLE
Updated CAP to support CWA Typhoon Warnings

### DIFF
--- a/app/src/main/java/org/breezyweather/sources/fpas/FpasService.kt
+++ b/app/src/main/java/org/breezyweather/sources/fpas/FpasService.kt
@@ -125,11 +125,8 @@ class FpasService @Inject constructor(
                                     startDate = start,
                                     endDate = it.expires?.value,
                                     headline = title,
-                                    description = formatAlertText(
-                                        it.senderName?.value,
-                                        it.description?.value
-                                    ),
-                                    instruction = it.instruction?.value,
+                                    description = it.formatAlertText(text = it.description?.value),
+                                    instruction = it.formatAlertText(text = it.instruction?.value),
                                     source = it.senderName?.value,
                                     severity = severity,
                                     color = Alert.colorFromSeverity(severity)
@@ -149,28 +146,6 @@ class FpasService @Inject constructor(
                 }
             )
         }
-    }
-
-    // apply formatting to alert text based on source
-    private fun formatAlertText(
-        source: String?,
-        text: String?,
-    ): String {
-        var result: String
-        if (text.isNullOrEmpty()) {
-            return ""
-        }
-        result = text
-        if (!source.isNullOrEmpty()) {
-            if (source.startsWith("NWS ", ignoreCase = true) ||
-                source.equals("National Weather Service", ignoreCase = true)
-            ) {
-                // Look for SINGLE line breaks surrounded by letters, numbers, and punctuation.
-                val regex = Regex("""([0-9A-Za-z.,]) *\n([0-9A-Za-z])""")
-                result = regex.replace(result, "$1 $2")
-            }
-        }
-        return result.trim()
     }
 
     // CONFIG

--- a/app/src/src_nonfreenet/org/breezyweather/sources/wmosevereweather/WmoSevereWeatherService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/wmosevereweather/WmoSevereWeatherService.kt
@@ -228,8 +228,8 @@ class WmoSevereWeatherService @Inject constructor(
                     ?: xmlAlert.sent?.value,
                 endDate = info.expires?.value ?: originalAlert.endDate,
                 headline = info.headline?.value ?: info.event?.value ?: originalAlert.headline,
-                description = info.description?.value ?: originalAlert.description,
-                instruction = info.instruction?.value ?: originalAlert.instruction,
+                description = info.formatAlertText(text = info.description?.value) ?: originalAlert.description,
+                instruction = info.formatAlertText(text = info.instruction?.value) ?: originalAlert.instruction,
                 source = info.senderName?.value
             )
         } ?: originalAlert


### PR DESCRIPTION
This patch updates the current implementation of CAP Alerts, to support Typhoon Warnings issued by CWA Taiwan as aggregated by NCDR and FPAS.

CWA extends its typhoon-related CAP Alerts with custom tags inside `<description>` elements rather than simple text values, breaking the existing implementation.

As part of the patch, enhanced formatting for CWA alerts is applied similar to Metro-France alerts.