### PR TITLE
AEMET: fix daily's night wind speed and current's visibility units

### DIFF
--- a/app/src/src_nonfreenet/org/breezyweather/sources/aemet/AemetService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/aemet/AemetService.kt
@@ -52,7 +52,7 @@ import org.breezyweather.sources.aemet.json.AemetHourlyResult
 import org.breezyweather.sources.aemet.json.AemetNormalsResult
 import org.breezyweather.sources.aemet.json.AemetStationsResult
 import org.breezyweather.sources.getWindDegree
-import org.breezyweather.unit.distance.Distance.Companion.meters
+import org.breezyweather.unit.distance.Distance.Companion.kilometers
 import org.breezyweather.unit.precipitation.Precipitation.Companion.millimeters
 import org.breezyweather.unit.pressure.Pressure.Companion.hectopascals
 import org.breezyweather.unit.ratio.Ratio.Companion.percent
@@ -243,7 +243,7 @@ class AemetService @Inject constructor(
                 relativeHumidity = it.hr?.percent,
                 dewPoint = it.tpr?.celsius,
                 pressure = it.pres?.hectopascals,
-                visibility = it.vis?.meters
+                visibility = it.vis?.kilometers
             )
         }
     }
@@ -351,8 +351,8 @@ class AemetService @Inject constructor(
                         ),
                         wind = Wind(
                             degree = wdMap.getOrElse(key) { null },
-                            speed = wsMap.getOrElse(key) { null }?.metersPerSecond,
-                            gusts = wgMap.getOrElse(key) { null }?.metersPerSecond
+                            speed = wsMap.getOrElse(key) { null }?.kilometersPerHour,
+                            gusts = wgMap.getOrElse(key) { null }?.kilometersPerHour
                         )
                     ),
                     relativeHumidity = DailyRelativeHumidity(


### PR DESCRIPTION
Daily's night should use km/h for wind speed. Relevant metadata excerpt:

```
{
  "id": "velocidad",
  "descripcion": "Velocidad del viento",
  "tipo_datos": "string",
  "unidad": "Kilómetros por hora (km/h)",
...
```

Daily's day already uses km/h for wind speed, so is correct.

Current's visibility should use km as a distance unit. Relevant metadata excerpt:

```
{
  "id": "vis",
  "descripcion": "Visibilidad, promedio de la medida de la visibilidad correspondiente a los 10 minutos anteriores a la fecha dada por 'fint' (Km)",
  ...
```

<!-- Please put the pull request description above -->

---

Please check all the boxes that apply:

- [x] I read the [rules for contributions](https://github.com/breezy-weather/breezy-weather/blob/main/CONTRIBUTE.md)
- [ ] I’m contributing to an issue/idea tagged “Open to contributions”, or an [org member](https://github.com/orgs/breezy-weather/people) gave me permission to work on this
- [x] I was assisted by AI
