### PR TITLE
Fix #2583 - Patched Pirate Weather to respect user unit settings

### DIFF
--- a/app/src/src_nonfreenet/org/breezyweather/sources/accu/AccuService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/accu/AccuService.kt
@@ -166,6 +166,8 @@ class AccuService @Inject constructor(
         } else {
             "en"
         }
+        // Using precipitation unit setting as a proxy of whether to use metric or imperial units.
+        // This is because AccuWeather's summary text reports precipitation amounts rather than temperature.
         val metric = SettingsManager.getInstance(context).getPrecipitationUnit(context) != PrecipitationUnit.INCH
         val failedFeatures = mutableMapOf<SourceFeature, Throwable>()
         val current = if (SourceFeature.CURRENT in requestedFeatures) {


### PR DESCRIPTION
This PR patched Pirate Weather source to call its endpoint with either `si` or `imperial` units based on user's unit setting. This way it will show daily summary texts with temperature figures matching the user's preference when it's used as a Current source.

This fixes #2583.