### PR TITLE
feat: implemented Pirate Weather API V2 features

### DIFF
--- a/app/src/main/java/org/breezyweather/sources/pirateweather/PirateWeatherApi.kt
+++ b/app/src/main/java/org/breezyweather/sources/pirateweather/PirateWeatherApi.kt
@@ -33,7 +33,10 @@ interface PirateWeatherApi {
         @Path("lon") lon: Double,
         @Query("units") units: String,
         @Query("lang") lang: String,
+        @Query("include") include: String?,
         @Query("exclude") exclude: String?,
         @Query("extend") extend: String?,
+        @Query("icon") icon: String?,
+        @Query("version") version: String?,
     ): Observable<PirateWeatherForecastResult>
 }

--- a/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherDayNight.kt
+++ b/app/src/main/java/org/breezyweather/sources/pirateweather/json/PirateWeatherDayNight.kt
@@ -16,15 +16,23 @@
 
 package org.breezyweather.sources.pirateweather.json
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class PirateWeatherForecastResult(
-    val currently: PirateWeatherCurrently?,
-    val minutely: PirateWeatherForecast<PirateWeatherMinutely>?,
-    val hourly: PirateWeatherForecast<PirateWeatherHourly>?,
-    @SerialName("day_night") val dayNight: PirateWeatherForecast<PirateWeatherDayNight>?,
-    val daily: PirateWeatherForecast<PirateWeatherDaily>?,
-    val alerts: List<PirateWeatherAlert>?,
+data class PirateWeatherDayNight(
+    val time: Long,
+    val summary: String?,
+    val icon: String?,
+
+    val precipProbability: Double?,
+    val liquidAccumulation: Double?,
+    val snowAccumulation: Double?,
+    val iceAccumulation: Double?,
+
+    val temperature: Double?,
+    val apparentTemperature: Double?,
+
+    val windSpeed: Double?,
+    val windGust: Double?,
+    val windBearing: Double?,
 )


### PR DESCRIPTION
Implemented the following API V2 features for Pirate Weather:

- `day_night` block with [half-day forecasts](https://docs.pirateweather.net/en/latest/API/#day_night)
- [extended icon set](https://docs.pirateweather.net/en/latest/API/#icon_1)
- [additional properties](https://docs.pirateweather.net/en/latest/API/#version) such as `liquidAccumulation`, `snowAccumulation` and `iceAccumulation`

fix #2591