### PR TITLE
Implemented IMGW data source

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -81,6 +81,7 @@ jobs:
           echo "breezy.cwa.key=$CWA_KEY" >> local.properties
           echo "breezy.eccc.key=$ECCC_KEY" >> local.properties
           echo "breezy.geonames.key=$GEO_NAMES_KEY" >> local.properties
+          echo "breezy.imgw.token=$IMGW_TOKEN" >> local.properties
           echo "breezy.metie.key=$MET_IE_KEY" >> local.properties
           echo "breezy.mf.jwtKey=$MF_WSFT_JWT_KEY" >> local.properties
           echo "breezy.mf.key=$MF_WSFT_KEY" >> local.properties
@@ -98,6 +99,7 @@ jobs:
           CWA_KEY: ${{ secrets.CWA_KEY }}
           ECCC_KEY: ${{ secrets.ECCC_KEY }}
           GEO_NAMES_KEY: ${{ secrets.GEO_NAMES_KEY }}
+          IMGW_TOKEN: ${{ secrets.IMGW_TOKEN }}
           MET_IE_KEY: ${{ secrets.MET_IE_KEY }}
           MF_WSFT_JWT_KEY: ${{ secrets.MF_WSFT_JWT_KEY }}
           MF_WSFT_KEY: ${{ secrets.MF_WSFT_KEY }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -299,6 +299,11 @@ configure<ApplicationExtension> {
         )
         it.buildConfigField(
             "String",
+            "IMGW_TOKEN",
+            "\"${localProperties.getProperty("breezy.imgw.token") ?: ""}\""
+        )
+        it.buildConfigField(
+            "String",
             "MET_IE_KEY",
             "\"${localProperties.getProperty("breezy.metie.key") ?: ""}\""
         )

--- a/app/src/main/kotlin/org/breezyweather/sources/SourceManager.kt
+++ b/app/src/main/kotlin/org/breezyweather/sources/SourceManager.kt
@@ -89,6 +89,7 @@ import org.breezyweather.sources.geosphereat.GeoSphereAtService
 import org.breezyweather.sources.hko.HkoService
 import org.breezyweather.sources.ilmateenistus.IlmateenistusService
 import org.breezyweather.sources.imd.ImdService
+import org.breezyweather.sources.imgw.ImgwService
 import org.breezyweather.sources.ims.ImsService
 import org.breezyweather.sources.infoplaza.InfoplazaService
 import org.breezyweather.sources.ipma.IpmaService
@@ -164,6 +165,7 @@ class SourceManager @Inject constructor(
     igebuService: IgebuService,
     ilmateenistusService: IlmateenistusService,
     imdService: ImdService,
+    imgwService: ImgwService,
     imsService: ImsService,
     infoplazaService: InfoplazaService,
     inmgbService: InmgbService,
@@ -269,6 +271,7 @@ class SourceManager @Inject constructor(
         igebuService,
         ilmateenistusService,
         imdService,
+        imgwService,
         imsService,
         inmgbService,
         ipmaService,

--- a/app/src/main/kotlin/org/breezyweather/sources/imgw/ImgwServiceStub.kt
+++ b/app/src/main/kotlin/org/breezyweather/sources/imgw/ImgwServiceStub.kt
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.imgw
+
+import android.content.Context
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.source.SourceContinent
+import breezyweather.domain.source.SourceFeature
+import org.breezyweather.BuildConfig
+import org.breezyweather.common.extensions.code
+import org.breezyweather.common.extensions.currentLocale
+import org.breezyweather.common.extensions.getCountryName
+import org.breezyweather.common.source.HttpSource
+import org.breezyweather.common.source.LocationParametersSource
+import org.breezyweather.common.source.NonFreeNetSource
+import org.breezyweather.common.source.ReverseGeocodingSource
+import org.breezyweather.common.source.WeatherSource
+import org.breezyweather.common.source.WeatherSource.Companion.PRIORITY_HIGHEST
+import org.breezyweather.common.source.WeatherSource.Companion.PRIORITY_NONE
+import org.breezyweather.domain.settings.SourceConfigStore
+import kotlin.text.startsWith
+
+abstract class ImgwServiceStub(context: Context) :
+    HttpSource(),
+    WeatherSource,
+    NonFreeNetSource {
+
+    override val id = "imgw"
+    override val name = "IMGW (${context.currentLocale.getCountryName("PL")})"
+    override val continent = SourceContinent.EUROPE
+
+    protected val weatherAttribution by lazy {
+        when {
+            context.currentLocale.code.startsWith("pl") -> "Instytut Meteorologii i Gospodarki Wodnej"
+            else -> "Polish Meteorology and Water Management Institute (IMGW)"
+        }
+    }
+
+    override val supportedFeatures = mapOf(
+        SourceFeature.CURRENT to weatherAttribution,
+        SourceFeature.FORECAST to weatherAttribution,
+        SourceFeature.MINUTELY to weatherAttribution
+    )
+
+    override fun isFeatureSupportedForLocation(
+        location: Location,
+        feature: SourceFeature,
+    ) = if (location.countryCode?.equals("PL", ignoreCase = true) == true) {
+        (!token.isBlank() && feature != SourceFeature.CURRENT) || feature == SourceFeature.CURRENT
+    } else {
+        false
+    }
+
+    override fun getFeaturePriorityForLocation(
+        location: Location,
+        feature: SourceFeature,
+    ) = when {
+        isFeatureSupportedForLocation(location, feature) -> PRIORITY_HIGHEST
+        else -> PRIORITY_NONE
+    }
+
+    private val config = SourceConfigStore(context, id)
+    protected var token: String
+        set(value) {
+            config.edit().putString("token", value).apply()
+        }
+        get() = config.getString("token", BuildConfig.IMGW_TOKEN) ?: ""
+}

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -791,4 +791,7 @@
     <string name="settings_source_api_key_invalid">Wartość nie jest w przewidywanym formacie</string>
     <string name="message_please_wait_refresh">Proszę poczekać na zakończenie odświeżania</string>
     <string name="settings_main_background_title">Tło oparte na pogodzie</string>
+    <string name="imgw_weather_text_thunderstorm_approaching">Nadciąga burza</string>
+    <string name="imgw_weather_text_thunderstorm_heavy">Silna burza</string>
+    <string name="imgw_weather_text_diamond_dust">Słupki lodowe</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1239,6 +1239,17 @@
     <string name="fmi_weather_text_ice_pellets_moderate" translatable="false">Moderate ice pellets</string>
     <string name="fmi_weather_text_ice_pellets_heavy" translatable="false">Heavy ice pellets</string>
     <string name="fmi_weather_text_ice_crystals" translatable="false">@string/nws_weather_text_ice_crystals</string>
+    <!-- Weather texts for IMGW -->
+    <string name="imgw_weather_text_thunderstorm_approaching" translatable="false">Thunderstorm approaching</string>
+    <string name="imgw_weather_text_thunderstorm_heavy" translatable="false">Heavy thunderstorm</string>
+    <string name="imgw_weather_text_diamond_dust" translatable="false">Diamond dust</string>
+    <string name="imgw_weather_text_thunder" translatable="false">@string/weather_kind_thunder</string>
+    <string name="imgw_weather_text_haze" translatable="false">@string/weather_kind_haze</string>
+    <string name="imgw_weather_text_hail" translatable="false">@string/weather_kind_hail</string>
+    <string name="imgw_weather_text_thunderstorm_slight_or_moderate" translatable="false">@string/openmeteo_weather_text_thunderstorm_slight_or_moderate</string>
+    <string name="imgw_weather_text_thunderstorm_with_slight_hail" translatable="false">@string/openmeteo_weather_text_thunderstorm_with_slight_hail</string>
+    <string name="imgw_weather_text_thunderstorm_with_heavy_hail" translatable="false">@string/openmeteo_weather_text_thunderstorm_with_heavy_hail</string>
+    <string name="imgw_weather_text_depositing_rime_fog" translatable="false">@string/openmeteo_weather_text_depositing_rime_fog</string>
     <!-- Do NOT translate everything below -->
     <!-- Widgets -->
     <string name="widget_custom_subtitle_keyword_cw" translatable="false">$cw$</string>

--- a/app/src/src_freenet/org/breezyweather/sources/imgw/ImgwService.kt
+++ b/app/src/src_freenet/org/breezyweather/sources/imgw/ImgwService.kt
@@ -1,0 +1,40 @@
+/*
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.imgw
+
+import android.content.Context
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.source.SourceFeature
+import breezyweather.domain.weather.wrappers.WeatherWrapper
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.common.exceptions.NonFreeNetSourceException
+import javax.inject.Inject
+
+class ImgwService @Inject constructor(
+    @ApplicationContext context: Context,
+    @Named("JsonClient") client: Retrofit.Builder,
+) : ImgwServiceStub(context) {
+
+    override fun requestWeather(
+        context: Context,
+        location: Location,
+        requestedFeatures: List<SourceFeature>,
+    ): Observable<WeatherWrapper> {
+        throw NonFreeNetSourceException()
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/imgw/ImgwApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/imgw/ImgwApi.kt
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.imgw
+
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.sources.imgw.json.ImgwMeteoStationEntry
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface ImgwApi {
+    @GET("/api/data/meteo")
+    fun getAllMeteoStationData(): Observable<List<ImgwMeteoStationEntry>>
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/imgw/ImgwDailyDateSerializer.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/imgw/ImgwDailyDateSerializer.kt
@@ -1,0 +1,24 @@
+package org.breezyweather.sources.imgw
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import org.breezyweather.common.extensions.toTimezoneSpecificHour
+import org.breezyweather.common.serializer.DateSerializer
+import java.util.Date
+import java.util.TimeZone
+
+object ImgwDailyDateSerializer: KSerializer<Date> {
+    override val descriptor: SerialDescriptor
+        get() = DateSerializer.descriptor
+
+    override fun serialize(encoder: Encoder, value: Date) = DateSerializer.serialize(encoder, value)
+
+    override fun deserialize(decoder: Decoder) = DateSerializer.deserialize(decoder)
+        .toTimezoneSpecificHour(
+            timeZone = TimeZone.getTimeZone("UTC"),
+            hour = 0,
+        )
+
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/imgw/ImgwForecastApi.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/imgw/ImgwForecastApi.kt
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.imgw
+
+import io.reactivex.rxjava3.core.Observable
+import org.breezyweather.sources.imgw.json.forecast.ImgwForecastResult
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface ImgwForecastApi {
+    @GET("/api/v1/forecast/fcapi")
+    fun getForecast(
+        @Query("token") token: String,
+        @Query("lat") latitude: String,
+        @Query("lon") longitude: String,
+        @Query("m") model: String = "hybrid",
+    ): Observable<ImgwForecastResult>
+
+    @GET("/api/v1/forecast/forecastapi")
+    fun getGfsForecast(
+        @Query("token") token: String,
+        @Query("lat") latitude: String,
+        @Query("lon") longitude: String,
+    ): Observable<ImgwForecastResult>
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/imgw/ImgwService.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/imgw/ImgwService.kt
@@ -1,0 +1,518 @@
+/*
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.imgw
+
+import android.content.Context
+import android.text.format.DateUtils
+import breezyweather.domain.location.model.Location
+import breezyweather.domain.source.SourceFeature
+import breezyweather.domain.weather.model.DailyCloudCover
+import breezyweather.domain.weather.model.Minutely
+import breezyweather.domain.weather.model.Precipitation
+import breezyweather.domain.weather.model.Wind
+import breezyweather.domain.weather.reference.WeatherCode
+import breezyweather.domain.weather.wrappers.CurrentWrapper
+import breezyweather.domain.weather.wrappers.DailyWrapper
+import breezyweather.domain.weather.wrappers.HalfDayWrapper
+import breezyweather.domain.weather.wrappers.HourlyWrapper
+import breezyweather.domain.weather.wrappers.TemperatureWrapper
+import breezyweather.domain.weather.wrappers.WeatherWrapper
+import com.google.maps.android.SphericalUtil
+import com.google.maps.android.model.LatLng
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.reactivex.rxjava3.core.Observable
+import jakarta.inject.Inject
+import org.breezyweather.R
+import org.breezyweather.common.extensions.toCalendar
+import org.breezyweather.common.extensions.toTimezoneSpecificHour
+import org.breezyweather.sources.imgw.json.ImgwMeteoStationEntry
+import org.breezyweather.sources.imgw.json.forecast.ImgwDailyForecastEntry
+import org.breezyweather.sources.imgw.json.forecast.ImgwDayNightForecastEntry
+import org.breezyweather.sources.imgw.json.forecast.ImgwForecastData
+import org.breezyweather.sources.imgw.json.forecast.ImgwShortTermForecastEntry
+import org.breezyweather.sources.imgw.json.forecast.ImgwUnits
+import org.breezyweather.unit.precipitation.Precipitation.Companion.centimeters
+import org.breezyweather.unit.precipitation.Precipitation.Companion.inches
+import org.breezyweather.unit.precipitation.Precipitation.Companion.millimeters
+import org.breezyweather.unit.pressure.Pressure.Companion.hectopascals
+import org.breezyweather.unit.pressure.Pressure.Companion.inchesOfMercury
+import org.breezyweather.unit.pressure.Pressure.Companion.kilopascals
+import org.breezyweather.unit.pressure.Pressure.Companion.millibars
+import org.breezyweather.unit.pressure.Pressure.Companion.millimetersOfMercury
+import org.breezyweather.unit.pressure.Pressure.Companion.pascals
+import org.breezyweather.unit.ratio.Ratio.Companion.percent
+import org.breezyweather.unit.speed.Speed.Companion.kilometersPerHour
+import org.breezyweather.unit.speed.Speed.Companion.knots
+import org.breezyweather.unit.speed.Speed.Companion.metersPerSecond
+import org.breezyweather.unit.speed.Speed.Companion.milesPerHour
+import org.breezyweather.unit.temperature.Temperature.Companion.celsius
+import org.breezyweather.unit.temperature.Temperature.Companion.fahrenheit
+import org.breezyweather.unit.temperature.Temperature.Companion.kelvin
+import retrofit2.Retrofit
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.GregorianCalendar
+import java.util.TimeZone
+import javax.inject.Named
+
+class ImgwService @Inject constructor(
+    @ApplicationContext context: Context,
+    @Named("JsonClient") client: Retrofit.Builder,
+) : ImgwServiceStub(context) {
+    override val privacyPolicyUrl: String
+        get() = "https://danepubliczne.imgw.pl/pl/regulations"
+
+    private val mApi by lazy {
+        client.baseUrl(IMGW_API_BASE_URL).build().create(ImgwApi::class.java)
+    }
+
+    private val mForecastApi by lazy {
+        client.baseUrl(IMGW_FORECAST_API_BASE_URL).build().create(ImgwForecastApi::class.java)
+    }
+
+    override fun requestWeather(
+        context: Context,
+        location: Location,
+        requestedFeatures: List<SourceFeature>,
+    ): Observable<WeatherWrapper> {
+        // if token is set, we use the forecast API; if not, we default to the public API for just current data
+        return if (token.isNotEmpty()) {
+            val gfsForecast = mForecastApi.getGfsForecast(
+                token = token,
+                latitude = location.latitude.toString(),
+                longitude = location.longitude.toString()
+            ).blockingFirst().data
+
+            mForecastApi.getForecast(
+                token = token,
+                latitude = location.latitude.toString(),
+                longitude = location.longitude.toString()
+            ).map {
+                if (it.data != null && gfsForecast != null) {
+                    WeatherWrapper(
+                        current = if (SourceFeature.CURRENT in requestedFeatures) {
+                            getCurrentWeather(context, it.data)
+                        } else {
+                            null
+                        },
+                        hourlyForecast = if (SourceFeature.FORECAST in requestedFeatures) {
+                            getHourlyWeather(context, it.data, gfsForecast)
+                        } else {
+                            null
+                        },
+                        minutelyForecast = if (SourceFeature.FORECAST in requestedFeatures) {
+                            getMinutelyWeather(it.data)
+                        } else {
+                            null
+                        },
+                        dailyForecast = if (SourceFeature.FORECAST in requestedFeatures) {
+                            getDailyWeather(context, it.data, gfsForecast)
+                        } else {
+                            null
+                        }
+                    )
+                } else {
+                    WeatherWrapper()
+                }
+            }
+        } else {
+            mApi.getAllMeteoStationData().map {
+                WeatherWrapper(
+                    current = mapToCurrent(findClosestStation(location, it))
+                )
+            }
+        }
+    }
+
+    private fun getCurrentWeather(context: Context, forecastData: ImgwForecastData): CurrentWrapper {
+        val latestData = forecastData.shortTermData.getCurrent()
+        val units = forecastData.units
+
+        return CurrentWrapper(
+            weatherCode = getWeatherCode(latestData.icon),
+            weatherText = getWeatherText(context, latestData.icon),
+            temperature = TemperatureWrapper(
+                temperature = getTemperature(units, latestData.airTemperature),
+                feelsLike = getTemperature(units, latestData.feelsLike)
+            ),
+            pressure = getPressure(units, latestData.pressureMSL),
+            wind = Wind(
+                degree = latestData.windDir?.toDouble(),
+                speed = getWindSpeed(units, latestData.windSpeed),
+                gusts = getWindSpeed(units, latestData.gustsSpeed)
+            ),
+            relativeHumidity = latestData.humidity?.percent,
+            dewPoint = getTemperature(units, latestData.dewpointTemperature),
+            cloudCover = latestData.cloud?.percent
+        )
+    }
+
+    private fun getDailyWeather(
+        context: Context,
+        hybridForecastData: ImgwForecastData,
+        gfsForecastData: ImgwForecastData,
+    ): List<DailyWrapper> {
+        val units = hybridForecastData.units
+        val collectedData = combineDailySources(
+            hybridForecastData.dailyData,
+            gfsForecastData.dailyData
+        ).filter { elem ->
+            !hybridForecastData.dayNightData.any { it.date == elem.date }
+        }
+
+        return hybridForecastData.dayNightData.groupBy { it.date }.map { dayNight ->
+            val daytime = dayNight.value.find { it.isDay }
+            val nighttime = dayNight.value.find { !it.isDay }
+            val allDay = hybridForecastData.dailyData.find { it.date == dayNight.key }
+                ?: gfsForecastData.dailyData.find { it.date == dayNight.key }
+
+            DailyWrapper(
+                date = dayNight.key,
+                day = HalfDayWrapper(
+                    weatherText = getWeatherText(context, daytime?.icon),
+                    weatherCode = getWeatherCode(daytime?.icon),
+                    temperature = TemperatureWrapper(
+                        temperature = getTemperature(units, daytime?.maxTemperature)
+                    ),
+                    precipitation = Precipitation(
+                        total = getPrecipitation(units, daytime?.sumPrecipitation),
+                        rain = getPrecipitation(units, daytime?.sumRain),
+                        snow = getPrecipitation(units, daytime?.sumSnow)
+                    ),
+                    wind = Wind(
+                        speed = getWindSpeed(units, daytime?.maxWindSpeed)
+                    )
+                ),
+                night = HalfDayWrapper(
+                    weatherText = getWeatherText(context, nighttime?.icon),
+                    weatherCode = getWeatherCode(nighttime?.icon),
+                    temperature = TemperatureWrapper(
+                        temperature = getTemperature(units, nighttime?.minTemperature)
+                    ),
+                    precipitation = Precipitation(
+                        total = getPrecipitation(units, nighttime?.sumPrecipitation),
+                        rain = getPrecipitation(units, nighttime?.sumRain),
+                        snow = getPrecipitation(units, nighttime?.sumSnow)
+                    ),
+                    wind = Wind(
+                        speed = getWindSpeed(units, nighttime?.maxWindSpeed)
+                    )
+                ),
+                cloudCover = DailyCloudCover(
+                    min = allDay?.minCloudCover?.percent,
+                    max = allDay?.maxCloudCover?.percent,
+                    average = allDay?.avgCloudCover?.percent
+                )
+            )
+        }.plus(
+            collectedData.map {
+                DailyWrapper(
+                    date = it.date,
+                    day = HalfDayWrapper(
+                        weatherText = getWeatherText(context, it.icon),
+                        weatherCode = getWeatherCode(it.icon),
+                        temperature = TemperatureWrapper(
+                            temperature = getTemperature(units, it.maxTemperature)
+                        ),
+                        precipitation = Precipitation(
+                            total = getPrecipitation(units, it.maxPrecipitation)
+                        ),
+                        wind = Wind(
+                            speed = getWindSpeed(units, it.maxWindSpeed)
+                        )
+                    ),
+                    cloudCover = DailyCloudCover(
+                        min = it.minCloudCover.percent,
+                        max = it.maxCloudCover.percent,
+                        average = it.avgCloudCover.percent
+                    )
+                )
+            }
+        ).let { dailyWrapperList ->
+            if (!dailyWrapperList.any { DateUtils.isToday(it.date.time) }) {
+                val current = hybridForecastData.shortTermData.getCurrent()
+
+                listOf(DailyWrapper(
+                    date = current.date.toTimezoneSpecificHour(
+                        timeZone = TimeZone.getTimeZone("UTC"),
+                        hour = 0,
+                    ),
+                    day = HalfDayWrapper(
+                        weatherText = getWeatherText(context, current.icon),
+                        weatherCode = getWeatherCode(current.icon),
+                        temperature = TemperatureWrapper(
+                            temperature = getTemperature(units, current.airTemperature)
+                        ),
+                        precipitation = Precipitation(
+                            total = getPrecipitation(units, current.precipitation)
+                        ),
+                        wind = Wind(
+                            speed = getWindSpeed(units, current.windSpeed)
+                        )
+                    ),
+                    cloudCover = DailyCloudCover(
+                        average = current.cloud?.percent
+                    )
+                )).plus(dailyWrapperList)
+            } else {
+                dailyWrapperList
+            }
+        }
+    }
+
+    private fun getHourlyWeather(
+        context: Context,
+        hybridForecastData: ImgwForecastData,
+        gfsForecastData: ImgwForecastData,
+    ): List<HourlyWrapper> {
+        val collectedData = combineHourlySources(
+            hybrid = hybridForecastData.shortTermData.filterHourly(),
+            gfs = gfsForecastData.shortTermData.filterHourly()
+        )
+        val units = hybridForecastData.units
+
+        return collectedData.map {
+            HourlyWrapper(
+                date = it.date,
+                isDaylight = isDaytime(it.icon),
+                weatherCode = getWeatherCode(it.icon),
+                weatherText = getWeatherText(context, it.icon),
+                temperature = TemperatureWrapper(
+                    temperature = getTemperature(units, it.airTemperature),
+                    feelsLike = getTemperature(units, it.feelsLike)
+                ),
+                pressure = getPressure(units, it.pressureMSL),
+                wind = Wind(
+                    degree = it.windDir?.toDouble(),
+                    speed = getWindSpeed(units, it.windSpeed),
+                    gusts = getWindSpeed(units, it.gustsSpeed)
+                ),
+                relativeHumidity = it.humidity?.percent,
+                dewPoint = getTemperature(units, it.dewpointTemperature),
+                cloudCover = it.cloud?.percent,
+                precipitation = Precipitation(
+                    total = getPrecipitation(units, it.precipitation),
+                    rain = getPrecipitation(units, it.rain),
+                    snow = getPrecipitation(units, it.snow)
+                )
+            )
+        }
+    }
+
+    private fun getMinutelyWeather(forecastData: ImgwForecastData): List<Minutely> =
+        forecastData.shortTermData.filterMinutely().map {
+            Minutely(
+                date = it.date,
+                minuteInterval = 10,
+                precipitationIntensity = getPrecipitation(forecastData.units, it.precipitation10m)
+            )
+        }
+
+    private fun List<ImgwShortTermForecastEntry>.filterHourly() = this.filter {
+        it.type == "Type_Hour"
+    }
+
+    private fun List<ImgwShortTermForecastEntry>.filterMinutely() = this.filter {
+        it.precipitation10m != null
+    }
+
+    private fun List<ImgwShortTermForecastEntry>.getCurrent() = this.first {
+        it.airTemperature != null
+    }
+
+    private fun combineHourlySources(
+        hybrid: List<ImgwShortTermForecastEntry>,
+        gfs: List<ImgwShortTermForecastEntry>,
+    ) = hybrid.plus(
+        gfs.filter {
+            !hybrid.any { elem -> elem.date == it.date }
+        }
+    )
+
+    private fun combineDailySources(
+        hybrid: List<ImgwDailyForecastEntry>,
+        gfs: List<ImgwDailyForecastEntry>,
+    ) = hybrid.plus(
+        gfs.filter {
+            !hybrid.any { elem -> elem.date == it.date }
+        }
+    )
+
+    // IMGW Meteo has icons encoded in "nXzYY<d/n>" format, where X - cloudiness, YY - WMO 4677 event code,
+    // d - day, n - night; Breezy Weather does not support most of the events and cloudiness levels
+    private fun getWeatherCode(iconCode: String?) = if (iconCode.isNullOrBlank()) {
+        null
+    } else {
+        val cloudiness = iconCode.take(2).takeLast(1)
+        val wmoCode = iconCode.takeLast(3).take(2)
+
+        val wmoCodeWeather = when (wmoCode) {
+            "00", "04", "76" -> WeatherCode.CLEAR
+            "06", "07", "08", "09", "18", "19" -> WeatherCode.WIND
+            "05", "10" -> WeatherCode.HAZE
+            "45", "49" -> WeatherCode.FOG
+            "50", "60", "61", "63", "65", "80", "81" -> WeatherCode.RAIN
+            "56", "66", "68", "69", "83", "84" -> WeatherCode.SLEET
+            "38", "70", "71", "73", "75", "85", "86" -> WeatherCode.SNOW
+            "90", "96", "99" -> WeatherCode.HAIL
+            "13", "17" -> WeatherCode.THUNDER
+            "95", "97" -> WeatherCode.THUNDERSTORM
+            else -> null
+        }
+
+        if (wmoCodeWeather == WeatherCode.CLEAR || wmoCodeWeather == null) {
+            when (cloudiness) {
+                "0" -> WeatherCode.CLEAR
+                "1", "2", "3", "4" -> WeatherCode.PARTLY_CLOUDY
+                "5", "6", "7", "8" -> WeatherCode.CLOUDY
+                else -> null
+            }
+        } else {
+            wmoCodeWeather
+        }
+    }
+
+    private fun getWeatherText(context: Context, iconCode: String?) = if (iconCode.isNullOrBlank()) {
+        null
+    } else {
+        val cloudiness = iconCode.take(2).takeLast(1)
+        val wmoCode = iconCode.takeLast(3).take(2)
+
+        val cloudinessString = when (cloudiness) {
+            "0" -> context.getString(R.string.common_weather_text_clear_sky)
+            "1", "2" -> context.getString(R.string.common_weather_text_mostly_clear)
+            "3", "4" -> context.getString(R.string.common_weather_text_partly_cloudy)
+            "5", "6" -> context.getString(R.string.common_weather_text_mostly_cloudy)
+            "7" -> context.getString(R.string.common_weather_text_cloudy)
+            "8" -> context.getString(R.string.common_weather_text_overcast)
+            else -> null
+        }
+
+        val weatherConditionString = when (wmoCode) {
+            "04" -> context.getString(R.string.common_weather_text_smoke)
+            "05" -> context.getString(R.string.imgw_weather_text_haze)
+            "10" -> context.getString(R.string.common_weather_text_mist)
+            "06", "07" -> context.getString(R.string.common_weather_text_dust)
+            "09" -> context.getString(R.string.common_weather_text_dust_storm)
+            "13" -> context.getString(R.string.imgw_weather_text_thunder)
+            "17" -> context.getString(R.string.imgw_weather_text_thunderstorm_approaching)
+            "18" -> context.getString(R.string.common_weather_text_squall)
+            "19" -> context.getString(R.string.common_weather_text_tornado)
+            "38" -> context.getString(R.string.common_weather_text_blowing_snow)
+            "45" -> context.getString(R.string.common_weather_text_fog)
+            "49" -> context.getString(R.string.imgw_weather_text_depositing_rime_fog)
+            "50" -> context.getString(R.string.common_weather_text_drizzle)
+            "56" -> context.getString(R.string.common_weather_text_drizzle_freezing)
+            "60" -> context.getString(R.string.common_weather_text_rain_showers_light)
+            "61" -> context.getString(R.string.common_weather_text_rain_light)
+            "63" -> context.getString(R.string.common_weather_text_rain_moderate)
+            "65" -> context.getString(R.string.common_weather_text_rain_heavy)
+            "66" -> context.getString(R.string.common_weather_text_rain_freezing_light)
+            "68" -> context.getString(R.string.common_weather_text_rain_snow_mixed)
+            "69" -> context.getString(R.string.common_weather_text_rain_snow_mixed_heavy)
+            "70" -> context.getString(R.string.common_weather_text_snow_showers_light)
+            "71" -> context.getString(R.string.common_weather_text_snow_light)
+            "73" -> context.getString(R.string.common_weather_text_snow_moderate)
+            "75" -> context.getString(R.string.common_weather_text_snow_heavy)
+            "76" -> context.getString(R.string.imgw_weather_text_diamond_dust)
+            "80" -> context.getString(R.string.common_weather_text_rain_showers)
+            "81" -> context.getString(R.string.common_weather_text_rain_showers_heavy)
+            "85" -> context.getString(R.string.common_weather_text_snow_showers)
+            "86" -> context.getString(R.string.common_weather_text_snow_showers_heavy)
+            "90" -> context.getString(R.string.imgw_weather_text_hail)
+            "95" -> context.getString(R.string.imgw_weather_text_thunderstorm_slight_or_moderate)
+            "96" -> context.getString(R.string.imgw_weather_text_thunderstorm_with_slight_hail)
+            "97" -> context.getString(R.string.imgw_weather_text_thunderstorm_heavy)
+            "99" -> context.getString(R.string.openmeteo_weather_text_thunderstorm_with_heavy_hail)
+            else -> null
+        }
+
+        if (cloudinessString == null) {
+            null
+        } else if (weatherConditionString == null) {
+            cloudinessString
+        } else {
+            "$cloudinessString - $weatherConditionString"
+        }
+    }
+
+    private fun isDaytime(iconCode: String?) = if (iconCode.isNullOrBlank()) {
+        null
+    } else {
+        iconCode.endsWith('d')
+    }
+
+    private fun getWindSpeed(units: ImgwUnits, value: Double?) = when (units.windSpeed) {
+        "[m/s]" -> value?.metersPerSecond
+        "[km/h]" -> value?.kilometersPerHour
+        "[mph]" -> value?.milesPerHour
+        "[kt]" -> value?.knots
+        else -> null
+    }
+
+    private fun getTemperature(units: ImgwUnits, value: Double?) = when (units.temperature) {
+        "[K]" -> value?.kelvin
+        "[C]" -> value?.celsius
+        "[F]" -> value?.fahrenheit
+        else -> null
+    }
+
+    private fun getPressure(units: ImgwUnits, value: Double?) =
+        when (units.pressure) {
+            "[Pa]" -> value?.pascals
+            "[hPa]" -> value?.hectopascals
+            "[kPa]" -> value?.kilopascals
+            "[mmHg]" -> value?.millimetersOfMercury
+            "[inHg]" -> value?.inchesOfMercury
+            "[mbar]" -> value?.millibars
+            else -> null
+        }
+
+    private fun getPrecipitation(units: ImgwUnits, value: Double?) = when (units.precipitation) {
+        "[mm]" -> value?.millimeters
+        "[cm]" -> value?.centimeters
+        "[in]" -> value?.inches
+        else -> null
+    }
+
+    private fun findClosestStation(location: Location, meteoData: List<ImgwMeteoStationEntry>) = meteoData.filter {
+        it.airTemperature != null && it.latitude != null && it.longitude != null
+    }.minByOrNull {
+        SphericalUtil.computeDistanceBetween(
+            LatLng(location.latitude, location.longitude),
+            LatLng(it.latitude!!, it.longitude!!)
+        )
+    }
+
+    private fun mapToCurrent(meteoStation: ImgwMeteoStationEntry?) = CurrentWrapper(
+        temperature = TemperatureWrapper(
+            temperature = meteoStation?.airTemperature?.celsius
+        ),
+        wind = Wind(
+            speed = meteoStation?.avgWindSpeed?.kilometersPerHour,
+            gusts = meteoStation?.windGust?.kilometersPerHour,
+            degree = meteoStation?.windDirection
+        ),
+        relativeHumidity = meteoStation?.relativeHumidity?.percent
+    )
+
+    companion object {
+        private const val IMGW_API_BASE_URL = "https://danepubliczne.imgw.pl"
+        private const val IMGW_FORECAST_API_BASE_URL = "https://meteo.imgw.pl"
+    }
+}

--- a/app/src/src_nonfreenet/org/breezyweather/sources/imgw/json/ImgwMeteoStationEntry.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/imgw/json/ImgwMeteoStationEntry.kt
@@ -1,0 +1,36 @@
+/*
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.imgw.json
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ImgwMeteoStationEntry(
+    @SerialName("kod_stacji") val stationId: String,
+    @SerialName("nazwa_stacji") val stationName: String,
+    @SerialName("lon") val longitude: Double?,
+    @SerialName("lat") val latitude: Double?,
+    @SerialName("temperatura_gruntu") val surfaceTemperature: Double?,
+    @SerialName("temperatura_powietrza") val airTemperature: Double?,
+    @SerialName("wiatr_kierunek") val windDirection: Double?,
+    @SerialName("wiatr_srednia_predkosc") val avgWindSpeed: Double?,
+    @SerialName("wiatr_predkosc_maksymalna") val maxWindSpeed: Double?,
+    @SerialName("wilgotnosc_wzgledna") val relativeHumidity: Int?,
+    @SerialName("wiatr_poryw_10min") val windGust: Double?,
+    @SerialName("opad_10min") val precipitation: Double?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/imgw/json/forecast/ImgwDailyForecastEntry.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/imgw/json/forecast/ImgwDailyForecastEntry.kt
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.imgw.json.forecast
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.breezyweather.sources.imgw.ImgwDailyDateSerializer
+import java.util.Date
+
+@Serializable
+data class ImgwDailyForecastEntry(
+    @SerialName("Temp_Min") val minTemperature: Double,
+    @SerialName("Temp_Max") val maxTemperature: Double,
+    @SerialName("Prec_Max") val maxPrecipitation: Double,
+    @SerialName("Cloud_Min") val minCloudCover: Int,
+    @SerialName("Cloud_Ave") val avgCloudCover: Int,
+    @SerialName("Cloud_Max") val maxCloudCover: Int,
+    @SerialName("Wind_Speed_Max") val maxWindSpeed: Double,
+    @SerialName("Icon") val icon: String,
+    @Serializable(ImgwDailyDateSerializer::class) @SerialName("Date") val date: Date,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/imgw/json/forecast/ImgwDayNightForecastEntry.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/imgw/json/forecast/ImgwDayNightForecastEntry.kt
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.imgw.json.forecast
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.breezyweather.common.serializer.DateSerializer
+import org.breezyweather.sources.imgw.ImgwDailyDateSerializer
+import java.util.Date
+
+@Serializable
+data class ImgwDayNightForecastEntry(
+    @Serializable(ImgwDailyDateSerializer::class) @SerialName("Date") val date: Date,
+    val isDay: Boolean,
+    @SerialName("Icon") val icon: String,
+    @SerialName("Cloud_Min") val minCloudCover: Int,
+    @SerialName("Cloud_Ave") val avgCloudCover: Int,
+    @SerialName("Cloud_Max") val maxCloudCover: Int,
+    @SerialName("Temp_Min") val minTemperature: Double,
+    @SerialName("Temp_Max") val maxTemperature: Double,
+    @SerialName("Prec_Sum") val sumPrecipitation: Double,
+    @SerialName("Prec_Max") val maxPrecipitation: Double,
+    @SerialName("Rain_Sum") val sumRain: Double,
+    @SerialName("Rain_Max") val maxRain: Double,
+    @SerialName("Snow_Sum") val sumSnow: Double,
+    @SerialName("Snow_Max") val maxSnow: Double,
+    @SerialName("Wind_Speed_Max") val maxWindSpeed: Double,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/imgw/json/forecast/ImgwForecastData.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/imgw/json/forecast/ImgwForecastData.kt
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.imgw.json.forecast
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ImgwForecastData(
+    @SerialName("Daily_Data") val dailyData: List<ImgwDailyForecastEntry>,
+    @SerialName("Day_Night_Data") val dayNightData: List<ImgwDayNightForecastEntry>,
+    @SerialName("Data") val shortTermData: List<ImgwShortTermForecastEntry>,
+    @SerialName("Valid") val valid: Boolean,
+    @SerialName("Units") val units: ImgwUnits,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/imgw/json/forecast/ImgwForecastResult.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/imgw/json/forecast/ImgwForecastResult.kt
@@ -1,0 +1,24 @@
+/*
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.imgw.json.forecast
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ImgwForecastResult(
+    val data: ImgwForecastData?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/imgw/json/forecast/ImgwShortTermForecastEntry.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/imgw/json/forecast/ImgwShortTermForecastEntry.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.imgw.json.forecast
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.breezyweather.common.serializer.DateSerializer
+import java.util.Date
+
+@Serializable
+data class ImgwShortTermForecastEntry(
+    @Serializable(DateSerializer::class) @SerialName("Date") val date: Date,
+    @SerialName("Type") val type: String?,
+    @SerialName("Icon10") val icon: String?,
+    @SerialName("Temperature") val airTemperature: Double?,
+    @SerialName("Temperature_Surface") val surfaceTemperature: Double?,
+    @SerialName("Dewpoint_Temperature") val dewpointTemperature: Double?,
+    @SerialName("Chill") val feelsLike: Double?,
+    @SerialName("Humidity") val humidity: Double?,
+    @SerialName("Cloud") val cloud: Int?,
+    @SerialName("PressureMSL") val pressureMSL: Double?,
+    @SerialName("Precipitation") val precipitation: Double?,
+    @SerialName("Precipitation10m") val precipitation10m: Double?,
+    @SerialName("Rain") val rain: Double?,
+    @SerialName("Rain10m") val rain10m: Double?,
+    @SerialName("Snow") val snow: Double?,
+    @SerialName("Snow10m") val snow10m: Double?,
+    @SerialName("Wind_Speed") val windSpeed: Double?,
+    @SerialName("Wind_Dir") val windDir: Int?,
+    @SerialName("Wind_Gust") val gustsSpeed: Double?,
+    @SerialName("Gusts_Dir") val gustsDir: Int?,
+    @SerialName("Irradiance_Radiation") val irradianceRadiation: Double?,
+)

--- a/app/src/src_nonfreenet/org/breezyweather/sources/imgw/json/forecast/ImgwUnits.kt
+++ b/app/src/src_nonfreenet/org/breezyweather/sources/imgw/json/forecast/ImgwUnits.kt
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Breezy Weather.
+ *
+ * Breezy Weather is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, version 3 of the License.
+ *
+ * Breezy Weather is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Breezy Weather. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.breezyweather.sources.imgw.json.forecast
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ImgwUnits(
+    @SerialName("Wind_Dir") val windDir: String,
+    @SerialName("Temperature") val temperature: String,
+    @SerialName("Precipitation") val precipitation: String,
+    @SerialName("Cloud") val cloud: String,
+    @SerialName("Humidity") val humidity: String,
+    @SerialName("Wind_Speed") val windSpeed: String,
+    @SerialName("Pressure") val pressure: String,
+)

--- a/docs/SOURCES.md
+++ b/docs/SOURCES.md
@@ -84,6 +84,7 @@ Below, you can find details about the support and implementation status for feat
 | 🇳🇴 Norway                        | [MET Norway](#met-norway)                                                                         | Forecast, Nowcasting, Air quality, Alerts                                            |
 | 🇵🇭 Philippines                   | [PAGASA](#pagasa)                                                                                 | Forecast, Current                                                                    |
 | 🇵🇹 Portugal                      | [IPMA](#instituto-português-do-mar-e-da-atmosfera)                                                | Forecast, Alerts, Address                                                            |
+| 🇵🇱 Poland                        | [IMGW Public](https://danepubliczne.imgw.pl), [IMGW Meteo](https://meteo.imgw.pl) 🔐              | Current (no key), Forecast, Address (🔐)                                             |
 | 🇵🇷 Puerto Rico                   | [NWS](#national-weather-service)                                                                  | Forecast, Current, Alerts, Address                                                   |
 | 🇷🇪 Réunion                       | [Météo-France](#météo-france)                                                                     | Forecast, Alert, Normals, Address                                                    |
 | 🇸🇲 San Marino                    | [Meteo AM](#servizio-meteo-am)                                                                    | Forecast, Current, Address                                                           |
@@ -693,6 +694,54 @@ This source aggregates data from Beijing Meteorological Service, ColorfulClouds 
 | Precipitation Duration    | ❌         | Cloud Cover       | ❌         |
 | Wind                      | ✅         | Visibility        | ❌         |
 | Pressure                  | ❌         | Ceiling           | ❌         |
+</details>
+
+### Instytut Meteorologii i Gospodarki Wodnej
+**[Instytut Meteorologii i Gospodarki Wodnej](https://imgw.pl)** (IMGW) is the meteorological
+and water management institute of Poland.
+
+There are two available APIs in IMGW:
+- public access API warranted by the Polish law;
+- their internal API used in IMGW's Meteo webapp (called the forecast API in code).
+
+The public access API gives current meteo and synoptic data, plus weather alerts; however, only the
+meteo data contains latitude and longitude for matching with location. That API requires no credentials.
+
+The internal API uses a static hardcoded public token for authentication. The value is set by default
+in the app, however if it changes, it is easy to fetch it by yourself:
+
+- go to [IMGW Meteo](https://meteo.imgw.pl) web app
+- open the browser console on the Network tab, refresh the page
+- the token is passed in clear text as a query parameter in multiple queries (look for token=)
+
+Features technically available but not implemented:
+- Address lookup: very rudimentary and imprecise. Other solutions already available work better.
+- Alerts: while possible to fetch, only meteo alerts can be matched with data available; hydrological alerts cannot be reasonably matched to current location.
+
+| Feature                        | Detail         |
+|--------------------------------|----------------|
+| 🗺️ **Coverage**               | 🇵🇱 Poland    |
+| 📆 **Daily forecast**          | Not available  |
+| ⏱️ **Hourly forecast**         | Up to 62 hours |
+| ▶️ **Current observation**     | Available      |
+| 😶‍🌫️ **Air quality**         | Not available  |
+| 🤧 **Pollen**                  | Not available  |
+| ☔ **Precipitation nowcasting** | Available      |
+| ⚠️ **Alerts**                  | Not available  |
+| 📊 **Normals**                 | Not available  |
+| 🧭 **Address lookup**          | Not available  |
+
+<details><summary><h4>Details of available data from IMGW</h4></summary>
+
+| Data                      | Available | Data              | Available |
+|---------------------------|---------|-------------------|---------|
+| Weather Condition         | ✅       | Humidity          | ✅       |
+| Temperature               | ✅       | Dew Point         | ✅        |
+| Precipitation             | ✅       | UV Index          | ❌       |
+| Precipitation Probability | ❌       | Sunshine Duration | ❌       |
+| Precipitation Duration    | ❌       | Cloud Cover       | ✅       |
+| Wind                      | ✅       | Visibility        | ❌       |
+| Pressure                  | ✅        | Ceiling           | ❌       |
 </details>
 
 ### Israel Meteorological Service


### PR DESCRIPTION
Contribution to #998 by @shindouj

> The code has been linted and tested. One possible bug has been found in either Breezy Weather or the implementation: the IMGW API does not return a daily forecast if it is late at night (around 10 PM). When that happens, Breezy Weather will show the next day as today. For example, if I add a location today at 10 PM, the daily weather will show July 2nd as "today" and July 3rd as "tomorrow" despite the fact that today is still July 1st.
> 
> To counteract that, I have added a workaround that adds the latest hourly data as today's daily item if it is missing - however, in one case this has resulted in today appearing twice, resulting in a hilarious sight of "June 30th, today", "June 30th, tomorrow" and "July 1st". This happened possibly because the hours have been different in today's dates, which would be easy to fix. I have not investigated this further as I thought it would be better to discuss a preferred approach with you - perhaps removing this workaround and just accepting tomorrow being shown as today would be better after all.
> 
> Technical disclaimer: The official "danepubliczne.imgw.pl" API (public data) has proven more or less useless. The information provided is scarce, and what is available is unusable as IMGW has not provided official endpoints for geomatching the information (e.g. the "synop" endpoint returns synoptic stations with an opaque ID that is not available anywhere else instead of lat/lon, or the hydro alerts that are matched by the water resource ID which is also impossible to find by lat/lon with just the official APIs). This change is based on IMGW's "internal" API. The reason I put internal in quotation marks is because this API is used in their public app (https://meteo.imgw.pl) and uses a hardcoded, non-rotating auth token, making it the least private private API in existence.
> 
> My plan is to write an official letter to IMGW requesting vast improvements to their public API, based on the fact they already do have much better APIs that they could publish right away. However, knowing how slowly the cogs of bureaucracy can turn, I hope we can use this solution before this happens (if it happens at all).
> 
> AI code assistance disclaimer: **Not a single line of this code has been LLM generated.** An LLM has been used to find all endpoints published in the IMGW "internal" API and for gathering all possible "icon codes", producing an API documentation that has been implemented by a human.

---

Please check all the boxes that apply:

- [X] I read the [rules for contributions](https://github.com/breezy-weather/breezy-weather/blob/main/CONTRIBUTE.md)
- [X] I’m contributing to an issue/idea tagged “Open to contributions”, or an [org member](https://github.com/orgs/breezy-weather/people) gave me permission to work on this
- [ ] I was assisted by AI
