### PR TITLE
Fix #2419 - Patched FPAS to handle duplicate Roshydromet alerts

### DIFF
--- a/app/src/main/java/org/breezyweather/sources/common/xml/CapAlert.kt
+++ b/app/src/main/java/org/breezyweather/sources/common/xml/CapAlert.kt
@@ -37,6 +37,7 @@ import java.util.Date
 @XmlSerialName("alert", "urn:oasis:names:tc:emergency:cap:1.2", "cap")
 data class CapAlert(
     val identifier: Identifier? = null,
+    val sender: Sender? = null,
     val sent: Sent? = null,
     val msgType: MsgType? = null,
     val info: List<Info>? = null,
@@ -44,6 +45,12 @@ data class CapAlert(
     @Serializable
     @XmlSerialName("identifier", "", "cap")
     data class Identifier(
+        @XmlValue(true) val value: String? = null,
+    )
+
+    @Serializable
+    @XmlSerialName("sender", "", "cap")
+    data class Sender(
         @XmlValue(true) val value: String? = null,
     )
 


### PR DESCRIPTION
Roshydromet transmits separate CAP alerts (Russian headline and English headline) for the same event, which get picked up by FPAS as two separate alerts. This patch identifies alerts that belong to the same event by matching parts of the alert IDs, and eliminate versions based on user language preference.