### PR TITLE
Fix back navigation in widget config

### DIFF
--- a/app/src/main/java/org/breezyweather/remoteviews/config/AbstractWidgetConfigActivity.kt
+++ b/app/src/main/java/org/breezyweather/remoteviews/config/AbstractWidgetConfigActivity.kt
@@ -66,7 +66,6 @@ import org.breezyweather.common.extensions.launchUI
 import org.breezyweather.common.options.appearance.CalendarHelper
 import org.breezyweather.common.snackbar.Snackbar
 import org.breezyweather.common.snackbar.SnackbarManager
-import org.breezyweather.common.utils.UnitUtils
 import org.breezyweather.common.utils.helpers.SnackbarHelper
 import org.breezyweather.domain.settings.ConfigStore
 import org.breezyweather.unit.formatting.UnitWidth
@@ -195,9 +194,7 @@ abstract class AbstractWidgetConfigActivity : BreezyActivity() {
 
     private val onBackPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
-            if (mBottomSheetBehavior!!.state == BottomSheetBehavior.STATE_EXPANDED) {
-                setBottomSheetState(true)
-            } else if (
+            if (
                 (System.currentTimeMillis() - mLastBackPressedTime) <
                 (Snackbar.ANIMATION_DURATION + Snackbar.ANIMATION_FADE_DURATION + SnackbarManager.LONG_DURATION_MS)
             ) {


### PR DESCRIPTION
After moving the help for custom subtitles from the app bar (bottom sheet) to a dialog, the back navigation via the system bar and via the back gesture stopped working. Although the bottom sheet stays collapsed, it seems that the state still changes. As a result, when onBackPressedCallback is called, the [first condition](https://github.com/breezy-weather/breezy-weather/blob/568159fc4999bda31693b502dcf7bace1a2fc74a/app/src/main/java/org/breezyweather/remoteviews/config/AbstractWidgetConfigActivity.kt#L198-L199) is met which prevents the user from actually navigating back.

Removing that condition fixes this issue.

Successfully tested on the following devices: Google Pixel 6a (Android 16), LG G6 (Android 9) and an emulated tablet (Android 15).

----

Side note: Since the help for custom subtitles is not part of the bottom sheet anymore, there's no reason to use a bottom sheet for the custom subtitle. We could replace this with a LinearLayout und use a RelativeLayout as [main layout](https://github.com/breezy-weather/breezy-weather/blob/568159fc4999bda31693b502dcf7bace1a2fc74a/app/src/main/res/layout/activity_widget_config.xml#L2) to keep the text input field at the bottom.

I could take care of the changes in a separate PR.