### PR TITLE
Fix weather background reappearing briefly when scrolling

### DIFF
--- a/app/src/main/java/org/breezyweather/ui/main/layouts/MainLayoutManager.kt
+++ b/app/src/main/java/org/breezyweather/ui/main/layouts/MainLayoutManager.kt
@@ -26,6 +26,7 @@ class MainLayoutManager(
 ) : GridLayoutManager(context, spanCount, RecyclerView.VERTICAL, false) {
 
     private var mDataSetChanged = false
+    private val childHeightMap = mutableMapOf<Int, Int>()
 
     init {
         recycleChildrenOnDetach = true
@@ -49,6 +50,30 @@ class MainLayoutManager(
             mDataSetChanged = false
         }
         super.onLayoutChildren(recycler, state)
+    }
+
+    /**
+     * Source: https://stackoverflow.com/a/50925862
+     */
+    override fun onLayoutCompleted(state: RecyclerView.State?) {
+        super.onLayoutCompleted(state)
+        for (i in 0 until childCount) {
+            getChildAt(i)?.let {
+                childHeightMap[getPosition(it)] = it.height
+            }
+        }
+    }
+
+    override fun computeVerticalScrollOffset(state: RecyclerView.State): Int {
+        if (childCount == 0) {
+            return 0
+        }
+
+        return getChildAt(0)?.let { firstVisibleChild ->
+            (0 until getPosition(firstVisibleChild)).sumOf {
+                childHeightMap[it] ?: 0
+            } - firstVisibleChild.y.toInt()
+        } ?: 0
     }
 }
 /* ) : LinearLayoutManager(context, RecyclerView.VERTICAL, false) {


### PR DESCRIPTION
Closes #2241.

This applies the solution mentioned in [my comment](https://github.com/breezy-weather/breezy-weather/issues/2241#issuecomment-3275532358) in the issue and uses a custom approach for accurately calculating the vertical scroll offset for the `recyclerView` in the `HomeFragment`.

Successfully tested on the following devices: Google Pixel 6a (Android 16) and LG G6 (Android 9).

Side note: The solution in [MainLayoutManager](https://github.com/breezy-weather/breezy-weather/blob/d86e61af237e53bae268861c8f59b8ae228c57a2/app/src/main/java/org/breezyweather/ui/main/layouts/MainLayoutManager.kt#L119) used in previous versions should also work, but I found the approach I linked in the issue more comprehensible.