### PR TITLE
[Pirate Weather] Replace temperatureHigh/temperatureLow with temperat…

### DIFF
--- a/app/src/main/java/org/breezyweather/sources/pirateweather/PirateWeatherService.kt
+++ b/app/src/main/java/org/breezyweather/sources/pirateweather/PirateWeatherService.kt
@@ -191,18 +191,16 @@ class PirateWeatherService @Inject constructor(
                     weatherSummary = result.summary,
                     weatherCode = getWeatherCode(result.icon),
                     temperature = TemperatureWrapper(
-                        temperature = result.temperatureHigh?.celsius,
-                        feelsLike = result.apparentTemperatureHigh?.celsius
+                        temperature = result.temperatureMax?.celsius,
+                        feelsLike = result.apparentTemperatureMax?.celsius
                     )
                 ),
                 night = HalfDayWrapper(
                     weatherSummary = result.summary,
                     weatherCode = getWeatherCode(result.icon),
-                    // temperatureLow/High are always forward-looking
-                    // See https://docs.pirateweather.net/en/latest/API/#temperaturelow
                     temperature = TemperatureWrapper(
-                        temperature = result.temperatureLow?.celsius,
-                        feelsLike = result.apparentTemperatureLow?.celsius
+                        temperature = result.temperatureMin?.celsius,
+                        feelsLike = result.apparentTemperatureMin?.celsius
                     )
                 ),
                 uV = UV(index = result.uvIndex),

--- a/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherDaily.kt
+++ b/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherDaily.kt
@@ -24,10 +24,10 @@ data class PirateWeatherDaily(
     val icon: String?,
     val summary: String?,
 
-    val temperatureHigh: Double?,
-    val temperatureLow: Double?,
-    val apparentTemperatureHigh: Double?,
-    val apparentTemperatureLow: Double?,
+    val temperatureMax: Double?,
+    val temperatureMin: Double?,
+    val apparentTemperatureMax: Double?,
+    val apparentTemperatureMin: Double?,
 
     val dewPoint: Double?,
     val humidity: Double?,


### PR DESCRIPTION
According to Pirate Weather's [doc](https://pirateweather.net/en/latest/API):

`temperatureHigh`
Only on daily. The daytime high temperature calculated between 6:01 am and 6:00 pm local time.

`temperatureLow`
Only on daily. The overnight low temperature calculated between 6:01 pm and 6:00 am local time.

`temperatureMax`
Only on daily. The maximum temperature calculated between 12:00 am and 11:59 pm local time.

`temperatureMin`
Only on daily. The minimum temperature calculated between 12:00 am and 11:59 pm local time.

`temperatureMax`/`temperatureMin` are the highest/lowest temperatures of the day. They should be put on the daily chart instead of `temperatureHigh`/`temperatureLow`.