### PR TITLE
Added snow-to-liquid ratio calculation for precipitation

### DIFF
--- a/app/src/main/java/org/breezyweather/sources/CommonConverter.kt
+++ b/app/src/main/java/org/breezyweather/sources/CommonConverter.kt
@@ -51,6 +51,8 @@ import org.breezyweather.unit.computing.computeApparentTemperature
 import org.breezyweather.unit.computing.computeDewPoint
 import org.breezyweather.unit.computing.computeHumidex
 import org.breezyweather.unit.computing.computeRelativeHumidity
+import org.breezyweather.unit.computing.computeTotalPrecipitation
+import org.breezyweather.unit.computing.computeTotalProbabilityOfPrecipitation
 import org.breezyweather.unit.computing.computeWindChillTemperature
 import org.breezyweather.unit.distance.Distance
 import org.breezyweather.unit.distance.Distance.Companion.meters
@@ -259,8 +261,32 @@ internal fun computeMissingHourlyData(
                 computedWindChill = computeWindChillTemperature(temp, wind?.speed),
                 computedHumidex = computeHumidex(temp, dewPoint)
             ),
-            precipitation = precipitation,
-            precipitationProbability = precipitationProbability,
+            precipitation = Precipitation(
+                total =
+                precipitation?.total
+                    ?: computeTotalPrecipitation(
+                        temp,
+                        precipitation?.rain,
+                        precipitation?.snow,
+                        precipitation?.ice
+                    ),
+                thunderstorm = precipitation?.thunderstorm,
+                rain = precipitation?.rain,
+                snow = precipitation?.snow,
+                ice = precipitation?.ice
+            ),
+            precipitationProbability = PrecipitationProbability(
+                total = precipitationProbability?.total ?: computeTotalProbabilityOfPrecipitation(
+                    precipitationProbability?.thunderstorm,
+                    precipitationProbability?.rain,
+                    precipitationProbability?.ice,
+                    precipitationProbability?.snow
+                ),
+                thunderstorm = precipitationProbability?.thunderstorm,
+                rain = precipitationProbability?.rain,
+                snow = precipitationProbability?.snow,
+                ice = precipitationProbability?.ice
+            ),
             wind = wind,
             relativeHumidity = relativeHumidity,
             dewPoint = dewPoint,

--- a/app/src/src_nonfreenet/org/breezyweather/sources/mf/MfService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/mf/MfService.kt
@@ -49,7 +49,6 @@ import org.breezyweather.R
 import org.breezyweather.common.exceptions.InvalidLocationException
 import org.breezyweather.common.extensions.code
 import org.breezyweather.common.extensions.currentLocale
-import org.breezyweather.common.extensions.plus
 import org.breezyweather.common.extensions.toCalendarWithTimeZone
 import org.breezyweather.common.preference.EditTextPreference
 import org.breezyweather.common.preference.Preference
@@ -433,7 +432,6 @@ class MfService @Inject constructor(
             snow1h ?: snow3h ?: snow6h ?: snow12h ?: snow24h
         }
         return Precipitation(
-            total = (rainCumul + snowCumul)?.millimeters,
             rain = rainCumul?.millimeters,
             snow = snowCumul?.millimeters
         )

--- a/app/src/src_nonfreenet/org/breezyweather/sources/openweather/OpenWeatherService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/openweather/OpenWeatherService.kt
@@ -220,7 +220,6 @@ class OpenWeatherService @Inject constructor(
                     feelsLike = result.main?.feelsLike?.celsius
                 ),
                 precipitation = Precipitation(
-                    total = getTotalPrecipitation(result.rain?.cumul3h, result.snow?.cumul3h)?.millimeters,
                     rain = result.rain?.cumul3h?.millimeters,
                     snow = result.snow?.cumul3h?.millimeters
                 ),
@@ -235,18 +234,6 @@ class OpenWeatherService @Inject constructor(
                 cloudCover = result.clouds?.all?.percent,
                 visibility = result.visibility?.meters
             )
-        }
-    }
-
-    // Function that checks for null before sum up
-    private fun getTotalPrecipitation(rain: Double?, snow: Double?): Double? {
-        if (rain == null) {
-            return snow
-        }
-        return if (snow == null) {
-            rain
-        } else {
-            rain + snow
         }
     }
 

