### PR TITLE
Patched NCDR to use new API endpoint

### DIFF
--- a/app/src/src_nonfreenet/org/breezyweather/sources/ncdr/NcdrApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/ncdr/NcdrApi.kt
@@ -24,7 +24,7 @@ import retrofit2.http.GET
 import retrofit2.http.Url
 
 interface NcdrApi {
-    @GET("RssAtomFeeds.ashx")
+    @GET("webapi/RssAtomFeeds.ashx")
     fun getAlerts(): Call<NcdrAlertsResult>
 
     @GET


### PR DESCRIPTION
Patched NCDR to switch to a new API endpoint, as the [existing one will be decommissioned on March 31, 2026](https://alerts.ncdr.nat.gov.tw/web/home/news/1000027).

CWA alerts are still available on the new API endpoint without signing up for an API key. Most other alerts are behind the API wall.