### PR TITLE
Avoid duplicated city/district

### DIFF
--- a/domain/src/main/java/breezyweather/domain/location/model/Location.kt
+++ b/domain/src/main/java/breezyweather/domain/location/model/Location.kt
@@ -264,7 +264,7 @@ data class Location(
             if (city.isNotEmpty()) {
                 builder.append(city)
             }
-            if (!district.isNullOrEmpty()) {
+            if (!district.isNullOrEmpty() && district != city) {
                 if (builder.toString().isNotEmpty()) {
                     builder.append(", ")
                 }


### PR DESCRIPTION
The district and city might be have the same name, this avoids displaying `City, City`