### PR TITLE
Fix double encoding in `ChinaService`

### DIFF
--- a/app/src/src_nonfreenet/org/breezyweather/sources/china/ChinaService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/china/ChinaService.kt
@@ -117,7 +117,7 @@ class ChinaService @Inject constructor(
                 location.latitude,
                 location.longitude,
                 location.isCurrentPosition,
-                locationKey = "weathercn%3A$locationKey",
+                locationKey = "weathercn:$locationKey",
                 days = 15,
                 appKey = CHINA_APP_KEY,
                 sign = CHINA_SIGN,


### PR DESCRIPTION
Close #2362.

`%3A` results in double encoding, which now leads to empty response from the API.