--- a/weather-unit/src/main/java/org/breezyweather/unit/computing/PrecipitationComputing.kt
+++ b/weather-unit/src/main/java/org/breezyweather/unit/computing/PrecipitationComputing.kt
@@ -1,0 +1,106 @@
+/*
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.unit.computing
+
+import org.breezyweather.unit.precipitation.Precipitation
+import org.breezyweather.unit.precipitation.Precipitation.Companion.micrometers
+import org.breezyweather.unit.ratio.Ratio
+import org.breezyweather.unit.ratio.Ratio.Companion.permille
+import org.breezyweather.unit.temperature.Temperature
+import kotlin.math.roundToLong
+
+/**
+ * Compute total precipitation in liquid equivalent.
+ * Uses Cobb-Waldstreicher method (2011 version) for snow.
+ * (X inches of snow = 1 inch of water equivalent, varies with temperature)
+ * Uses 0.92 as ratio for ice equivalent:
+ *  - density of ice at 0°C = 916.2 kg/m³
+ *  - density of water at 0°C = 999.8 kg/m³
+ * Ice density increases insignificantly as temperature drops further.
+ * 0.92 is a good enough approximation without adding unnecessary computation.
+ * Source: https://www.engineeringtoolbox.com/ice-thermal-properties-d_576.html
+ */
+fun computeTotalPrecipitation(
+    temperature: Temperature?,
+    rain: Precipitation?,
+    snow: Precipitation?,
+    ice: Precipitation?,
+): Precipitation? {
+    if (rain == null && snow == null && ice == null) return null
+    val snowEquivalent = snow?.value?.div(computeSnowToLiquidRatio(temperature))?.roundToLong()
+    val iceEquivalent = ice?.value?.times(0.92)?.roundToLong()
+    return (rain?.value ?: 0).plus(snowEquivalent ?: 0).plus(iceEquivalent ?: 0).micrometers
+}
+
+fun computeTotalProbabilityOfPrecipitation(
+    thunderstorm: Ratio?,
+    rain: Ratio?,
+    snow: Ratio?,
+    ice: Ratio?,
+): Ratio? {
+    if (thunderstorm == null && rain == null && snow == null && ice == null) return null
+    return maxOf(thunderstorm?.value ?: 0, rain?.value ?: 0, snow?.value ?: 0, ice?.value ?: 0).permille
+}
+
+private fun computeSnowToLiquidRatio(
+    temperature: Temperature?,
+): Double {
+    if (temperature == null) {
+        return 7.2
+    }
+    SNOW_TO_LIQUID_RATIOS.forEachIndexed { i, ratio ->
+        if (i >= SNOW_TO_LIQUID_RATIOS.size - 1) { // > 300°C
+            return ratio.second
+        }
+        val next = SNOW_TO_LIQUID_RATIOS[i + 1]
+        if (temperature.inCelsius >= ratio.first && temperature.inCelsius < next.first) {
+            return ratio.second +
+                (next.second - ratio.second) / (next.first - ratio.first) *
+                (temperature.inCelsius - ratio.first)
+        }
+    }
+    // Theoretically we should never reach this.
+    return 1.0
+}
+
+/**
+ * Snow to liquid ratios based on the 2011 version of the
+ * Cobb-Waldstreicher method. Ratio is set to 1.0 for
+ * temperatures above freezing.
+ * Source: https://www.weather.gov/media/mdl/SLR.pdf
+ */
+private val SNOW_TO_LIQUID_RATIOS = listOf(
+    Pair(-300.0, 7.2),
+    Pair(-30.0, 7.2),
+    Pair(-28.0, 6.8),
+    Pair(-26.0, 7.0),
+    Pair(-24.0, 8.8),
+    Pair(-22.0, 12.0),
+    Pair(-20.0, 18.0),
+    Pair(-18.0, 23.0),
+    Pair(-16.0, 26.0),
+    Pair(-14.0, 22.5),
+    Pair(-12.0, 17.5),
+    Pair(-10.0, 12.0),
+    Pair(-8.0, 9.5),
+    Pair(-6.0, 9.0),
+    Pair(-4.0, 8.5),
+    Pair(-2.0, 7.0),
+    Pair(0.0, 3.0),
+    Pair(1.0, 1.0),
+    Pair(300.0, 1.0)
+)


### PR DESCRIPTION
Snowfall is much less dense than rainfall. One should not add rainfall and snowfall directly to calculate total precipitation. Common convention (in the US) is to convert 10 units of snowfall to 1 unit of rainfall, however the ratio varies greatly with temperature.

Snow is "wetter" and denser at warmer temperatures, and looser at colder temperatures, up to a certain point. At 0°C, 3 units of snowfall is equivalent to 1 unit of rainfall; but at −16°C, the ratio peaks at 26 units of snow to 1 unit of rain.

This patch adds conversion of snow to liquid equivalent by calculating the snow-to-liquid ratio at various temperatures, using the Cobb-Waldstreicher method (2011 version). It also removes the direct additions in MF and OpenWeather, and patches `CommonConverter.kt` to fill in the missing total instead.