### PR TITLE
Gadgetbridge #6570: add atmospheric pressure, cloud cover and dew point forecasts

### DIFF
--- a/app/src/main/kotlin/org/breezyweather/sources/gadgetbridge/GadgetbridgeService.kt
+++ b/app/src/main/kotlin/org/breezyweather/sources/gadgetbridge/GadgetbridgeService.kt
@@ -145,7 +145,10 @@ class GadgetbridgeService @Inject constructor() : BroadcastSource {
                 moonSet = day.moon?.setDate?.time?.div(1000)?.toInt(),
                 moonPhase = day.moonPhase?.angle,
 
-                airQuality = getAirQuality(day.airQuality)
+                airQuality = getAirQuality(day.airQuality),
+
+                pressure = day.pressure?.average?.inMillibars?.toFloat(),
+                cloudCover = day.cloudCover?.average?.inPercent?.roundToInt()
             )
         }
     }
@@ -183,7 +186,10 @@ class GadgetbridgeService @Inject constructor() : BroadcastSource {
                 windSpeed = hour.wind?.speed?.inKilometersPerHour?.toFloat(),
                 windDirection = hour.wind?.degree?.roundToInt(),
                 uvIndex = hour.uV?.index?.toFloat(),
-                precipProbability = hour.precipitationProbability?.total?.inPercent?.roundToInt()
+                precipProbability = hour.precipitationProbability?.total?.inPercent?.roundToInt(),
+                dewPoint = hour.dewPoint?.inKelvins?.roundToInt(),
+                pressure = hour.pressure?.inMillibars?.toFloat(),
+                cloudCover = hour.cloudCover?.inPercent?.roundToInt()
             )
         }
     }

--- a/app/src/main/kotlin/org/breezyweather/sources/gadgetbridge/json/GadgetbridgeDailyForecast.kt
+++ b/app/src/main/kotlin/org/breezyweather/sources/gadgetbridge/json/GadgetbridgeDailyForecast.kt
@@ -34,4 +34,6 @@ data class GadgetbridgeDailyForecast(
     val moonSet: Int? = null,
     val moonPhase: Int? = null,
     val airQuality: GadgetbridgeAirQuality? = null,
+    val pressure: Float? = null,
+    val cloudCover: Int? = null,
 )

--- a/app/src/main/kotlin/org/breezyweather/sources/gadgetbridge/json/GadgetbridgeHourlyForecast.kt
+++ b/app/src/main/kotlin/org/breezyweather/sources/gadgetbridge/json/GadgetbridgeHourlyForecast.kt
@@ -28,4 +28,7 @@ data class GadgetbridgeHourlyForecast(
     val windDirection: Int? = null,
     val uvIndex: Float? = null,
     val precipProbability: Int? = null,
+    val dewPoint: Int? = null,
+    val pressure: Float? = null,
+    val cloudCover: Int? = null,
 )


### PR DESCRIPTION
As discussed in #2930

> Expand information encoded for intent ACTION_GENERIC_WEATHER's intent extras WeatherGz and WeatherJson:
> - add pressure (millibar) to daily and hourly forecasts
> - add cloudCover (percent) to daily and hourly forecasts
> - add dewPoint (Kelvin) to hourly forecasts
>
> See also: https://codeberg.org/Freeyourgadget/Gadgetbridge/pulls/6570