### PR TITLE
Infoplaza - Use hourly UV index from API

### DIFF
--- a/app/src/src_nonfreenet/org/breezyweather/sources/infoplaza/InfoplazaService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/infoplaza/InfoplazaService.kt
@@ -269,6 +269,7 @@ class InfoplazaService @Inject constructor(
                 dewPoint = result.dewPoint?.celsius,
                 pressure = result.pressure?.hectopascals,
                 cloudCover = result.cloudCover?.fraction,
+                uV = UV(index = result.uvIndex),
                 visibility = result.visibility?.meters
             )
         }

--- a/app/src/src_nonfreenet/org/breezyweather/sources/infoplaza/json/InfoplazaHourly.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/infoplaza/json/InfoplazaHourly.kt
@@ -34,5 +34,6 @@ data class InfoplazaHourly(
     val windGust: Double?,
     val windBearing: Double?,
     val cloudCover: Double?,
+    val uvIndex: Double?,
     val visibility: Double?,
 )


### PR DESCRIPTION
Currently the UV index from the day is used to calculate the hourly UV index, which can be very inaccurate. The API does send an UV index per hour, so this PR changes it so it makes use of the hourly UV index.

---

Please check all the boxes that apply:

- [x] I read the [rules for contributions](https://github.com/breezy-weather/breezy-weather/blob/main/CONTRIBUTE.md)
- [x] I’m contributing to an issue/idea tagged “Open to contributions”, or an [org member](https://github.com/orgs/breezy-weather/people) gave me permission to work on this
- [ ] I was assisted by AI
