### PR TITLE
Add Thunderstorm support for Pirate Weather and update docs

### DIFF
--- a/app/src/main/java/org/breezyweather/sources/pirateweather/PirateWeatherService.kt
+++ b/app/src/main/java/org/breezyweather/sources/pirateweather/PirateWeatherService.kt
@@ -317,6 +317,7 @@ class PirateWeatherService @Inject constructor(
             "clear-day", "clear-night" -> WeatherCode.CLEAR
             "partly-cloudy-day", "partly-cloudy-night" -> WeatherCode.PARTLY_CLOUDY
             "cloudy" -> WeatherCode.CLOUDY
+            "thunderstorm" -> WeatherCode.THUNDERSTORM
             else -> null
         }
     }

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -222,7 +222,7 @@ For the United States, [Forecast Advisor](https://www.forecastadvisor.com/) has 
 |--------------------------------|---------------------------------------------------------------------|
 | 🗺️ **Coverage**               | 🌐 Worldwide (some features may not be available for all locations) |
 | 📆 **Daily forecast**          | Up to 8 days                                                        |
-| ⏱️ **Hourly forecast**         | Up to 2 days                                                        |
+| ⏱️ **Hourly forecast**         | Up to 7 days                                                        |
 | ▶️ **Current observation**     | Available: can complement another source as a **Current Source**    |
 | 😶‍🌫️ **Air quality**         | Not available                                                       |
 | 🤧 **Pollen**                  | Not available                                                       |
@@ -235,14 +235,14 @@ For the United States, [Forecast Advisor](https://www.forecastadvisor.com/) has 
 
 <details><summary><h4>Details of available data from Pirate Weather</h4></summary>
 
-| Data                      | Available | Data              | Available   |
-|---------------------------|-----------|-------------------|-------------|
+| Data                      | Available  | Data              | Available    |
+|---------------------------|------------|-------------------|--------------|
 | Weather Condition         | ✅         | Humidity          | ✅           |
 | Temperature               | ✅         | Dew Point         | ✅           |
-| Precipitation             | ✅ (RS)    | UV Index          | ✅           |
+| Precipitation             | ✅ (RSI)   | UV Index          | ✅           |
 | Precipitation Probability | ✅         | Sunshine Duration | ❌           |
 | Precipitation Duration    | ❌         | Cloud Cover       | ✅           |
-| Wind                      | ✅         | Visibility        | ✅ (Current) |
+| Wind                      | ✅         | Visibility        | ✅           |
 | Pressure                  | ✅         | Ceiling           | ❌           |
 </details>
 

--- a/docs/TECHNICAL.md
+++ b/docs/TECHNICAL.md
@@ -177,26 +177,15 @@ https://openweathermap.org/api
 
 ## Pirate Weather
 
-*Last checked: 2024-04-16*
+*Last checked: 2025-10-30*
 
 https://github.com/Pirate-Weather/pirateweather
 
-| Endpoint | Version | Notes                  |
-|----------|---------|------------------------|
-| Forecast | v1.5.6  | V2.0 is in pre-release |
+| Endpoint | Version  | Notes                  |
+|----------|----------|------------------------|
+| Forecast | v2.7.11  | V2.8 is in pre-release |
 
 We should check regularly for additional fields we could use. Latest version checked is written above, everything more recent requires to check changelog.
-
-
-## HERE
-
-*Last checked: 2024-02-13*
-
-| Endpoint            | Version    | Documentation                                                                                  |
-|---------------------|------------|------------------------------------------------------------------------------------------------|
-| Weather Destination | v3         | https://www.here.com/docs/bundle/here-destination-weather-api-v3-api-reference/page/index.html |
-| Geocode             | v1 (7.116) | https://www.here.com/docs/bundle/geocoding-and-search-api-v7-api-reference/page/index.html     |
-| Reverse geocode     | v1 (7.116) | https://www.here.com/docs/bundle/geocoding-and-search-api-v7-api-reference/page/index.html     |
 
 
 ## Météo-France


### PR DESCRIPTION
Starting in the next API version `thunderstorm` will be a valid icon returned by Pirate Weather. It's also stated in [the docs also](https://pirateweather.net/en/latest/API/#icon_1) that `hail` and `mixed` might be included in the future. Do you want me to add support for them in this PR or wait until they get added to add support?

I also updated the documentation as the docs for Pirate Weather were a bit outdated.

- Updated forecast to 7 days in SOURCES.MD
- Updated precipitation to include ice in SOURCES.MD
- Removed (current) from visibility in SOURCES.MD
- Updated version in TECHNICAL.MD
- Removed HERE from TECHNICAL.MD as was removed from Breezy Weather