### PR TITLE
GadgetBridge: indicate whether a given weather location is current

### DIFF
--- a/app/src/main/kotlin/org/breezyweather/sources/gadgetbridge/GadgetbridgeService.kt
+++ b/app/src/main/kotlin/org/breezyweather/sources/gadgetbridge/GadgetbridgeService.kt
@@ -107,7 +107,7 @@ class GadgetbridgeService @Inject constructor() : BroadcastSource {
             moonRise = today?.moon?.riseDate?.time?.div(1000)?.toInt(),
             moonSet = today?.moon?.setDate?.time?.div(1000)?.toInt(),
             moonPhase = today?.moonPhase?.angle,
-
+            isCurrentLocation = if (location.isCurrentPosition) 1 else 0,
             airQuality = getAirQuality(current?.airQuality),
 
             forecasts = getDailyForecasts(location.weather?.dailyForecastStartingToday),

--- a/app/src/main/kotlin/org/breezyweather/sources/gadgetbridge/json/GadgetbridgeData.kt
+++ b/app/src/main/kotlin/org/breezyweather/sources/gadgetbridge/json/GadgetbridgeData.kt
@@ -46,6 +46,7 @@ data class GadgetbridgeData(
     val moonSet: Int? = null,
     val moonPhase: Int? = null,
     val feelsLikeTemp: Int? = null,
+    var isCurrentLocation: Int = -1,
     val forecasts: List<GadgetbridgeDailyForecast>? = null,
     val hourly: List<GadgetbridgeHourlyForecast>? = null,
     val airQuality: GadgetbridgeAirQuality? = null,


### PR DESCRIPTION
Two-line fix to resolve #2706. With this change, the JSON we send to GadgetBridge now indicates whether the location is the current location.

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [X] I read the [rules for contributions](https://github.com/breezy-weather/breezy-weather/blob/main/CONTRIBUTE.md)
- [ ] I’m contributing to an issue/idea tagged “Open to contributions”, or an [org member](https://github.com/orgs/breezy-weather/people) gave me permission to work on this
- [ ] I was assisted by AI
