### PR TITLE
Add "Secondary location data" preference

### DIFF
--- a/app/src/main/java/org/breezyweather/domain/settings/SettingsManager.kt
+++ b/app/src/main/java/org/breezyweather/domain/settings/SettingsManager.kt
@@ -476,6 +476,14 @@ class SettingsManager private constructor(
         }
         get() = config.getBoolean("notification_widget_feelslike", false)
 
+    // data sharing
+    var sendSecondaryLocationData: Boolean
+        set(value) {
+            config.edit().putBoolean("send_secondary_location_data", value).apply()
+            notifySettingsChanged()
+        }
+        get() = config.getBoolean("send_secondary_location_data", true)
+
     var useNumberFormatter: Boolean
         set(value) {
             config.edit().putBoolean("use_number_formatter", value).apply()

--- a/app/src/main/java/org/breezyweather/sources/gadgetbridge/GadgetbridgeService.kt
+++ b/app/src/main/java/org/breezyweather/sources/gadgetbridge/GadgetbridgeService.kt
@@ -29,6 +29,7 @@ import org.breezyweather.common.basic.models.options.unit.TemperatureUnit
 import org.breezyweather.common.source.BroadcastSource
 import org.breezyweather.common.utils.helpers.LogHelper
 import org.breezyweather.domain.location.model.getPlace
+import org.breezyweather.domain.settings.SettingsManager
 import org.breezyweather.domain.weather.index.PollutantIndex
 import org.breezyweather.domain.weather.model.getIndex
 import org.breezyweather.sources.gadgetbridge.json.GadgetbridgeAirQuality
@@ -60,14 +61,16 @@ class GadgetbridgeService @Inject constructor() : BroadcastSource {
                 "WeatherJson",
                 Json.encodeToString(getWeatherData(context, allLocations[0]))
             )
-            putString(
-                "WeatherSecondaryJson",
-                Json.encodeToString(
-                    allLocations.drop(1).mapNotNull {
-                        if (it.weather?.current != null) getWeatherData(context, it) else null
-                    }
+            if (SettingsManager.getInstance(context).sendSecondaryLocationData) {
+                putString(
+                    "WeatherSecondaryJson",
+                    Json.encodeToString(
+                        allLocations.drop(1).mapNotNull {
+                            if (it.weather?.current != null) getWeatherData(context, it) else null
+                        }
+                    )
                 )
-            )
+            }
         }
     }
 

--- a/app/src/main/java/org/breezyweather/ui/settings/compose/ModulesSettingsScreen.kt
+++ b/app/src/main/java/org/breezyweather/ui/settings/compose/ModulesSettingsScreen.kt
@@ -411,6 +411,20 @@ fun ModulesSettingsScreen(
                         smallSeparatorItem()
                     }
                 }
+            smallSeparatorItem()
+            switchPreferenceItem(R.string.settings_modules_broadcast_send_secondary_location_data) { id ->
+                SwitchPreferenceView(
+                    titleId = id,
+                    summaryOnId = R.string.settings_enabled,
+                    summaryOffId = R.string.settings_disabled,
+                    checked = SettingsManager.getInstance(context).sendSecondaryLocationData,
+                    isFirst = true,
+                    isLast = true,
+                    onValueChanged = {
+                        SettingsManager.getInstance(context).sendSecondaryLocationData = it
+                    }
+                )
+            }
             sectionFooterItem(R.string.settings_modules_broadcast_title)
 
             bottomInsetItem()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -839,6 +839,7 @@
     <!-- %s is for example Gadgetbridge, as in "Send data of type Gadgetbridge" -->
     <string name="settings_modules_broadcast_send_data_title">Send %s data</string>
     <string name="settings_modules_broadcast_send_data_summary_empty">No compatible packages found</string>
+    <string name="settings_modules_broadcast_send_secondary_location_data">Send secondary location data</string>
     <string name="about_privacy_policy">Privacy policy</string>
     <string name="settings_debug">Debug</string>
     <!-- %s is the string with the key action_grant_permission -->


### PR DESCRIPTION
Gadgetbridge currently crashes when 5 or more locations are saved in Breezy Weather.
Since most wearables don't support showing more than one location, sending secondary location data is usually unnecessary. This PR introduces a switch for sending secondary location data, fixing #1851 
The switch is enabled by default, so secondary location data is still sent by default.