### PR TITLE
feat: expanded summary texts for HKO and SMG sources

### DIFF
--- a/app/src/src_nonfreenet/org/breezyweather/sources/smg/SmgApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/smg/SmgApi.kt
@@ -20,6 +20,7 @@ import io.reactivex.rxjava3.core.Observable
 import org.breezyweather.sources.smg.json.SmgBulletinResult
 import org.breezyweather.sources.smg.json.SmgCurrentResult
 import org.breezyweather.sources.smg.json.SmgForecastResult
+import org.breezyweather.sources.smg.json.SmgOutlookResult
 import org.breezyweather.sources.smg.json.SmgUvResult
 import org.breezyweather.sources.smg.json.SmgWarningResult
 import retrofit2.http.POST
@@ -42,6 +43,11 @@ interface SmgApi {
         @Query("selection") selection: String = "forecast",
         @Query("lang") lang: String = "e",
     ): Observable<SmgBulletinResult>
+
+    @POST("weather_v2")
+    fun getOutlook(
+        @Query("selection") selection: String = "weatherForecastDesc",
+    ): Observable<SmgOutlookResult>
 
     @POST("weather_v2")
     fun getCurrent(

--- a/app/src/src_nonfreenet/org/breezyweather/sources/smg/json/SmgOutlookCustom.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/smg/json/SmgOutlookCustom.kt
@@ -14,13 +14,12 @@
  * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.breezyweather.sources.hko.json
+package org.breezyweather.sources.smg.json
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class HkoOneJsonFlw(
-    val GeneralSituation: String?,
-    val OutlookContent: String?,
-    val Icon1: String?,
+data class SmgOutlookCustom(
+    @SerialName("WeatherForecastDescReport") val Report: List<SmgOutlookReport>?,
 )

--- a/app/src/src_nonfreenet/org/breezyweather/sources/smg/json/SmgOutlookDescription.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/smg/json/SmgOutlookDescription.kt
@@ -14,13 +14,13 @@
  * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.breezyweather.sources.hko.json
+package org.breezyweather.sources.smg.json
 
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class HkoOneJsonFlw(
-    val GeneralSituation: String?,
-    val OutlookContent: String?,
-    val Icon1: String?,
+data class SmgOutlookDescription(
+    val Chinese: List<String>?,
+    val Portuguese: List<String>?,
+    val English: List<String>?,
 )

--- a/app/src/src_nonfreenet/org/breezyweather/sources/smg/json/SmgOutlookReport.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/smg/json/SmgOutlookReport.kt
@@ -14,13 +14,11 @@
  * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.breezyweather.sources.hko.json
+package org.breezyweather.sources.smg.json
 
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class HkoOneJsonFlw(
-    val GeneralSituation: String?,
-    val OutlookContent: String?,
-    val Icon1: String?,
+data class SmgOutlookReport(
+    val Description: List<SmgOutlookDescription>?,
 )

--- a/app/src/src_nonfreenet/org/breezyweather/sources/smg/json/SmgOutlookResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/smg/json/SmgOutlookResult.kt
@@ -14,13 +14,12 @@
  * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.breezyweather.sources.hko.json
+package org.breezyweather.sources.smg.json
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class HkoOneJsonFlw(
-    val GeneralSituation: String?,
-    val OutlookContent: String?,
-    val Icon1: String?,
+data class SmgOutlookResult(
+    @SerialName("WeatherForecastDesc") val Forecast: SmgOutlookRoot? = null,
 )

--- a/app/src/src_nonfreenet/org/breezyweather/sources/smg/json/SmgOutlookRoot.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/smg/json/SmgOutlookRoot.kt
@@ -14,13 +14,11 @@
  * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
  */
 
-package org.breezyweather.sources.hko.json
+package org.breezyweather.sources.smg.json
 
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class HkoOneJsonFlw(
-    val GeneralSituation: String?,
-    val OutlookContent: String?,
-    val Icon1: String?,
+data class SmgOutlookRoot(
+    val Custom: List<SmgOutlookCustom>?,
 )


### PR DESCRIPTION
This PR implements summary texts from HKO and SMG in the following contexts:

- [HKO outlook](https://www.hko.gov.hk/en/wxinfo/currwx/flw.htm)
e.g. "Still warm during the day on Sunday. Relatively humid early to midweek next week. Windier on Monday. Warm during the day on Tuesday."
- [HKO 9-day forecast](https://www.hko.gov.hk/en/wxinfo/currwx/fnd.htm)
e.g. "Sunny periods. Warm during the day."
- [SMG 7-day forecast and week-long outlook](https://www.smg.gov.mo/en/subpage/83/7daysforecast)
e.g. "Fine apart from cloudy periods. Force 2 to 3 southeasterly winds."
and "Plenty of sunshine is expected during the day in the next couple of days. …"

The newly included texts are available in English (both sources), Traditional Chinese (both sources), Simplified Chinese (HKO), and Portuguese (SMG).

Fix #2595